### PR TITLE
Fix core tests

### DIFF
--- a/tests/test_project_gaussians.py
+++ b/tests/test_project_gaussians.py
@@ -128,6 +128,7 @@ def test_project_gaussians_forward():
     print("passed project_gaussians_forward test")
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 def test_project_gaussians_backward():
     num_points = 100
 


### PR DESCRIPTION
The core tests are broken since https://github.com/nerfstudio-project/gsplat/pull/118 Because the `test_project_gaussians_backward` was not properly annotated. 