### PR TITLE
Bug: fix out of bounds Cuda crashing

### DIFF
--- a/csrc/backward.cu
+++ b/csrc/backward.cu
@@ -32,6 +32,11 @@ __global__ void rasterize_backward_kernel(
     float py = (float)i;
     int32_t pix_id = i * img_size.x + j;
 
+    // return if out of bounds
+    if (i >= img_size.y || j >= img_size.x) {
+        return;
+    }
+
     // which gaussians get gradients for this pixel
     int2 range = tile_bins[tile_id];
     // df/d_out for this pixel

--- a/csrc/forward.cu
+++ b/csrc/forward.cu
@@ -337,6 +337,11 @@ __global__ void rasterize_forward_kernel(
     float py = (float)i;
     int32_t pix_id = i * img_size.x + j;
 
+    // return if out of bounds
+    if (i >= img_size.y || j >= img_size.x) {
+        return;
+    }
+    
     // which gaussians to look through in this tile
     int2 range = tile_bins[tile_id];
     float3 conic;


### PR DESCRIPTION
Found another difficult to catch bug, and would like to discuss it. I noticed that training with gt_image size of e.g (10,257) or (257,257) or even (1,5) resulted in Cuda runtime error (when training all params or just self.scales). Similar to the confusion of width/height in the previous PR, I think we are indexing inside the rasterization kernels incorrectly; but, putting some safe guard returns seems to fix this on my end. 

img_size should be (width,height) everywhere now, and if `i` corresponds to row and `j` corresponds to column pixel indices, then to prevent indexing out of bounds:

```
unsigned i = blockIdx.y * blockDim.y + threadIdx.y;
unsigned j = blockIdx.x * blockDim.x + threadIdx.x;
if (i >= img_size.y || j >= img_size.x) {
        return;
    } 
```

Does this make sense? Can anyone confirm this and maybe test with these resolutions before and after the fix?

