### PR TITLE
Normalize quaternions in PyTorch Implementation

### DIFF
--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -142,7 +142,7 @@ def scale_rot_to_cov3d(scale: Tensor, glob_scale: float, quat: Tensor) -> Tensor
     assert scale.shape[-1] == 3, scale.shape
     assert quat.shape[-1] == 4, quat.shape
     assert scale.shape[:-1] == quat.shape[:-1], (scale.shape, quat.shape)
-    R = normalized_quat_to_rotmat(quat)  # (..., 3, 3)
+    R = quat_to_rotmat(quat)  # (..., 3, 3)
     M = R * glob_scale * scale[..., None, :]  # (..., 3, 3)
     # TODO: save upper right because symmetric
     return M @ M.transpose(-1, -2)  # (..., 3, 3)

--- a/tests/test_project_gaussians.py
+++ b/tests/test_project_gaussians.py
@@ -44,7 +44,6 @@ def test_project_gaussians_forward():
     scales = torch.rand((num_points, 3), device=device) + 0.2
     glob_scale = 0.1
     quats = torch.randn((num_points, 4), device=device)
-    quats /= torch.linalg.norm(quats, dim=-1, keepdim=True)
 
     H, W = 512, 512
     cx, cy = W / 2, H / 2


### PR DESCRIPTION
I was using the PyTorch implementation for educational purposes and noticed the implementation did not quite match the cuda one.
In the cuda implementation the quaternions are always normalized but not in the PyTorch reference implementation. 
