### PR TITLE
clean up the shape of the colors

### DIFF
--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -1,0 +1,74 @@
+"""Tests for the functions in the CUDA extension.
+
+Usage:
+```bash
+pytest <THIS_PY_FILE> -s
+```
+"""
+
+import math
+from typing import Optional
+
+import pytest
+import torch
+
+device = torch.device("cuda:0")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.parametrize("per_view_color", [True, False])
+@pytest.mark.parametrize("sh_degree", [None, 3])
+@pytest.mark.parametrize("render_mode", ["RGB", "RGB+D", "D"])
+@pytest.mark.parametrize("packed", [True, False])
+def test_rasterization(
+    per_view_color: bool, sh_degree: Optional[int], render_mode: str, packed: bool
+):
+    from gsplat.rendering import rasterization
+
+    torch.manual_seed(42)
+
+    C, N = 2, 10_000
+    means = torch.rand(N, 3, device=device)
+    quats = torch.randn(N, 4, device=device)
+    scales = torch.rand(N, 3, device=device)
+    opacities = torch.rand(N, device=device)
+    if per_view_color:
+        if sh_degree is None:
+            colors = torch.rand(C, N, 3, device=device)
+        else:
+            colors = torch.rand(C, N, (sh_degree + 1) ** 2, 3, device=device)
+    else:
+        if sh_degree is None:
+            colors = torch.rand(N, 3, device=device)
+        else:
+            colors = torch.rand(N, (sh_degree + 1) ** 2, 3, device=device)
+
+    width, height = 300, 200
+    focal = 300.0
+    Ks = torch.tensor(
+        [[focal, 0.0, width / 2.0], [0.0, focal, height / 2.0], [0.0, 0.0, 1.0]],
+        device=device,
+    ).expand(C, -1, -1)
+    viewmats = torch.eye(4, device=device).expand(C, -1, -1)
+
+    colors, alphas, meta = rasterization(
+        means=means,
+        quats=quats,
+        scales=scales,
+        opacities=opacities,
+        colors=colors,
+        viewmats=viewmats,
+        Ks=Ks,
+        width=width,
+        height=height,
+        sh_degree=sh_degree,
+        render_mode=render_mode,
+        packed=packed,
+    )
+
+    if render_mode == "D":
+        assert colors.shape == (C, height, width, 1)
+    elif render_mode == "RGB":
+        assert colors.shape == (C, height, width, 3)
+    elif render_mode == "RGB+D":
+        assert colors.shape == (C, height, width, 4)


### PR DESCRIPTION
Cleans up the logic about the shape of the input `colors` in the `rasterization()` function.

Now it supports colors with shape:

- if `sh_degree` is None: (N, D) or (C, N, D). 
- if `sh_degree` is not None: (N, K, 3) or (C, N, K, 3).

The support of (C, N, D) is necessary to enable appearance embedding which causes the colors to be different across views.
https://github.com/nerfstudio-project/gsplat/blob/4723fe8edfac5fd8fb5c21a6076ac321b2208127/examples/simple_trainer.py#L339-L347

Add an unit test `tests/test_rasterization.py` to make sure the combination of different input arguments to the `rasterization()` function can work together correctly.