### PR TITLE
workaround for n-dim rendering with n>32

### DIFF
--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -295,20 +295,52 @@ def rasterization(
         colors = depths[..., None]
     else:  # RGB
         pass
-    render_colors, render_alphas = rasterize_to_pixels(
-        means2d,
-        conics,
-        colors,
-        opacities,
-        width,
-        height,
-        tile_size,
-        isect_offsets,
-        flatten_ids,
-        backgrounds=backgrounds,
-        packed=packed,
-        absgrad=absgrad,
-    )
+    if colors.shape[-1] > 32:
+        # slice into 32-channel chunks
+        n_chunks = (colors.shape[-1] + 31) // 32
+        render_colors = []
+        render_alphas = []
+
+        for i in range(n_chunks):
+            colors_chunk = colors[..., i * 32 : (i + 1) * 32]
+            backgrounds_chunk = (
+                backgrounds[:, i * 32 : (i + 1) * 32]
+                if backgrounds is not None
+                else None
+            )
+            render_colors_, render_alphas_ = rasterize_to_pixels(
+                means2d,
+                conics,
+                colors_chunk,
+                opacities,
+                width,
+                height,
+                tile_size,
+                isect_offsets,
+                flatten_ids,
+                backgrounds=backgrounds_chunk,
+                packed=packed,
+                absgrad=absgrad,
+            )
+            render_colors.append(render_colors_)
+            render_alphas.append(render_alphas_)
+        render_colors = torch.cat(render_colors, dim=-1)
+        render_alphas = render_alphas[0]  # discard the rest
+    else:
+        render_colors, render_alphas = rasterize_to_pixels(
+            means2d,
+            conics,
+            colors,
+            opacities,
+            width,
+            height,
+            tile_size,
+            isect_offsets,
+            flatten_ids,
+            backgrounds=backgrounds,
+            packed=packed,
+            absgrad=absgrad,
+        )
     if render_mode in ["ED", "RGB+ED"]:
         # normalize the accumulated depth to get the expected depth
         render_colors = torch.cat(

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -49,8 +49,8 @@ def rasterization(
 
     .. note::
         **Support N-D Features**: If `sh_degree` is None,
-        the `colors` is expected to be with shape [N, D], in which D is the channel of 
-        the features to be rendered. The computation is slow when D > 32 at the moment. 
+        the `colors` is expected to be with shape [N, D], in which D is the channel of
+        the features to be rendered. The computation is slow when D > 32 at the moment.
         If `sh_degree` is set, the `colors` is expected to be the SH coefficients with
         shape [N, K, 3], where K is the number of SH bases. In this case, it is expected
         that :math:`(\\textit{sh_degree} + 1) ^ 2 \\leq K`, where `sh_degree` controls the

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -49,9 +49,9 @@ def rasterization(
 
     .. note::
         **Support N-D Features**: If `sh_degree` is None,
-        the `colors` is expected to be with shape [N, D], in which D is the channel
-        of the features to be rendered, up to 32 at the moment. If
-        `sh_degree` is set, the `colors` is expected to be the SH coefficients with
+        the `colors` is expected to be with shape [N, D], in which D is the channel of 
+        the features to be rendered. The computation is slow when D > 32 at the moment. 
+        If `sh_degree` is set, the `colors` is expected to be the SH coefficients with
         shape [N, K, 3], where K is the number of SH bases. In this case, it is expected
         that :math:`(\\textit{sh_degree} + 1) ^ 2 \\leq K`, where `sh_degree` controls the
         activated bases in the SH coefficients.


### PR DESCRIPTION
slice the input colors & background in 32-dim slices and iteratively rasterize to pixels