### PR TITLE
Support Batch Rasterization For Multiple GS Scenes

### DIFF
--- a/examples/simple_viewer.py
+++ b/examples/simple_viewer.py
@@ -56,7 +56,7 @@ if args.ckpt is None:
     N = len(means)
     print("Number of Gaussians:", N)
 
-    # batched render
+    # batched render on 2 scenes, each scene has C cameras.
     render_colors, render_alphas, meta = rasterization(
         means.expand(2, -1, -1),  # [B, N, 3]
         quats.expand(2, -1, -1),  # [B, N, 4]
@@ -69,6 +69,7 @@ if args.ckpt is None:
         height,
         render_mode="RGB+D",
     )
+    # [B, C, H, W, D]
     assert render_colors.shape == (2, C, height, width, 4)
     assert render_alphas.shape == (2, C, height, width, 1)
 

--- a/gsplat/cuda/_torch_impl.py
+++ b/gsplat/cuda/_torch_impl.py
@@ -103,27 +103,27 @@ def _persp_proj(
 
 
 def _world_to_cam(
-    means: Tensor,  # [N, 3]
-    covars: Tensor,  # [N, 3, 3]
-    viewmats: Tensor,  # [C, 4, 4]
+    means: Tensor,  # [B, N, 3]
+    covars: Tensor,  # [B, N, 3, 3]
+    viewmats: Tensor,  # [B, C, 4, 4]
 ) -> Tuple[Tensor, Tensor]:
     """PyTorch implementation of world to camera transformation on Gaussians.
 
     Args:
-        means: Gaussian means in world coordinate system. [C, N, 3].
-        covars: Gaussian covariances in world coordinate system. [C, N, 3, 3].
-        viewmats: world to camera transformation matrices. [C, 4, 4].
+        means: Gaussian means in world coordinate system. [B, C, N, 3].
+        covars: Gaussian covariances in world coordinate system. [B, C, N, 3, 3].
+        viewmats: world to camera transformation matrices. [B, C, 4, 4].
 
     Returns:
         A tuple:
 
-        - **means_c**: Gaussian means in camera coordinate system. [C, N, 3].
-        - **covars_c**: Gaussian covariances in camera coordinate system. [C, N, 3, 3].
+        - **means_c**: Gaussian means in camera coordinate system. [B, C, N, 3].
+        - **covars_c**: Gaussian covariances in camera coordinate system. [B, C, N, 3, 3].
     """
-    R = viewmats[:, :3, :3]  # [C, 3, 3]
-    t = viewmats[:, :3, 3]  # [C, 3]
-    means_c = torch.einsum("cij,nj->cni", R, means) + t[:, None, :]  # (C, N, 3)
-    covars_c = torch.einsum("cij,njk,clk->cnil", R, covars, R)  # [C, N, 3, 3]
+    R = viewmats[:, :, :3, :3]  # [B, C, 3, 3]
+    t = viewmats[:, :, :3, 3]  # [B, C, 3]
+    means_c = torch.einsum("bcij,bnj->bcni", R, means) + t[:, :, None, :]  # [B, C, N, 3]
+    covars_c = torch.einsum("bcij,bnjk,bclk->bcnil", R, covars, R)  # [B, C, N, 3, 3]
     return means_c, covars_c
 
 

--- a/gsplat/cuda/_torch_impl.py
+++ b/gsplat/cuda/_torch_impl.py
@@ -7,8 +7,8 @@ from torch import Tensor
 
 
 def _quat_scale_to_covar_preci(
-    quats: Tensor,  # [N, 4],
-    scales: Tensor,  # [N, 3],
+    quats: Tensor,  # [..., 4],
+    scales: Tensor,  # [..., 3],
     compute_covar: bool = True,
     compute_preci: bool = True,
     triu: bool = False,
@@ -36,7 +36,7 @@ def _quat_scale_to_covar_preci(
 
     if compute_covar:
         M = R * scales[..., None, :]  # (..., 3, 3)
-        covars = torch.bmm(M, M.transpose(-1, -2))  # (..., 3, 3)
+        covars = torch.einsum("...ij,...kj->...ik", M, M)  # (..., 3, 3)
         if triu:
             covars = covars.reshape(covars.shape[:-2] + (9,))  # (..., 9)
             covars = (
@@ -44,7 +44,7 @@ def _quat_scale_to_covar_preci(
             ) / 2.0  # (..., 6)
     if compute_preci:
         P = R * (1 / scales[..., None, :])  # (..., 3, 3)
-        precis = torch.bmm(P, P.transpose(-1, -2))  # (..., 3, 3)
+        precis = torch.einsum("...ij,...kj->...ik", P, P)  # (..., 3, 3)
         if triu:
             precis = precis.reshape(precis.shape[:-2] + (9,))
             precis = (

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -425,10 +425,10 @@ def rasterize_to_pixels(
 
     # Pad the channels to the nearest supported number if necessary
     channels = colors.shape[-1]
-    if channels > 512 or channels == 0:
+    if channels > 33 or channels == 0:
         # TODO: maybe worth to support zero channels?
         raise ValueError(f"Unsupported number of color channels: {channels}")
-    if channels not in (1, 2, 3, 4, 8, 16, 32, 64, 128, 256, 512):
+    if channels not in (1, 2, 3, 4, 5, 8, 9, 16, 17, 32, 33):
         padded_channels = (1 << (channels - 1).bit_length()) - channels
         colors = torch.cat(
             [

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -44,8 +44,8 @@ def spherical_harmonics(
 
 
 def quat_scale_to_covar_preci(
-    quats: Tensor,  # [N, 4],
-    scales: Tensor,  # [N, 3],
+    quats: Tensor,  # [..., 4],
+    scales: Tensor,  # [..., 3],
     compute_covar: bool = True,
     compute_preci: bool = True,
     triu: bool = False,
@@ -53,8 +53,8 @@ def quat_scale_to_covar_preci(
     """Converts quaternions and scales to covariance and precision matrices.
 
     Args:
-        quats: Quaternions (No need to be normalized). [N, 4]
-        scales: Scales. [N, 3]
+        quats: Quaternions (No need to be normalized). [..., 4]
+        scales: Scales. [..., 3]
         compute_covar: Whether to compute covariance matrices. Default: True. If False,
             the returned covariance matrices will be None.
         compute_preci: Whether to compute precision matrices. Default: True. If False,
@@ -64,11 +64,12 @@ def quat_scale_to_covar_preci(
     Returns:
         A tuple:
 
-        - **Covariance matrices**. If `triu` is True the returned shape is [N, 6], otherwise [N, 3, 3].
-        - **Precision matrices**. If `triu` is True the returned shape is [N, 6], otherwise [N, 3, 3].
+        - **Covariance matrices**. If `triu` is True the returned shape is [..., 6], otherwise [..., 3, 3].
+        - **Precision matrices**. If `triu` is True the returned shape is [..., 6], otherwise [..., 3, 3].
     """
-    assert quats.dim() == 2 and quats.size(1) == 4, quats.size()
-    assert scales.dim() == 2 and scales.size(1) == 3, scales.size()
+    assert quats.shape[:-1] == scales.shape[:-1], (quats.shape, scales.shape)
+    assert quats.shape[-1] == 4, quats.shape
+    assert scales.shape[-1] == 3, scales.shape
     quats = quats.contiguous()
     scales = scales.contiguous()
     covars, precis = _QuatScaleToCovarPreci.apply(

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -111,28 +111,29 @@ def persp_proj(
 
 
 def world_to_cam(
-    means: Tensor,  # [N, 3]
-    covars: Tensor,  # [N, 3, 3]
-    viewmats: Tensor,  # [C, 4, 4]
+    means: Tensor,  # [B, N, 3]
+    covars: Tensor,  # [B, N, 3, 3]
+    viewmats: Tensor,  # [B, C, 4, 4]
 ) -> Tuple[Tensor, Tensor]:
     """Transforms Gaussians from world to camera coordinate system.
 
     Args:
-        means: Gaussian means. [N, 3]
-        covars: Gaussian covariances. [N, 3, 3]
-        viewmats: World-to-camera transformation matrices. [C, 4, 4]
+        means: Gaussian means. [B, N, 3]
+        covars: Gaussian covariances. [B, N, 3, 3]
+        viewmats: World-to-camera transformation matrices. [B, C, 4, 4]
 
     Returns:
         A tuple:
 
-        - **Gaussian means in camera coordinate system**. [C, N, 3]
-        - **Gaussian covariances in camera coordinate system**. [C, N, 3, 3]
+        - **Gaussian means in camera coordinate system**. [B, C, N, 3]
+        - **Gaussian covariances in camera coordinate system**. [B, C, N, 3, 3]
     """
-    C = viewmats.size(0)
-    N = means.size(0)
-    assert means.size() == (N, 3), means.size()
-    assert covars.size() == (N, 3, 3), covars.size()
-    assert viewmats.size() == (C, 4, 4), viewmats.size()
+    B = means.size(0)
+    C = viewmats.size(1)
+    N = means.size(1)
+    assert means.size() == (B, N, 3), means.size()
+    assert covars.size() == (B, N, 3, 3), covars.size()
+    assert viewmats.size() == (B, C, 4, 4), viewmats.size()
     means = means.contiguous()
     covars = covars.contiguous()
     viewmats = viewmats.contiguous()
@@ -637,9 +638,9 @@ class _WorldToCam(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx,
-        means: Tensor,  # [N, 3]
-        covars: Tensor,  # [N, 3, 3]
-        viewmats: Tensor,  # [C, 4, 4]
+        means: Tensor,  # [B, N, 3]
+        covars: Tensor,  # [B, N, 3, 3]
+        viewmats: Tensor,  # [B, C, 4, 4]
     ) -> Tuple[Tensor, Tensor]:
         means_c, covars_c = _make_lazy_cuda_func("world_to_cam_fwd")(
             means, covars, viewmats

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -69,15 +69,16 @@ world_to_cam_bwd_tensor(const torch::Tensor &means,                    // [N, 3]
                         const bool viewmats_requires_grad);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-fully_fused_projection_fwd_tensor(const torch::Tensor &means,                // [N, 3]
-                      const at::optional<torch::Tensor> &covars, // [N, 6] optional
-                      const at::optional<torch::Tensor> &quats,  // [N, 4] optional
-                      const at::optional<torch::Tensor> &scales, // [N, 3] optional
-                      const torch::Tensor &viewmats,             // [C, 4, 4]
-                      const torch::Tensor &Ks,                   // [C, 3, 3]
-                      const uint32_t image_width, const uint32_t image_height, const float eps2d,
-                      const float near_plane, const float far_plane,
-                      const float radius_clip, const bool calc_compensations);
+fully_fused_projection_fwd_tensor(
+    const torch::Tensor &means,                // [N, 3]
+    const at::optional<torch::Tensor> &covars, // [N, 6] optional
+    const at::optional<torch::Tensor> &quats,  // [N, 4] optional
+    const at::optional<torch::Tensor> &scales, // [N, 3] optional
+    const torch::Tensor &viewmats,             // [C, 4, 4]
+    const torch::Tensor &Ks,                   // [C, 3, 3]
+    const uint32_t image_width, const uint32_t image_height, const float eps2d,
+    const float near_plane, const float far_plane, const float radius_clip,
+    const bool calc_compensations);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 fully_fused_projection_bwd_tensor(
@@ -101,13 +102,14 @@ fully_fused_projection_bwd_tensor(
     const bool viewmats_requires_grad);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
-isect_tiles_tensor(const torch::Tensor &means2d,                // [C, N, 2] or [nnz, 2]
-                   const torch::Tensor &radii,                  // [C, N] or [nnz]
-                   const torch::Tensor &depths,                 // [C, N] or [nnz]
-                   const at::optional<torch::Tensor> &camera_ids, // [nnz]
+isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
+                   const torch::Tensor &radii,   // [C, N] or [nnz]
+                   const torch::Tensor &depths,  // [C, N] or [nnz]
+                   const at::optional<torch::Tensor> &camera_ids,   // [nnz]
                    const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
-                   const uint32_t C, const uint32_t tile_size, const uint32_t tile_width,
-                   const uint32_t tile_height, const bool sort, const bool double_buffer);
+                   const uint32_t C, const uint32_t tile_size,
+                   const uint32_t tile_width, const uint32_t tile_height,
+                   const bool sort, const bool double_buffer);
 
 torch::Tensor isect_offset_encode_tensor(const torch::Tensor &isect_ids, // [n_isects]
                                          const uint32_t C, const uint32_t tile_width,
@@ -124,7 +126,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
     const torch::Tensor &tile_offsets, // [C, tile_height, tile_width]
-    const torch::Tensor &flatten_ids     // [n_isects]
+    const torch::Tensor &flatten_ids   // [n_isects]
 );
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
@@ -139,7 +141,7 @@ rasterize_to_pixels_bwd_tensor(
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
     const torch::Tensor &tile_offsets, // [C, tile_height, tile_width]
-    const torch::Tensor &flatten_ids,    // [n_isects]
+    const torch::Tensor &flatten_ids,  // [n_isects]
     // forward outputs
     const torch::Tensor &render_alphas, // [C, image_height, image_width, 1]
     const torch::Tensor &last_ids,      // [C, image_height, image_width]
@@ -150,7 +152,7 @@ rasterize_to_pixels_bwd_tensor(
     bool absgrad);
 
 std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(
-    const uint32_t range_start, const uint32_t range_end,   // iteration steps
+    const uint32_t range_start, const uint32_t range_end, // iteration steps
     const torch::Tensor transmittances, // [C, image_height, image_width]
     // Gaussian parameters
     const torch::Tensor &means2d,   // [C, N, 2]
@@ -160,7 +162,7 @@ std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
     const torch::Tensor &tile_offsets, // [C, tile_height, tile_width]
-    const torch::Tensor &flatten_ids     // [n_isects]
+    const torch::Tensor &flatten_ids   // [n_isects]
 );
 
 torch::Tensor compute_sh_fwd_tensor(const uint32_t degrees_to_use,
@@ -181,30 +183,31 @@ compute_sh_bwd_tensor(const uint32_t K, const uint32_t degrees_to_use,
  ****************************************************************************************/
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
            torch::Tensor, torch::Tensor, torch::Tensor>
-fully_fused_projection_packed_fwd_tensor(const torch::Tensor &means,                // [N, 3]
-                             const at::optional<torch::Tensor> &covars, // [N, 6]
-                             const at::optional<torch::Tensor> &quats,  // [N, 3]
-                             const at::optional<torch::Tensor> &scales, // [N, 3]
-                             const torch::Tensor &viewmats,             // [C, 4, 4]
-                             const torch::Tensor &Ks,                   // [C, 3, 3]
-                             const uint32_t image_width, const uint32_t image_height,
-                             const float eps2d, const float near_plane,
-                             const float far_plane, const float radius_clip,
-                             const bool calc_compensations);
+fully_fused_projection_packed_fwd_tensor(
+    const torch::Tensor &means,                // [B, N, 3]
+    const at::optional<torch::Tensor> &covars, // [B, N, 6]
+    const at::optional<torch::Tensor> &quats,  // [B, N, 3]
+    const at::optional<torch::Tensor> &scales, // [B, N, 3]
+    const torch::Tensor &viewmats,             // [B, C, 4, 4]
+    const torch::Tensor &Ks,                   // [B, C, 3, 3]
+    const uint32_t image_width, const uint32_t image_height, const float eps2d,
+    const float near_plane, const float far_plane, const float radius_clip,
+    const bool calc_compensations);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 fully_fused_projection_packed_bwd_tensor(
     // fwd inputs
-    const torch::Tensor &means,                // [N, 3]
-    const at::optional<torch::Tensor> &covars, // [N, 6]
-    const at::optional<torch::Tensor> &quats,  // [N, 4]
-    const at::optional<torch::Tensor> &scales, // [N, 3]
-    const torch::Tensor &viewmats,             // [C, 4, 4]
-    const torch::Tensor &Ks,                   // [C, 3, 3]
+    const torch::Tensor &means,                // [B, N, 3]
+    const at::optional<torch::Tensor> &covars, // [B, N, 6]
+    const at::optional<torch::Tensor> &quats,  // [B, N, 4]
+    const at::optional<torch::Tensor> &scales, // [B, N, 3]
+    const torch::Tensor &viewmats,             // [B, C, 4, 4]
+    const torch::Tensor &Ks,                   // [B, C, 3, 3]
     const uint32_t image_width, const uint32_t image_height, const float eps2d,
     // fwd outputs
-    const torch::Tensor &camera_ids,                    // [nnz]
-    const torch::Tensor &gaussian_ids,                    // [nnz]
+    const torch::Tensor &batch_ids,                   // [nnz]
+    const torch::Tensor &camera_ids,                  // [nnz]
+    const torch::Tensor &gaussian_ids,                // [nnz]
     const torch::Tensor &conics,                      // [nnz, 3]
     const at::optional<torch::Tensor> &compensations, // [nnz] optional
     // grad outputs

--- a/gsplat/cuda/csrc/projection.cu
+++ b/gsplat/cuda/csrc/projection.cu
@@ -396,24 +396,27 @@ persp_proj_bwd_tensor(const torch::Tensor &means,  // [C, N, 3]
  * World to Camera Transformation
  ****************************************************************************/
 
-__global__ void world_to_cam_fwd_kernel(const uint32_t C, const uint32_t N,
-                                        const float *__restrict__ means,    // [N, 3]
-                                        const float *__restrict__ covars,   // [N, 3, 3]
-                                        const float *__restrict__ viewmats, // [C, 4, 4]
-                                        float *__restrict__ means_c,        // [C, N, 3]
-                                        float *__restrict__ covars_c // [C, N, 3, 3]
-) { // parallelize over C * N.
+__global__ void
+world_to_cam_fwd_kernel(const uint32_t B, const uint32_t C, const uint32_t N,
+                        const float *__restrict__ means,    // [B, N, 3]
+                        const float *__restrict__ covars,   // [B, N, 3, 3]
+                        const float *__restrict__ viewmats, // [B, C, 4, 4]
+                        float *__restrict__ means_c,        // [B, C, N, 3]
+                        float *__restrict__ covars_c        // [B, C, N, 3, 3]
+) {
+    // parallelize over B * C * N.
     uint32_t idx = cg::this_grid().thread_rank();
-    if (idx >= C * N) {
+    if (idx >= B * C * N) {
         return;
     }
-    const uint32_t cid = idx / N; // camera id
-    const uint32_t gid = idx % N; // gaussian id
+    const uint32_t bid = idx / (C * N); // batch id
+    const uint32_t cid = idx / N % C;   // camera id
+    const uint32_t gid = idx % N;       // gaussian id
 
     // shift pointers to the current camera and gaussian
-    means += gid * 3;
-    covars += gid * 9;
-    viewmats += cid * 16;
+    means += gid * 3 + bid * N * 3;
+    covars += gid * 9 + bid * N * 9;
+    viewmats += cid * 16 + bid * C * 16;
 
     // glm is column-major but input is row-major
     glm::mat3 R = glm::mat3(viewmats[0], viewmats[4], viewmats[8], // 1st column
@@ -448,28 +451,29 @@ __global__ void world_to_cam_fwd_kernel(const uint32_t C, const uint32_t N,
 }
 
 __global__ void
-world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
-                        const float *__restrict__ means,      // [N, 3]
-                        const float *__restrict__ covars,     // [N, 3, 3]
-                        const float *__restrict__ viewmats,   // [C, 4, 4]
-                        const float *__restrict__ v_means_c,  // [C, N, 3]
-                        const float *__restrict__ v_covars_c, // [C, N, 3, 3]
-                        float *__restrict__ v_means,          // [N, 3]
-                        float *__restrict__ v_covars,         // [N, 3, 3]
-                        float *__restrict__ v_viewmats        // [C, 4, 4]
+world_to_cam_bwd_kernel(const uint32_t B, const uint32_t C, const uint32_t N,
+                        const float *__restrict__ means,      // [B, N, 3]
+                        const float *__restrict__ covars,     // [B, N, 3, 3]
+                        const float *__restrict__ viewmats,   // [B, C, 4, 4]
+                        const float *__restrict__ v_means_c,  // [B, C, N, 3]
+                        const float *__restrict__ v_covars_c, // [B, C, N, 3, 3]
+                        float *__restrict__ v_means,          // [B, N, 3]
+                        float *__restrict__ v_covars,         // [B, N, 3, 3]
+                        float *__restrict__ v_viewmats        // [B, C, 4, 4]
 ) {
-    // parallelize over C * N.
+    // parallelize over B * C * N.
     uint32_t idx = cg::this_grid().thread_rank();
-    if (idx >= C * N) {
+    if (idx >= B * C * N) {
         return;
     }
-    const uint32_t cid = idx / N; // camera id
-    const uint32_t gid = idx % N; // gaussian id
+    const uint32_t bid = idx / (C * N); // batch id
+    const uint32_t cid = idx / N % C;   // camera id
+    const uint32_t gid = idx % N;       // gaussian id
 
     // shift pointers to the current camera and gaussian
-    means += gid * 3;
-    covars += gid * 9;
-    viewmats += cid * 16;
+    means += gid * 3 + bid * N * 3;
+    covars += gid * 9 + bid * N * 9;
+    viewmats += cid * 16 + bid * C * 16;
 
     // glm is column-major but input is row-major
     glm::mat3 R = glm::mat3(viewmats[0], viewmats[4], viewmats[8], // 1st column
@@ -494,12 +498,13 @@ world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
 
     // #if __CUDA_ARCH__ >= 700
     // write out results with warp-level reduction
+    // TODO: this is problematic when N < 32!! should fix it on main?
     auto warp = cg::tiled_partition<32>(cg::this_thread_block());
     auto warp_group_g = cg::labeled_partition(warp, gid);
     if (v_means != nullptr) {
         warpSum(v_mean, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
-            v_means += gid * 3;
+            v_means += gid * 3 + bid * N * 3;
             PRAGMA_UNROLL
             for (uint32_t i = 0; i < 3; i++) {
                 atomicAdd(v_means + i, v_mean[i]);
@@ -509,7 +514,7 @@ world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
     if (v_covars != nullptr) {
         warpSum(v_covar, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
-            v_covars += gid * 9;
+            v_covars += gid * 9 + bid * N * 9;
             PRAGMA_UNROLL
             for (uint32_t i = 0; i < 3; i++) { // rows
                 PRAGMA_UNROLL
@@ -524,7 +529,7 @@ world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
         warpSum(v_R, warp_group_c);
         warpSum(v_t, warp_group_c);
         if (warp_group_c.thread_rank() == 0) {
-            v_viewmats += cid * 16;
+            v_viewmats += cid * 16 + bid * C * 16;
             PRAGMA_UNROLL
             for (uint32_t i = 0; i < 3; i++) { // rows
                 PRAGMA_UNROLL
@@ -538,40 +543,41 @@ world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
 }
 
 std::tuple<torch::Tensor, torch::Tensor>
-world_to_cam_fwd_tensor(const torch::Tensor &means,   // [N, 3]
-                        const torch::Tensor &covars,  // [N, 3, 3]
-                        const torch::Tensor &viewmats // [C, 4, 4]
+world_to_cam_fwd_tensor(const torch::Tensor &means,   // [B, N, 3]
+                        const torch::Tensor &covars,  // [B, N, 3, 3]
+                        const torch::Tensor &viewmats // [B, C, 4, 4]
 ) {
     DEVICE_GUARD(means);
     CHECK_INPUT(means);
     CHECK_INPUT(covars);
     CHECK_INPUT(viewmats);
 
-    uint32_t N = means.size(0);
-    uint32_t C = viewmats.size(0);
+    uint32_t B = means.size(0);
+    uint32_t N = means.size(1);
+    uint32_t C = viewmats.size(1);
 
-    torch::Tensor means_c = torch::empty({C, N, 3}, means.options());
-    torch::Tensor covars_c = torch::empty({C, N, 3, 3}, means.options());
+    torch::Tensor means_c = torch::empty({B, C, N, 3}, means.options());
+    torch::Tensor covars_c = torch::empty({B, C, N, 3, 3}, means.options());
 
     if (C && N) {
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
-        world_to_cam_fwd_kernel<<<(C * N + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
+        world_to_cam_fwd_kernel<<<(B * C * N + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
                                   stream>>>(
-            C, N, means.data_ptr<float>(), covars.data_ptr<float>(),
+            B, C, N, means.data_ptr<float>(), covars.data_ptr<float>(),
             viewmats.data_ptr<float>(), means_c.data_ptr<float>(),
             covars_c.data_ptr<float>());
     }
     return std::make_tuple(means_c, covars_c);
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
-world_to_cam_bwd_tensor(const torch::Tensor &means,                    // [N, 3]
-                        const torch::Tensor &covars,                   // [N, 3, 3]
-                        const torch::Tensor &viewmats,                 // [C, 4, 4]
-                        const at::optional<torch::Tensor> &v_means_c,  // [C, N, 3]
-                        const at::optional<torch::Tensor> &v_covars_c, // [C, N, 3, 3]
-                        const bool means_requires_grad, const bool covars_requires_grad,
-                        const bool viewmats_requires_grad) {
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> world_to_cam_bwd_tensor(
+    const torch::Tensor &means,                    // [B, N, 3]
+    const torch::Tensor &covars,                   // [B, N, 3, 3]
+    const torch::Tensor &viewmats,                 // [B, C, 4, 4]
+    const at::optional<torch::Tensor> &v_means_c,  // [B, C, N, 3]
+    const at::optional<torch::Tensor> &v_covars_c, // [B, C, N, 3, 3]
+    const bool means_requires_grad, const bool covars_requires_grad,
+    const bool viewmats_requires_grad) {
     DEVICE_GUARD(means);
     CHECK_INPUT(means);
     CHECK_INPUT(covars);
@@ -582,25 +588,27 @@ world_to_cam_bwd_tensor(const torch::Tensor &means,                    // [N, 3]
     if (v_covars_c.has_value()) {
         CHECK_INPUT(v_covars_c.value());
     }
-    uint32_t N = means.size(0);
-    uint32_t C = viewmats.size(0);
+
+    uint32_t B = means.size(0);
+    uint32_t N = means.size(1);
+    uint32_t C = viewmats.size(1);
 
     torch::Tensor v_means, v_covars, v_viewmats;
     if (means_requires_grad) {
-        v_means = torch::zeros({N, 3}, means.options());
+        v_means = torch::zeros_like(means);
     }
     if (covars_requires_grad) {
-        v_covars = torch::zeros({N, 3, 3}, means.options());
+        v_covars = torch::zeros_like(covars);
     }
     if (viewmats_requires_grad) {
-        v_viewmats = torch::zeros({C, 4, 4}, means.options());
+        v_viewmats = torch::zeros_like(viewmats);
     }
 
-    if (C && N) {
+    if (B && C && N) {
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
-        world_to_cam_bwd_kernel<<<(C * N + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
+        world_to_cam_bwd_kernel<<<(B * C * N + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
                                   stream>>>(
-            C, N, means.data_ptr<float>(), covars.data_ptr<float>(),
+            B, C, N, means.data_ptr<float>(), covars.data_ptr<float>(),
             viewmats.data_ptr<float>(),
             v_means_c.has_value() ? v_means_c.value().data_ptr<float>() : nullptr,
             v_covars_c.has_value() ? v_covars_c.value().data_ptr<float>() : nullptr,

--- a/gsplat/cuda/csrc/rasterization.cu
+++ b/gsplat/cuda/csrc/rasterization.cu
@@ -742,8 +742,30 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
             renders.data_ptr<float>(), alphas.data_ptr<float>(),
             last_ids.data_ptr<int32_t>());
         break;
+    case 5:
+        rasterize_to_pixels_fwd_kernel<5><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
     case 8:
         rasterize_to_pixels_fwd_kernel<8><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
+    case 9:
+        rasterize_to_pixels_fwd_kernel<9><<<blocks, threads, 0, stream>>>(
             C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
             (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
             opacities.data_ptr<float>(),
@@ -764,8 +786,30 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
             renders.data_ptr<float>(), alphas.data_ptr<float>(),
             last_ids.data_ptr<int32_t>());
         break;
+    case 17:
+        rasterize_to_pixels_fwd_kernel<17><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
     case 32:
         rasterize_to_pixels_fwd_kernel<32><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
+    case 33:
+        rasterize_to_pixels_fwd_kernel<33><<<blocks, threads, 0, stream>>>(
             C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
             (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
             opacities.data_ptr<float>(),
@@ -786,8 +830,30 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
             renders.data_ptr<float>(), alphas.data_ptr<float>(),
             last_ids.data_ptr<int32_t>());
         break;
+    case 65:
+        rasterize_to_pixels_fwd_kernel<65><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
     case 128:
         rasterize_to_pixels_fwd_kernel<128><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
+    case 129:
+        rasterize_to_pixels_fwd_kernel<129><<<blocks, threads, 0, stream>>>(
             C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
             (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
             opacities.data_ptr<float>(),
@@ -808,8 +874,30 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
             renders.data_ptr<float>(), alphas.data_ptr<float>(),
             last_ids.data_ptr<int32_t>());
         break;
+    case 257:
+        rasterize_to_pixels_fwd_kernel<257><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
     case 512:
         rasterize_to_pixels_fwd_kernel<512><<<blocks, threads, 0, stream>>>(
+            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+            opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+        break;
+    case 513:
+        rasterize_to_pixels_fwd_kernel<513><<<blocks, threads, 0, stream>>>(
             C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
             (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
             opacities.data_ptr<float>(),
@@ -1185,8 +1273,40 @@ rasterize_to_pixels_bwd_tensor(
                 (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
                 v_opacities.data_ptr<float>());
             break;
+        case 5:
+            rasterize_to_pixels_bwd_kernel<5><<<blocks, threads, 0, stream>>>(
+                C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+                (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+                opacities.data_ptr<float>(),
+                backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
+                                        : nullptr,
+                image_width, image_height, tile_size, tile_width, tile_height,
+                tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+                render_alphas.data_ptr<float>(), last_ids.data_ptr<int32_t>(),
+                v_render_colors.data_ptr<float>(), v_render_alphas.data_ptr<float>(),
+                absgrad ? (float2 *)v_means2d_abs.data_ptr<float>() : nullptr,
+                (float2 *)v_means2d.data_ptr<float>(),
+                (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
+                v_opacities.data_ptr<float>());
+            break;
         case 8:
             rasterize_to_pixels_bwd_kernel<8><<<blocks, threads, 0, stream>>>(
+                C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+                (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+                opacities.data_ptr<float>(),
+                backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
+                                        : nullptr,
+                image_width, image_height, tile_size, tile_width, tile_height,
+                tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+                render_alphas.data_ptr<float>(), last_ids.data_ptr<int32_t>(),
+                v_render_colors.data_ptr<float>(), v_render_alphas.data_ptr<float>(),
+                absgrad ? (float2 *)v_means2d_abs.data_ptr<float>() : nullptr,
+                (float2 *)v_means2d.data_ptr<float>(),
+                (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
+                v_opacities.data_ptr<float>());
+            break;
+        case 9:
+            rasterize_to_pixels_bwd_kernel<9><<<blocks, threads, 0, stream>>>(
                 C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
                 (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
                 opacities.data_ptr<float>(),
@@ -1217,8 +1337,40 @@ rasterize_to_pixels_bwd_tensor(
                 (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
                 v_opacities.data_ptr<float>());
             break;
+        case 17:
+            rasterize_to_pixels_bwd_kernel<17><<<blocks, threads, 0, stream>>>(
+                C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+                (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+                opacities.data_ptr<float>(),
+                backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
+                                        : nullptr,
+                image_width, image_height, tile_size, tile_width, tile_height,
+                tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+                render_alphas.data_ptr<float>(), last_ids.data_ptr<int32_t>(),
+                v_render_colors.data_ptr<float>(), v_render_alphas.data_ptr<float>(),
+                absgrad ? (float2 *)v_means2d_abs.data_ptr<float>() : nullptr,
+                (float2 *)v_means2d.data_ptr<float>(),
+                (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
+                v_opacities.data_ptr<float>());
+            break;
         case 32:
             rasterize_to_pixels_bwd_kernel<32><<<blocks, threads, 0, stream>>>(
+                C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
+                (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
+                opacities.data_ptr<float>(),
+                backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
+                                        : nullptr,
+                image_width, image_height, tile_size, tile_width, tile_height,
+                tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+                render_alphas.data_ptr<float>(), last_ids.data_ptr<int32_t>(),
+                v_render_colors.data_ptr<float>(), v_render_alphas.data_ptr<float>(),
+                absgrad ? (float2 *)v_means2d_abs.data_ptr<float>() : nullptr,
+                (float2 *)v_means2d.data_ptr<float>(),
+                (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
+                v_opacities.data_ptr<float>());
+            break;
+        case 33:
+            rasterize_to_pixels_bwd_kernel<33><<<blocks, threads, 0, stream>>>(
                 C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
                 (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
                 opacities.data_ptr<float>(),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -91,10 +91,11 @@ def test_world_to_cam(test_data):
 
     torch.manual_seed(42)
 
-    viewmats = test_data["viewmats"]
-    means = test_data["means"]
-    scales = test_data["scales"]
-    quats = test_data["quats"]
+    # batch size of 2
+    viewmats = test_data["viewmats"].expand(2, -1, -1, -1)
+    means = test_data["means"].expand(2, -1, -1)
+    scales = test_data["scales"].expand(2, -1, -1)
+    quats = test_data["quats"].expand(2, -1, -1)
     covars, _ = quat_scale_to_covar_preci(quats, scales)
     means.requires_grad = True
     covars.requires_grad = True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -169,13 +169,14 @@ def test_projection(test_data, fused: bool, calc_compensations: bool):
 
     torch.manual_seed(42)
 
-    Ks = test_data["Ks"]
-    viewmats = test_data["viewmats"]
+    # batch size of 2
+    Ks = test_data["Ks"].expand(2, -1, -1, -1)
+    viewmats = test_data["viewmats"].expand(2, -1, -1, -1)
     height = test_data["height"]
     width = test_data["width"]
-    quats = test_data["quats"]
-    scales = test_data["scales"]
-    means = test_data["means"]
+    quats = test_data["quats"].expand(2, -1, -1)
+    scales = test_data["scales"].expand(2, -1, -1)
+    means = test_data["means"].expand(2, -1, -1)
     viewmats.requires_grad = True
     quats.requires_grad = True
     scales.requires_grad = True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -52,8 +52,9 @@ def test_quat_scale_to_covar_preci(test_data, triu: bool):
 
     torch.manual_seed(42)
 
-    quats = test_data["quats"]
-    scales = test_data["scales"]
+    # batch size of 2
+    quats = test_data["quats"].expand(2, -1, -1)
+    scales = test_data["scales"].expand(2, -1, -1)
     quats.requires_grad = True
     scales.requires_grad = True
 


### PR DESCRIPTION
After this PR, we will  have the full batching support

The API of `rasterization()` will support passing in GS attributes with shape `[B, N, ...]`, in which `B` is the batch dimension for scenes, and `N` is the number of GS in each scene. For cameras, it will support cameras extrinsics with shape `[B, C, 4, 4]` and intrinsics with shape`[B, C, 3, 3]`, in which C is the number of cameras **per scene**. The rendered image would be with shape `[B, C, H, W, 3]`.

This API would support various batching use cases:
- Single scene multi-view (C) rendering. GS would be with shape `[1, N, ...]` and cameras would be with shape `[1, C, ...]`. The output would be with shape `[1, C, H, W, 3]`.
- Multiple scenes (B), each scene has ONE distinct viewpoint. GS would be with shape `[B, N, ...]` and cameras would be with shape `[B, 1, ...]`. The output would be with shape `[B, 1, H, W, 3]`.
- Multiple scenes (B), each scene has multiple (C) cameras. GS would be with shape `[B, N, ...]` and cameras would be with shape `[B, C, ...]`. The output would be with shape `[B, C, H, W, 3]`.