### PR TITLE
fix get_tile_bin_edges; revert ndc2pix

### DIFF
--- a/gsplat/cuda/csrc/forward.cu
+++ b/gsplat/cuda/csrc/forward.cu
@@ -151,8 +151,9 @@ __global__ void get_tile_bin_edges(
             tile_bins[cur_tile_idx].x = 0;
         if (idx == num_intersects - 1)
             tile_bins[cur_tile_idx].y = num_intersects;
-        return;
     }
+    if (idx == 0)
+        return;
     int32_t prev_tile_idx = (int32_t)(isect_ids_sorted[idx - 1] >> 32);
     if (prev_tile_idx != cur_tile_idx) {
         tile_bins[prev_tile_idx].y = idx;

--- a/gsplat/cuda/csrc/helpers.cuh
+++ b/gsplat/cuda/csrc/helpers.cuh
@@ -5,7 +5,7 @@
 #include <iostream>
 
 inline __device__ float ndc2pix(const float x, const float W, const float cx) {
-    return 0.5f * W * x + cx + 0.5f;
+    return 0.5f * W * x + cx - 0.5f;
 }
 
 inline __device__ void get_bbox(


### PR DESCRIPTION
Continue fixing #111.

It is actually not the -0.5 in `ndc2pix` that causes the bug -- flipping the sign only hides it. Here is another test case that still  render with artifacts (bottom right corner) after #112:

```python
import imageio
import numpy as np
import torch
from gsplat import ProjectGaussians, RasterizeGaussians

torch.manual_seed(42)

device = torch.device("cuda:0")
num_points = 3

means3d = torch.rand((num_points, 3), device=device, requires_grad=True)
scales = torch.rand((num_points, 3), device=device) * 3
quats = torch.randn((num_points, 4), device=device)
quats /= torch.linalg.norm(quats, dim=-1, keepdim=True)
rgbs = torch.rand((num_points, 3), device=device)
opacities = torch.ones((num_points, 1), device=device)

glob_scale = 0.3
viewmat = torch.eye(4, device=device)
projmat = torch.eye(4, device=device)
fx, fy = 3.0, 3.0
H, W = 256, 256
clip_thresh = 0.0
BLOCK_X, BLOCK_Y = 16, 16
tile_bounds = (W + BLOCK_X - 1) // BLOCK_X, (H + BLOCK_Y - 1) // BLOCK_Y, 1

background = torch.zeros(3, device=device)


xys, depths, radii, conics, num_tiles_hit, cov3d = ProjectGaussians.apply(
    means3d,
    scales,
    1,
    quats,
    viewmat,
    viewmat,
    fx,
    fy,
    W / 2,
    H / 2,
    H,
    W,
    tile_bounds,
)
render = RasterizeGaussians.apply(
    xys,
    depths,
    radii,
    conics,
    num_tiles_hit,
    rgbs,
    opacities,
    H,
    W,
    background,
)

canvas = (render * 255.0).detach().cpu().numpy()
imageio.imwrite("ref.png", canvas.astype(np.uint8))
```
![ref](https://github.com/nerfstudio-project/gsplat/assets/10151885/ff0c97d1-d382-4de7-aa28-3e6393b881c3)

