### PR TITLE
Fixed a potential forwarding bug

### DIFF
--- a/tests/test_bindings_forward.py
+++ b/tests/test_bindings_forward.py
@@ -8,9 +8,6 @@ Make sure you have the ref bindings installed:
 import torch
 import imageio
 
-import os
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from diff_rast import project_gaussians, rasterize
 from ref_rast import GaussianRasterizationSettings, rasterize_gaussians
 


### PR DESCRIPTION
- I found that 0.2f is the value in the original implementation, and after testing, the forwarding mismatched is smaller than 0.1%(before was 60%)
-  I am also curious why we deleted the proj_mat here? I noticed that in their repo they also used the proj_mat in this function. ( I might have missed some parts in our code; please correct me if so :) )