### PR TITLE
Fast SH implementation

### DIFF
--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -145,7 +145,6 @@ def eval_sh_bases_fast(basis_dim: int, dirs: torch.Tensor):
         return
 
     x, y, z = dirs.unbind(-1)
-    z2 = z * z
 
     fTmpA = -0.48860251190292
     result[..., 2] = 0.4886025119029199 * z
@@ -155,6 +154,7 @@ def eval_sh_bases_fast(basis_dim: int, dirs: torch.Tensor):
     if basis_dim <= 4:
         return
 
+    z2 = z * z
     fTmpB = -1.092548430592079 * z
     fTmpA = 0.5462742152960395
     fC1 = x * x - y * y

--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -169,15 +169,15 @@ def eval_sh_bases_fast(basis_dim: int, dirs: torch.Tensor):
     fTmpC = -2.285228997322329 * z2 + 0.4570457994644658
     fTmpB = 1.445305721320277 * z
     fTmpA = -0.5900435899266435
-    fC0 = x * fC1 - y * fS1
-    fS0 = x * fS1 + y * fC1
+    fC2 = x * fC1 - y * fS1
+    fS2 = x * fS1 + y * fC1
     result[..., 12] = z * (1.865881662950577 * z2 - 1.119528997770346)
     result[..., 13] = fTmpC * x
     result[..., 11] = fTmpC * y
     result[..., 14] = fTmpB * fC1
     result[..., 10] = fTmpB * fS1
-    result[..., 15] = fTmpA * fC0
-    result[..., 9] = fTmpA * fS0
+    result[..., 15] = fTmpA * fC2
+    result[..., 9] = fTmpA * fS2
 
     if basis_dim <= 16:
         return
@@ -186,17 +186,17 @@ def eval_sh_bases_fast(basis_dim: int, dirs: torch.Tensor):
     fTmpC = 3.31161143515146 * z2 - 0.47308734787878
     fTmpB = -1.770130769779931 * z
     fTmpA = 0.6258357354491763
-    fC1 = x * fC0 - y * fS0
-    fS1 = x * fS0 + y * fC0
+    fC3 = x * fC2 - y * fS2
+    fS3 = x * fS2 + y * fC2
     result[..., 20] = 1.984313483298443 * z * result[..., 12] + -1.006230589874905 * result[..., 6]
     result[..., 21] = fTmpD * x
     result[..., 19] = fTmpD * y
     result[..., 22] = fTmpC * fC1
     result[..., 18] = fTmpC * fS1
-    result[..., 23] = fTmpB * fC0
-    result[..., 17] = fTmpB * fS0
-    result[..., 24] = fTmpA * fC1
-    result[..., 16] = fTmpA * fS1
+    result[..., 23] = fTmpB * fC2
+    result[..., 17] = fTmpB * fS2
+    result[..., 24] = fTmpA * fC3
+    result[..., 16] = fTmpA * fS3
     return result
 
 

--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -12,7 +12,7 @@ from typing import Tuple, Literal
 def compute_sh_color(
     viewdirs: Float[Tensor, "*batch 3"],
     sh_coeffs: Float[Tensor, "*batch D C"],
-    mode: Literal["poly", "fast"] = "fast",
+    method: Literal["poly", "fast"] = "fast",
 ):
     """
     :param viewdirs (*, C)
@@ -20,12 +20,12 @@ def compute_sh_color(
     return colors (*, C)
     """
     *dims, dim_sh, C = sh_coeffs.shape
-    if mode == "poly":
+    if method == "poly":
         bases = eval_sh_bases(dim_sh, viewdirs)  # (*, dim_sh)
-    elif mode == "fast":
+    elif method == "fast":
         bases = eval_sh_bases_fast(dim_sh, viewdirs)  # (*, dim_sh)
     else:
-        raise RuntimeError(f"Unknown mode: {mode} for compute sh color.")
+        raise RuntimeError(f"Unknown mode: {method} for compute sh color.")
     return (bases[..., None] * sh_coeffs).sum(dim=-2)
 
 

--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -6,11 +6,12 @@ import torch
 import torch.nn.functional as F
 from jaxtyping import Float
 from torch import Tensor
-from typing import Tuple
+from typing import Tuple, Literal
 
 
 def compute_sh_color(
-    viewdirs: Float[Tensor, "*batch 3"], sh_coeffs: Float[Tensor, "*batch D C"]
+        viewdirs: Float[Tensor, "*batch 3"], sh_coeffs: Float[Tensor, "*batch D C"],
+        mode: Literal["poly", "fast"] = "poly"
 ):
     """
     :param viewdirs (*, C)
@@ -18,7 +19,12 @@ def compute_sh_color(
     return colors (*, C)
     """
     *dims, dim_sh, C = sh_coeffs.shape
-    bases = eval_sh_bases(dim_sh, viewdirs)  # (*, dim_sh)
+    if mode == "poly":
+        bases = eval_sh_bases(dim_sh, viewdirs)  # (*, dim_sh)
+    elif mode == "fast":
+        bases = eval_sh_bases_codegen(dim_sh, viewdirs)  # (*, dim_sh)
+    else:
+        raise RuntimeError(f"Unknown mode: {mode} for compute sh color.")
     return (bases[..., None] * sh_coeffs).sum(dim=-2)
 
 
@@ -111,6 +117,162 @@ def eval_sh_bases(basis_dim: int, dirs: torch.Tensor):
                         xx * (xx - 3 * yy) - yy * (3 * xx - yy)
                     )
     return result
+
+
+def eval_sh3_bases_codegen(dirs: torch.Tensor):
+    """
+    See reference C++ code in https://jcgt.org/published/0002/02/06/code.zip
+    """
+    x, y, z = dirs.unbind(-1)
+    result = torch.empty(
+        (*dirs.shape[:-1], 9), dtype=dirs.dtype, device=dirs.device
+    )
+
+    z2 = z * z
+
+    result[..., 0] = 0.2820947917738781
+    result[..., 2] = 0.4886025119029199 * z
+    result[..., 6] = 0.9461746957575601 * z2 - 0.3153915652525201
+    # fC0 = x
+    # fS0 = y
+
+    fTmpA = -0.48860251190292
+    result[..., 3] = fTmpA * x
+    result[..., 1] = fTmpA * y
+    fTmpB = -1.092548430592079 * z
+    result[..., 7] = fTmpB * x
+    result[..., 5] = fTmpB * y
+    fC1 = x * x - y * y
+    fS1 = 2 * x * y
+    fTmpC = 0.5462742152960395
+    result[..., 8] = fTmpC * fC1
+    result[..., 4] = fTmpC * fS1
+    return result
+
+def eval_sh4_bases_codegen(dirs: torch.Tensor):
+    """
+    See reference C++ code in https://jcgt.org/published/0002/02/06/code.zip
+    """
+    x, y, z = dirs.unbind(-1)
+    result = torch.empty(
+        (*dirs.shape[:-1], 16), dtype=dirs.dtype, device=dirs.device
+    )
+
+    z2 = z * z
+
+    result[..., 0] = 0.2820947917738781
+    result[..., 2] = 0.4886025119029199 * z
+    result[..., 6] = 0.9461746957575601 * z2 - 0.3153915652525201
+    result[..., 12] = z * (1.865881662950577 * z2 -1.119528997770346)
+    # fC0 = x
+    # fS0 = y
+
+    fTmpA = -0.48860251190292
+    result[..., 3] = fTmpA * x
+    result[..., 1] = fTmpA * y
+    fTmpB = -1.092548430592079 * z
+    result[..., 7] = fTmpB * x
+    result[..., 5] = fTmpB * y
+    fTmpC = -2.285228997322329 * z2 + 0.4570457994644658
+    result[..., 13] = fTmpC * x
+    result[..., 11] = fTmpC * y
+    fC1 = x * x - y * y
+    fS1 = 2 * x * y
+
+    fTmpA = 0.5462742152960395
+    result[..., 8] = fTmpA * fC1
+    result[..., 4] = fTmpA * fS1
+    fTmpB = 1.445305721320277 * z
+    result[..., 14] = fTmpB * fC1
+    result[..., 10] = fTmpB * fS1
+    fC0 = x * fC1 - y * fS1
+    fS0 = x * fS1 + y * fC1
+
+    fTmpC = -0.5900435899266435
+    result[..., 15] = fTmpC * fC0
+    result[..., 9] = fTmpC * fS0
+    return result
+
+def eval_sh5_bases_codegen(dirs: torch.Tensor):
+    """
+    See reference C++ code in https://jcgt.org/published/0002/02/06/code.zip
+    """
+    x, y, z = dirs.unbind(-1)
+    result = torch.empty(
+        (*dirs.shape[:-1], 25), dtype=dirs.dtype, device=dirs.device
+    )
+
+    z2 = z * z
+
+    result[..., 0] = 0.2820947917738781
+    result[..., 2] = 0.4886025119029199 * z
+    result[..., 6] = 0.9461746957575601 * z2 - 0.3153915652525201
+    result[..., 12] = z * (1.865881662950577 * z2 - 1.119528997770346)
+    result[..., 20] = 1.984313483298443 * z * result[..., 12] + -1.006230589874905 * result[..., 6]
+    # fC0 = x
+    # fS0 = y
+
+    fTmpA = -0.48860251190292
+    result[..., 3] = fTmpA * x
+    result[..., 1] = fTmpA * y
+    fTmpB = -1.092548430592079 * z
+    result[..., 7] = fTmpB * x
+    result[..., 5] = fTmpB * y
+    fTmpC = -2.285228997322329 * z2 + 0.4570457994644658
+    result[..., 13] = fTmpC * x
+    result[..., 11] = fTmpC * y
+    fTmpA = z * (-4.683325804901025 * z2 + 2.007139630671868)
+    result[..., 21] = fTmpA * x
+    result[..., 19] = fTmpA * y
+    fC1 = x * x - y * y
+    fS1 = 2 * x * y
+
+    fTmpA = 0.5462742152960395
+    result[..., 8] = fTmpA * fC1
+    result[..., 4] = fTmpA * fS1
+    fTmpB = 1.445305721320277 * z
+    result[..., 14] = fTmpB * fC1
+    result[..., 10] = fTmpB * fS1
+    fTmpC = 3.31161143515146 * z2 - 0.47308734787878
+    result[..., 22] = fTmpC * fC1
+    result[..., 18] = fTmpC * fS1
+    fC0 = x * fC1 - y * fS1
+    fS0 = x * fS1 + y * fC1
+
+    fTmpA = -0.5900435899266435
+    result[..., 15] = fTmpA * fC0
+    result[..., 9] = fTmpA * fS0
+    fTmpB = -1.770130769779931 * z
+    result[..., 23] = fTmpB * fC0
+    result[..., 17] = fTmpB * fS0
+    fC1 = x * fC0 - y * fS0
+    fS1 = x * fS0 + y * fC0
+
+    fTmpC = 0.6258357354491763
+    result[..., 24] = fTmpC * fC1
+    result[..., 16] = fTmpC * fS1
+    return result
+def eval_sh_bases_codegen(basis_dim: int, dirs: torch.Tensor):
+    """
+    Evaluate spherical harmonics bases at unit direction for high orders
+    using approach described by
+    Efficient Spherical Harmonic Evaluation, Peter-Pike Sloan, JCGT 2013
+    https://jcgt.org/published/0002/02/06/
+
+
+    :param basis_dim: int SH basis dim. Currently, only 1-25 square numbers supported
+    :param dirs: torch.Tensor (..., 3) unit directions
+
+    :return: torch.Tensor (..., basis_dim)
+    """
+    if basis_dim <= 4:
+        return eval_sh_bases(basis_dim, dirs)
+    if basis_dim == 9:
+        return eval_sh3_bases_codegen(dirs)
+    if basis_dim == 16:
+        return eval_sh4_bases_codegen(dirs)
+    if basis_dim == 25:
+        return eval_sh5_bases_codegen(dirs)
 
 
 def normalized_quat_to_rotmat(quat: Tensor) -> Tensor:

--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -10,8 +10,9 @@ from typing import Tuple, Literal
 
 
 def compute_sh_color(
-        viewdirs: Float[Tensor, "*batch 3"], sh_coeffs: Float[Tensor, "*batch D C"],
-        mode: Literal["poly", "fast"] = "fast"
+    viewdirs: Float[Tensor, "*batch 3"],
+    sh_coeffs: Float[Tensor, "*batch D C"],
+    mode: Literal["poly", "fast"] = "fast",
 ):
     """
     :param viewdirs (*, C)
@@ -118,6 +119,7 @@ def eval_sh_bases(basis_dim: int, dirs: torch.Tensor):
                     )
     return result
 
+
 def eval_sh_bases_fast(basis_dim: int, dirs: torch.Tensor):
     """
     Evaluate spherical harmonics bases at unit direction for high orders
@@ -188,7 +190,9 @@ def eval_sh_bases_fast(basis_dim: int, dirs: torch.Tensor):
     fTmpA = 0.6258357354491763
     fC3 = x * fC2 - y * fS2
     fS3 = x * fS2 + y * fC2
-    result[..., 20] = 1.984313483298443 * z * result[..., 12] + -1.006230589874905 * result[..., 6]
+    result[..., 20] = (
+        1.984313483298443 * z * result[..., 12] + -1.006230589874905 * result[..., 6]
+    )
     result[..., 21] = fTmpD * x
     result[..., 19] = fTmpD * y
     result[..., 22] = fTmpC * fC1

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -22,6 +22,7 @@ std::tuple<
 compute_cov2d_bounds_tensor(const int num_pts, torch::Tensor &A);
 
 torch::Tensor compute_sh_forward_tensor(
+    const std::string &method,
     unsigned num_points,
     unsigned degree,
     unsigned degrees_to_use,
@@ -30,6 +31,7 @@ torch::Tensor compute_sh_forward_tensor(
 );
 
 torch::Tensor compute_sh_backward_tensor(
+    const std::string &method,
     unsigned num_points,
     unsigned degree,
     unsigned degrees_to_use,

--- a/gsplat/cuda/csrc/sh.cuh
+++ b/gsplat/cuda/csrc/sh.cuh
@@ -42,14 +42,16 @@ __host__ __device__ unsigned num_sh_bases(const unsigned degree) {
         return 16;
     return 25;
 }
+
+// Evaluate spherical harmonics bases at unit direction for high orders using approach described by
+// Efficient Spherical Harmonic Evaluation, Peter-Pike Sloan, JCGT 2013
+// See https://jcgt.org/published/0002/02/06/ for reference implementation
 __device__ void sh_coeffs_to_color_fast(
     const unsigned degree,
     const float3 &viewdir,
     const float *coeffs,
     float *colors
 ) {
-    // Expects v_colors to be len CHANNELS
-    // and v_coeffs to be num_bases * CHANNELS
     for (int c = 0; c < CHANNELS; ++c) {
         colors[c] = 0.2820947917738781f * coeffs[c];
     }

--- a/gsplat/cuda/csrc/sh.cuh
+++ b/gsplat/cuda/csrc/sh.cuh
@@ -42,7 +42,7 @@ __host__ __device__ unsigned num_sh_bases(const unsigned degree) {
         return 16;
     return 25;
 }
-__device__ void sh_coeffs_to_color_new(
+__device__ void sh_coeffs_to_color_fast(
     const unsigned degree,
     const float3 &viewdir,
     const float *coeffs,
@@ -148,7 +148,7 @@ __device__ void sh_coeffs_to_color_new(
     }
 }
 
-__device__ void sh_coeffs_to_color_new_vjp(
+__device__ void sh_coeffs_to_color_fast_vjp(
     const unsigned degree,
     const float3 &viewdir,
     const float *v_colors,
@@ -441,7 +441,7 @@ __global__ void compute_sh_forward_kernel(
     unsigned idx_sh = num_bases * num_channels * idx;
     unsigned idx_col = num_channels * idx;
 
-    sh_coeffs_to_color_new(
+    sh_coeffs_to_color_fast(
         degrees_to_use, viewdirs[idx], &(coeffs[idx_sh]), &(colors[idx_col])
     );
 }
@@ -463,7 +463,7 @@ __global__ void compute_sh_backward_kernel(
     unsigned idx_sh = num_bases * num_channels * idx;
     unsigned idx_col = num_channels * idx;
 
-    sh_coeffs_to_color_new_vjp(
+    sh_coeffs_to_color_fast_vjp(
         degrees_to_use, viewdirs[idx], &(v_colors[idx_col]), &(v_coeffs[idx_sh])
     );
 }

--- a/gsplat/cuda/csrc/sh.cuh
+++ b/gsplat/cuda/csrc/sh.cuh
@@ -170,9 +170,10 @@ __device__ void sh_coeffs_to_color_new_vjp(
     float y = viewdir.y / norm;
     float z = viewdir.z / norm;
 
+
+    float fTmp0A = 0.48860251190292f;
 #pragma unroll
     for (int c = 0; c < CHANNELS; ++c) {
-        float fTmp0A = 0.48860251190292f;
         v_coeffs[1 * CHANNELS + c] = -fTmp0A * y * v_colors[c];
         v_coeffs[2 * CHANNELS + c] = fTmp0A * z * v_colors[c];
         v_coeffs[3 * CHANNELS + c] = -fTmp0A * x * v_colors[c];

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+import time
 
 
 device = torch.device("cuda:0")
@@ -46,6 +47,46 @@ def test_sh(method):
     torch.testing.assert_close(check_colors, gt_colors)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def profile_sh(method, num_points: int = 1_000_000, degree: int = 4, n_iters: int = 1000):
+    from gsplat import sh
+
+    viewdirs = torch.randn(num_points, 3, device=device)
+    viewdirs /= torch.linalg.norm(viewdirs, dim=-1, keepdim=True)
+    sh_coeffs = torch.rand(
+        num_points, sh.num_sh_bases(degree), 3, device=device, requires_grad=True
+    )
+
+    for _ in range(10): # warmup
+        colors = sh.spherical_harmonics(degree, viewdirs, sh_coeffs, method)
+    
+    n_iters_fwd = n_iters
+    torch.cuda.synchronize()
+    tic = time.time()
+    for _ in range(n_iters_fwd):
+        _ = sh.spherical_harmonics(degree, viewdirs, sh_coeffs)
+    torch.cuda.synchronize()
+    toc = time.time()
+    ellipsed = (toc - tic) / n_iters_fwd * 1000 # ms
+    print(f"[Fwd] Method: {method}, ellipsed: {ellipsed:.2f} ms")
+
+    loss = sh.spherical_harmonics(degree, viewdirs, sh_coeffs, method).sum()
+    for _ in range(10): # warmup
+        loss.backward(retain_graph=True)
+
+    n_iters_bwd = n_iters // 20
+    torch.cuda.synchronize()
+    tic = time.time()
+    for _ in range(n_iters_bwd):
+        loss.backward(retain_graph=True)
+    torch.cuda.synchronize()
+    toc = time.time()
+    ellipsed = (toc - tic) / n_iters_bwd * 1000 # ms
+    print(f"[Bwd] Method: {method}, ellipsed: {ellipsed:.2f} ms")
+    
+
 if __name__ == "__main__":
     test_sh("poly")
     test_sh("fast")
+    profile_sh("poly")
+    profile_sh("fast")

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -66,7 +66,7 @@ def profile_sh(
     torch.cuda.synchronize()
     tic = time.time()
     for _ in range(n_iters_fwd):
-        _ = sh.spherical_harmonics(degree, viewdirs, sh_coeffs)
+        _ = sh.spherical_harmonics(degree, viewdirs, sh_coeffs, method)
     torch.cuda.synchronize()
     toc = time.time()
     ellipsed = (toc - tic) / n_iters_fwd * 1000  # ms

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -25,7 +25,7 @@ def test_sh():
         optim.zero_grad()
 
         # compute PyTorch's color and grad
-        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs, 'fast')
+        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs)
         check_loss = torch.square(check_colors - gt_colors).mean()
         check_loss.backward()
         check_grad = sh_coeffs.grad.detach()

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -6,7 +6,7 @@ device = torch.device("cuda:0")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
-def test_sh():
+def test_sh(method):
     from gsplat import _torch_impl
     from gsplat import sh
 
@@ -25,7 +25,7 @@ def test_sh():
         optim.zero_grad()
 
         # compute PyTorch's color and grad
-        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs, "poly")
+        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs, method)
         check_loss = torch.square(check_colors - gt_colors).mean()
         check_loss.backward()
         check_grad = sh_coeffs.grad.detach()
@@ -47,4 +47,5 @@ def test_sh():
 
 
 if __name__ == "__main__":
-    test_sh()
+    test_sh("poly")
+    test_sh("fast")

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -25,7 +25,7 @@ def test_sh():
         optim.zero_grad()
 
         # compute PyTorch's color and grad
-        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs)
+        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs, "poly")
         check_loss = torch.square(check_colors - gt_colors).mean()
         check_loss.backward()
         check_grad = sh_coeffs.grad.detach()

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -25,7 +25,7 @@ def test_sh():
         optim.zero_grad()
 
         # compute PyTorch's color and grad
-        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs)
+        check_colors = _torch_impl.compute_sh_color(viewdirs, sh_coeffs, 'fast')
         check_loss = torch.square(check_colors - gt_colors).mean()
         check_loss.backward()
         check_grad = sh_coeffs.grad.detach()

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -48,7 +48,9 @@ def test_sh(method):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
-def profile_sh(method, num_points: int = 1_000_000, degree: int = 4, n_iters: int = 1000):
+def profile_sh(
+    method, num_points: int = 1_000_000, degree: int = 4, n_iters: int = 1000
+):
     from gsplat import sh
 
     viewdirs = torch.randn(num_points, 3, device=device)
@@ -57,9 +59,9 @@ def profile_sh(method, num_points: int = 1_000_000, degree: int = 4, n_iters: in
         num_points, sh.num_sh_bases(degree), 3, device=device, requires_grad=True
     )
 
-    for _ in range(10): # warmup
+    for _ in range(10):  # warmup
         colors = sh.spherical_harmonics(degree, viewdirs, sh_coeffs, method)
-    
+
     n_iters_fwd = n_iters
     torch.cuda.synchronize()
     tic = time.time()
@@ -67,11 +69,11 @@ def profile_sh(method, num_points: int = 1_000_000, degree: int = 4, n_iters: in
         _ = sh.spherical_harmonics(degree, viewdirs, sh_coeffs)
     torch.cuda.synchronize()
     toc = time.time()
-    ellipsed = (toc - tic) / n_iters_fwd * 1000 # ms
+    ellipsed = (toc - tic) / n_iters_fwd * 1000  # ms
     print(f"[Fwd] Method: {method}, ellipsed: {ellipsed:.2f} ms")
 
     loss = sh.spherical_harmonics(degree, viewdirs, sh_coeffs, method).sum()
-    for _ in range(10): # warmup
+    for _ in range(10):  # warmup
         loss.backward(retain_graph=True)
 
     n_iters_bwd = n_iters // 20
@@ -81,9 +83,9 @@ def profile_sh(method, num_points: int = 1_000_000, degree: int = 4, n_iters: in
         loss.backward(retain_graph=True)
     torch.cuda.synchronize()
     toc = time.time()
-    ellipsed = (toc - tic) / n_iters_bwd * 1000 # ms
+    ellipsed = (toc - tic) / n_iters_bwd * 1000  # ms
     print(f"[Bwd] Method: {method}, ellipsed: {ellipsed:.2f} ms")
-    
+
 
 if __name__ == "__main__":
     test_sh("poly")

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -34,7 +34,7 @@ def test_sh(method):
         optim.zero_grad()
 
         # compute our colors and grads
-        colors = sh.spherical_harmonics(degree, viewdirs, sh_coeffs)
+        colors = sh.spherical_harmonics(degree, viewdirs, sh_coeffs, method)
         loss = torch.square(colors - gt_colors).mean()
         loss.backward()
         grad = sh_coeffs.grad.detach()


### PR DESCRIPTION
I recently read this paper: https://jcgt.org/published/0002/02/06/ (it has sample codes) there is a faster way to evaluate spherical harmonics. I made an attempt to implement the idea in gsplat and was able to observe 40% time saving in forward calls of degree 3 and 50% time saving of degree 4.

