### PR TITLE
Fix build detection on Windows

### DIFF
--- a/gsplat/cuda/_backend.py
+++ b/gsplat/cuda/_backend.py
@@ -64,7 +64,7 @@ except ImportError:
         except OSError:
             pass
 
-        if os.path.exists(os.path.join(build_dir, "gsplat_cuda.so")):
+        if os.path.exists(os.path.join(build_dir, "gsplat_cuda.so")) or os.path.exists(os.path.join(build_dir, "gsplat_cuda.lib")):
             # If the build exists, we assume the extension has been built
             # and we can load it.
 


### PR DESCRIPTION
Hello :wave:,

the current code on Windows will fail to detect when a build has already been done, due to libraries having .lib extension rather than .so and will repeat the build at every program load.

The proposed change checks for .lib extension also.