### PR TITLE
Compute density compensation for screen space blurring of tiny gaussians

### DIFF
--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 from jaxtyping import Float
 from torch import Tensor
+from typing import Tuple
 
 
 def compute_sh_color(
@@ -116,15 +117,15 @@ def quat_to_rotmat(quat: Tensor) -> Tensor:
     w, x, y, z = torch.unbind(F.normalize(quat, dim=-1), dim=-1)
     mat = torch.stack(
         [
-            1 - 2 * (y ** 2 + z ** 2),
+            1 - 2 * (y**2 + z**2),
             2 * (x * y - w * z),
             2 * (x * z + w * y),
             2 * (x * y + w * z),
-            1 - 2 * (x ** 2 + z ** 2),
+            1 - 2 * (x**2 + z**2),
             2 * (y * z - w * x),
             2 * (x * z - w * y),
             2 * (y * z + w * x),
-            1 - 2 * (x ** 2 + y ** 2),
+            1 - 2 * (x**2 + y**2),
         ],
         dim=-1,
     )
@@ -149,7 +150,7 @@ def project_cov3d_ewa(
     fy: float,
     tan_fovx: float,
     tan_fovy: float,
-) -> Tensor:
+) -> Tuple[Tensor, Tensor]:
     assert mean3d.shape[-1] == 3, mean3d.shape
     assert cov3d.shape[-2:] == (3, 3), cov3d.shape
     assert viewmat.shape[-2:] == (4, 4), viewmat.shape
@@ -158,7 +159,7 @@ def project_cov3d_ewa(
     t = torch.einsum("...ij,...j->...i", W, mean3d) + p  # (..., 3)
 
     rz = 1.0 / t[..., 2]  # (...,)
-    rz2 = rz ** 2  # (...,)
+    rz2 = rz**2  # (...,)
 
     lim_x = 1.3 * torch.tensor([tan_fovx], device=mean3d.device)
     lim_y = 1.3 * torch.tensor([tan_fovy], device=mean3d.device)
@@ -174,9 +175,12 @@ def project_cov3d_ewa(
     T = torch.matmul(J, W)  # (..., 2, 3)
     cov2d = torch.einsum("...ij,...jk,...kl->...il", T, cov3d, T.transpose(-1, -2))
     # add a little blur along axes and (TODO save upper triangular elements)
+    det_orig = cov2d[..., 0, 0] * cov2d[..., 1, 1] - cov2d[..., 0, 1] * cov2d[..., 0, 1]
     cov2d[..., 0, 0] = cov2d[..., 0, 0] + 0.3
     cov2d[..., 1, 1] = cov2d[..., 1, 1] + 0.3
-    return cov2d[..., :2, :2]
+    det_blur = cov2d[..., 0, 0] * cov2d[..., 1, 1] - cov2d[..., 0, 1] * cov2d[..., 0, 1]
+    compensation = torch.sqrt(torch.clamp(det_orig / det_blur, min=0))
+    return cov2d[..., :2, :2], compensation.detach()
 
 
 def compute_cov2d_bounds(cov2d_mat: Tensor):
@@ -198,8 +202,8 @@ def compute_cov2d_bounds(cov2d_mat: Tensor):
         dim=-1,
     )  # (..., 3)
     b = (cov2d[..., 0, 0] + cov2d[..., 1, 1]) / 2  # (...,)
-    v1 = b + torch.sqrt(torch.clamp(b ** 2 - det, min=0.1))  # (...,)
-    v2 = b - torch.sqrt(torch.clamp(b ** 2 - det, min=0.1))  # (...,)
+    v1 = b + torch.sqrt(torch.clamp(b**2 - det, min=0.1))  # (...,)
+    v2 = b - torch.sqrt(torch.clamp(b**2 - det, min=0.1))  # (...,)
     radius = torch.ceil(3.0 * torch.sqrt(torch.max(v1, v2)))  # (...,)
     radius_all = torch.zeros(*cov2d_mat.shape[:-2], device=cov2d_mat.device)
     conic_all = torch.zeros(*cov2d_mat.shape[:-2], 3, device=cov2d_mat.device)
@@ -272,7 +276,9 @@ def project_gaussians_forward(
     tan_fovy = 0.5 * img_size[1] / fy
     p_view, is_close = clip_near_plane(means3d, viewmat, clip_thresh)
     cov3d = scale_rot_to_cov3d(scales, glob_scale, quats)
-    cov2d = project_cov3d_ewa(means3d, cov3d, viewmat, fx, fy, tan_fovx, tan_fovy)
+    cov2d, compensation = project_cov3d_ewa(
+        means3d, cov3d, viewmat, fx, fy, tan_fovx, tan_fovy
+    )
     conic, radius, det_valid = compute_cov2d_bounds(cov2d)
     xys = project_pix(fullmat, means3d, img_size, (cx, cy))
     tile_min, tile_max = get_tile_bbox(xys, radius, tile_bounds)
@@ -290,6 +296,7 @@ def project_gaussians_forward(
     xys = torch.where(~mask[..., None], 0, xys)
     cov3d = torch.where(~mask[..., None, None], 0, cov3d)
     cov2d = torch.where(~mask[..., None, None], 0, cov2d)
+    compensation = torch.where(~mask, 0, compensation)
     num_tiles_hit = torch.where(~mask, 0, num_tiles_hit)
     depths = torch.where(~mask, 0, depths)
 
@@ -297,7 +304,17 @@ def project_gaussians_forward(
     cov3d_triu = cov3d[..., i, j]
     i, j = torch.triu_indices(2, 2)
     cov2d_triu = cov2d[..., i, j]
-    return cov3d_triu, cov2d_triu, xys, depths, radii, conic, num_tiles_hit, mask
+    return (
+        cov3d_triu,
+        cov2d_triu,
+        xys,
+        depths,
+        radii,
+        conic,
+        compensation,
+        num_tiles_hit,
+        mask,
+    )
 
 
 def map_gaussian_to_intersects(
@@ -339,7 +356,6 @@ def get_tile_bin_edges(num_intersects, isect_ids_sorted, tile_bounds):
     )
 
     for idx in range(num_intersects):
-
         cur_tile_idx = isect_ids_sorted[idx] >> 32
 
         if idx == 0:

--- a/gsplat/cuda/csrc/bindings.cu
+++ b/gsplat/cuda/csrc/bindings.cu
@@ -122,6 +122,7 @@ std::tuple<
     torch::Tensor,
     torch::Tensor,
     torch::Tensor,
+    torch::Tensor,
     torch::Tensor>
 project_gaussians_forward_tensor(
     const int num_points,
@@ -162,6 +163,8 @@ project_gaussians_forward_tensor(
         torch::zeros({num_points}, means3d.options().dtype(torch::kInt32));
     torch::Tensor conics_d =
         torch::zeros({num_points, 3}, means3d.options().dtype(torch::kFloat32));
+    torch::Tensor compensation_d =
+        torch::zeros({num_points}, means3d.options().dtype(torch::kFloat32));
     torch::Tensor num_tiles_hit_d =
         torch::zeros({num_points}, means3d.options().dtype(torch::kInt32));
 
@@ -185,11 +188,12 @@ project_gaussians_forward_tensor(
         depths_d.contiguous().data_ptr<float>(),
         radii_d.contiguous().data_ptr<int>(),
         (float3 *)conics_d.contiguous().data_ptr<float>(),
+        compensation_d.contiguous().data_ptr<float>(),
         num_tiles_hit_d.contiguous().data_ptr<int32_t>()
     );
 
     return std::make_tuple(
-        cov3d_d, xys_d, depths_d, radii_d, conics_d, num_tiles_hit_d
+        cov3d_d, xys_d, depths_d, radii_d, conics_d, compensation_d, num_tiles_hit_d
     );
 }
 

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -40,6 +40,7 @@ std::tuple<
     torch::Tensor,
     torch::Tensor,
     torch::Tensor,
+    torch::Tensor,
     torch::Tensor>
 project_gaussians_forward_tensor(
     const int num_points,

--- a/gsplat/cuda/csrc/forward.cuh
+++ b/gsplat/cuda/csrc/forward.cuh
@@ -20,6 +20,7 @@ __global__ void project_gaussians_forward_kernel(
     float* __restrict__ depths,
     int* __restrict__ radii,
     float3* __restrict__ conics,
+    float* __restrict__ compensation,
     int32_t* __restrict__ num_tiles_hit
 );
 
@@ -57,14 +58,16 @@ __global__ void nd_rasterize_forward(
 );
 
 // device helper to approximate projected 2d cov from 3d mean and cov
-__device__ float3 project_cov3d_ewa(
+__device__ void project_cov3d_ewa(
     const float3 &mean3d,
     const float *cov3d,
     const float *viewmat,
     const float fx,
     const float fy,
     const float tan_fovx,
-    const float tan_fovy
+    const float tan_fovy,
+    float3 &cov2d,
+    float &comp
 );
 
 // device helper to get 3D covariance from scale and quat parameters

--- a/tests/test_project_gaussians.py
+++ b/tests/test_project_gaussians.py
@@ -66,7 +66,15 @@ def test_project_gaussians_forward():
     BLOCK_X, BLOCK_Y = 16, 16
     tile_bounds = (W + BLOCK_X - 1) // BLOCK_X, (H + BLOCK_Y - 1) // BLOCK_Y, 1
 
-    (cov3d, xys, depths, radii, conics, num_tiles_hit,) = _C.project_gaussians_forward(
+    (
+        cov3d,
+        xys,
+        depths,
+        radii,
+        conics,
+        compensation,
+        num_tiles_hit,
+    ) = _C.project_gaussians_forward(
         num_points,
         means3d,
         scales,
@@ -93,6 +101,7 @@ def test_project_gaussians_forward():
             _depths,
             _radii,
             _conics,
+            _compensation,
             _num_tiles_hit,
             _masks,
         ) = _torch_impl.project_gaussians_forward(
@@ -114,6 +123,7 @@ def test_project_gaussians_forward():
     check_close(depths, _depths)
     check_close(radii, _radii)
     check_close(conics, _conics)
+    check_close(compensation, _compensation)
     check_close(num_tiles_hit, _num_tiles_hit)
     print("passed project_gaussians_forward test")
 
@@ -155,6 +165,7 @@ def test_project_gaussians_backward():
         depths,
         radii,
         conics,
+        _,
         _,
         masks,
     ) = _torch_impl.project_gaussians_forward(
@@ -219,7 +230,7 @@ def test_project_gaussians_backward():
         i, j = torch.triu_indices(3, 3)
         cov3d_mat[..., i, j] = cov3d
         cov3d_mat[..., [1, 2, 2], [0, 0, 1]] = cov3d[..., [1, 2, 4]]
-        cov2d = _torch_impl.project_cov3d_ewa(
+        cov2d, _ = _torch_impl.project_cov3d_ewa(
             mean3d, cov3d_mat, viewmat, fx, fy, tan_fovx, tan_fovy
         )
         ii, jj = torch.triu_indices(2, 2)


### PR DESCRIPTION
# Why
Current gaussian splatting (both Inria and nerfstudio) doesn't sufficiently deal with the case when rendering tiny gaussians at substantial different resolution than the captured one. The reason is caused by the [0.3 pix kernel screen space blurring](https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/_torch_impl.py#L193-L194) applied to the tiny splats. 

A tiny splat that has been enlarged by 0.3 pixel can block more gaussians behind it if rendering at lower resolution than the captured one, or looks much thinner than it should be if rendering at higher resolution than the captured one. One would easily observe this artifacts by changing the distance or resolution of rendering. 

This issue is [acknowledged](https://github.com/graphdeco-inria/gaussian-splatting/issues/294#issuecomment-1772688093) by the original author of Gaussian splatting, and was [addressed](https://github.com/wanmeihuali/taichi_3d_gaussian_splatting/issues/151) in another open source repo. 

Addressing this issue has significant benefit in an interactive webviewer, where one zoom in/out to inspect a splat model, and see much less artifacts then before. Another simple quantitative experiment one can do is to train at 1/2 resolution and evaluation at the original resolution, addressing the issue expects to improve metrics. 

# Solution

The solution is rather simple. We will compute a compensation factor $\rho=\sqrt{\dfrac{Det(\Sigma)}{Det(\Sigma+ 0.3 I)}}$ for each splat and multiply it to the opacity of gaussian before rasterization. The same solution was also proposed in [another research paper](https://github.com/autonomousvision/mip-splatting).

The PR will basically modify the output of rasterize_gaussians to return the compensation factor $\rho$ and  the change allows us to have two modes in nerfstudio's splatfacto: the classic mode which mimic the behavior of official GS, and the new mode which address the "aliasing-like" issue. 

See results [here](https://github.com/jb-ye/gsplat/issues/1) (I had to upload the video to my own forked repo's issue due to file size limit).


