### PR TITLE
Support for Python 3.7.13

### DIFF
--- a/gsplat/sh.py
+++ b/gsplat/sh.py
@@ -5,7 +5,10 @@ import gsplat.cuda as _C
 from jaxtyping import Float
 from torch import Tensor
 from torch.autograd import Function
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 
 def num_sh_bases(degree: int):

--- a/gsplat/sh.py
+++ b/gsplat/sh.py
@@ -5,6 +5,7 @@ import gsplat.cuda as _C
 from jaxtyping import Float
 from torch import Tensor
 from torch.autograd import Function
+
 try:
     from typing import Literal
 except ImportError:


### PR DESCRIPTION
Added support for Python 3.7.13 for compatibility with the original Gaussian Splatting repo.