### PR TITLE
Improve numerical stability of _torch_impl.project_cov3d_ewa

### DIFF
--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from jaxtyping import Float
 from torch import Tensor
-from typing import Tuple, Literal
+from typing import Tuple, Literal, Optional
 
 
 def compute_sh_color(
@@ -247,13 +247,18 @@ def project_cov3d_ewa(
     fy: float,
     tan_fovx: float,
     tan_fovy: float,
+    is_valid: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor]:
     assert mean3d.shape[-1] == 3, mean3d.shape
     assert cov3d.shape[-2:] == (3, 3), cov3d.shape
     assert viewmat.shape[-2:] == (4, 4), viewmat.shape
+
+    if is_valid is None:
+        is_valid = torch.ones(mean3d.shape[:-1], dtype=torch.bool, device=mean3d.device)
+
     W = viewmat[..., :3, :3]  # (..., 3, 3)
     p = viewmat[..., :3, 3]  # (..., 3)
-    t = torch.einsum("...ij,...j->...i", W, mean3d) + p  # (..., 3)
+    t = torch.einsum("...ij,...j->...i", W, mean3d[is_valid, ...]) + p  # (..., 3)
 
     rz = 1.0 / t[..., 2]  # (...,)
     rz2 = rz**2  # (...,)
@@ -270,14 +275,23 @@ def project_cov3d_ewa(
         dim=-1,
     ).reshape(*rz.shape, 2, 3)
     T = torch.matmul(J, W)  # (..., 2, 3)
-    cov2d = torch.einsum("...ij,...jk,...kl->...il", T, cov3d, T.transpose(-1, -2))
+    cov2d = torch.einsum("...ij,...jk,...kl->...il", T, cov3d[is_valid, ...], T.transpose(-1, -2))
+
     # add a little blur along axes and (TODO save upper triangular elements)
     det_orig = cov2d[..., 0, 0] * cov2d[..., 1, 1] - cov2d[..., 0, 1] * cov2d[..., 0, 1]
-    cov2d[..., 0, 0] = cov2d[..., 0, 0] + 0.3
-    cov2d[..., 1, 1] = cov2d[..., 1, 1] + 0.3
-    det_blur = cov2d[..., 0, 0] * cov2d[..., 1, 1] - cov2d[..., 0, 1] * cov2d[..., 0, 1]
-    compensation = torch.sqrt(torch.clamp(det_orig / det_blur, min=0))
-    return cov2d[..., :2, :2], compensation
+    cov2d_blurred = cov2d * 1
+    cov2d_blurred[..., 0, 0] = cov2d[..., 0, 0] + 0.3
+    cov2d_blurred[..., 1, 1] = cov2d[..., 1, 1] + 0.3
+    det_blur = cov2d_blurred[..., 0, 0] * cov2d_blurred[..., 1, 1] - cov2d_blurred[..., 0, 1] * cov2d_blurred[..., 0, 1]
+    # note: sqrt(x) is not differentiable at x=0
+    compensation = torch.sqrt(torch.clamp(det_orig / det_blur, min=1e-10))
+
+    cov2d_all = torch.zeros(cov3d.shape[0], 2, 2, device=cov2d.device)
+    compensation_all = torch.zeros(cov3d.shape[0], device=cov2d.device)
+
+    cov2d_all[is_valid, ...] = cov2d_blurred
+    compensation_all[is_valid] = compensation
+    return cov2d_all, compensation_all
 
 
 def compute_compensation(cov2d_mat: Tensor):
@@ -292,13 +306,15 @@ def compute_compensation(cov2d_mat: Tensor):
     return torch.sqrt(torch.clamp(det_nomin / det_denom, min=0))
 
 
-def compute_cov2d_bounds(cov2d_mat: Tensor):
+def compute_cov2d_bounds(cov2d_mat: Tensor, cov_valid: Optional[Tensor] = None):
     """
     param: cov2d matrix (*, 2, 2)
     returns: conic parameters (*, 3)
     """
     det_all = cov2d_mat[..., 0, 0] * cov2d_mat[..., 1, 1] - cov2d_mat[..., 0, 1] ** 2
     valid = det_all != 0
+    if cov_valid is not None:
+        valid = valid & cov_valid
     # det = torch.clamp(det, min=eps)
     det = det_all[valid]
     cov2d = cov2d_mat[valid]
@@ -386,9 +402,9 @@ def project_gaussians_forward(
     p_view, is_close = clip_near_plane(means3d, viewmat, clip_thresh)
     cov3d = scale_rot_to_cov3d(scales, glob_scale, quats)
     cov2d, compensation = project_cov3d_ewa(
-        means3d, cov3d, viewmat, fx, fy, tan_fovx, tan_fovy
+        means3d, cov3d, viewmat, fx, fy, tan_fovx, tan_fovy, ~is_close
     )
-    conic, radius, det_valid = compute_cov2d_bounds(cov2d)
+    conic, radius, det_valid = compute_cov2d_bounds(cov2d, ~is_close)
     xys = project_pix((fx, fy), p_view, (cx, cy))
     tile_min, tile_max = get_tile_bbox(xys, radius, tile_bounds, block_width)
     tile_area = (tile_max[..., 0] - tile_min[..., 0]) * (

--- a/gsplat/_torch_impl.py
+++ b/gsplat/_torch_impl.py
@@ -275,14 +275,19 @@ def project_cov3d_ewa(
         dim=-1,
     ).reshape(*rz.shape, 2, 3)
     T = torch.matmul(J, W)  # (..., 2, 3)
-    cov2d = torch.einsum("...ij,...jk,...kl->...il", T, cov3d[is_valid, ...], T.transpose(-1, -2))
+    cov2d = torch.einsum(
+        "...ij,...jk,...kl->...il", T, cov3d[is_valid, ...], T.transpose(-1, -2)
+    )
 
     # add a little blur along axes and (TODO save upper triangular elements)
     det_orig = cov2d[..., 0, 0] * cov2d[..., 1, 1] - cov2d[..., 0, 1] * cov2d[..., 0, 1]
     cov2d_blurred = cov2d * 1
     cov2d_blurred[..., 0, 0] = cov2d[..., 0, 0] + 0.3
     cov2d_blurred[..., 1, 1] = cov2d[..., 1, 1] + 0.3
-    det_blur = cov2d_blurred[..., 0, 0] * cov2d_blurred[..., 1, 1] - cov2d_blurred[..., 0, 1] * cov2d_blurred[..., 0, 1]
+    det_blur = (
+        cov2d_blurred[..., 0, 0] * cov2d_blurred[..., 1, 1]
+        - cov2d_blurred[..., 0, 1] * cov2d_blurred[..., 0, 1]
+    )
     # note: sqrt(x) is not differentiable at x=0
     compensation = torch.sqrt(torch.clamp(det_orig / det_blur, min=1e-10))
 


### PR DESCRIPTION
Fixes the a minimal set of numerical issues in `_torch_impl` so that it can be used in actual training and not just unit tests. This makes testing and optimizing various things a lot easier (example [here](https://github.com/SpectacularAI/gsplat/commit/f40a3eeec4967c210674c21ec7ebb15d3ea1ac76)). Similar to one of the goals in https://github.com/nerfstudio-project/gsplat/pull/172. However, #172 seems to be still a work-in-progress, so this PR still makes sense too and should not conflict with #172.

The numerical issues were mostly related to:
 1. Computing things for Gaussians that are behind the current camera
 2. Trying to differentiate $\sqrt x$ too close to $x = 0$



