### PR TITLE
normalize the quats in torch implements

### DIFF
--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -293,7 +293,7 @@ def project_gaussians_forward(
     tan_fovx = 0.5 * img_size[0] / fx
     tan_fovy = 0.5 * img_size[1] / fy
     p_view, is_close = clip_near_plane(means3d, viewmat, clip_thresh)
-    cov3d = scale_rot_to_cov3d(scales, glob_scale, quats)
+    cov3d = scale_rot_to_cov3d(scales, glob_scale, F.normalize(quats, dim=-1))
     cov2d, compensation = project_cov3d_ewa(
         means3d, cov3d, viewmat, fx, fy, tan_fovx, tan_fovy
     )

--- a/tests/test_project_gaussians.py
+++ b/tests/test_project_gaussians.py
@@ -44,7 +44,6 @@ def test_project_gaussians_forward():
     scales = torch.rand((num_points, 3), device=device) + 0.2
     glob_scale = 0.1
     quats = torch.randn((num_points, 4), device=device)
-    quats /= torch.linalg.norm(quats, dim=-1, keepdim=True)
 
     H, W = 512, 512
     cx, cy = W / 2, H / 2


### PR DESCRIPTION
When the quaternion is not normalized, project_gaussians in _torch_impl.py  and forward.cu give different results.I think the reason for this problem is that the latter has an additional normalization operation for quaternions compared to the former.

https://github.com/nerfstudio-project/gsplat/blob/2135488e27f2ee3c00de13d16b583605050614f0/gsplat/cuda/csrc/helpers.cuh#L150-L153