### PR TITLE
num_sh_bases() is used in both host and device

### DIFF
--- a/gsplat/cuda/csrc/sh.cuh
+++ b/gsplat/cuda/csrc/sh.cuh
@@ -30,7 +30,8 @@ __device__ const float SH_C4[] = {
     -1.7701307697799304f,
     0.6258357354491761f};
 
-__device__ unsigned num_sh_bases(const unsigned degree) {
+// This function is used in both host and device code
+__host__ __device__ unsigned num_sh_bases(const unsigned degree) {
     if (degree == 0)
         return 1;
     if (degree == 1)


### PR DESCRIPTION
Fix the following bug when compiling:

```
gsplat/cuda/csrc/bindings.cu(72): error: calling a __device__ function("num_sh_bases(unsigned int)") from a __host__ function("compute_sh_forward_tensor") is not allowed

gsplat/cuda/csrc/bindings.cu(104): error: calling a __device__ function("_Z12num_sh_bases1?") from a __host__ function("compute_sh_backward_tensor") is not allowed
```