### PR TITLE
Quat test bugfix & test cleanup

### DIFF
--- a/csrc/check_serial_backward.cu
+++ b/csrc/check_serial_backward.cu
@@ -237,7 +237,7 @@ void compare_cov2d_ewa_backward() {
         {dL_dmean.x, dL_dmean_ref.x},
         {dL_dmean.x, dL_dmean_ref.x},
     };
-    print_errors(dmean_data, "ds (cov2d_ewa)");
+    print_errors(dmean_data, "dmean (cov2d_ewa)");
 
     std::vector<std::pair<float,float>> dcov_data;
     for (int i = 0; i < 6; ++i)


### PR DESCRIPTION
Fixed quaternion test bug, added percent error comparison for our implementation vs ref, improved appearance of tests' output, and cleaned some code up.

Output now looks like this:

```
<Check 1202>
=====================
dmean (project2d):
     ours:     refs:
[0]:   3.63e-01,   7.27e-01     (percent error=50.00)
[1]:   4.81e-01,   9.62e-01     (percent error=50.00)
[2]:   0.00e+00,   0.00e+00     (percent error=-nan)

dcov2d (conic):
     ours:     refs:
[0]:  -4.05e+02,  -4.04e+02     (percent error=-0.38)
[1]:   5.97e+02,   5.94e+02     (percent error=0.38)
[2]:  -2.23e+02,  -2.22e+02     (percent error=-0.38)

do (rasterize):
     ours:     refs:
[0]:   9.38e-04,   9.38e-04     (percent error=0.00)
[1]:   2.53e-03,   2.53e-03     (percent error=0.00)
[2]:   5.40e-03,   5.40e-03     (percent error=0.00)
[3]:   5.01e-03,   5.01e-03     (percent error=0.00)
```