### PR TITLE
updating background for different rendering modes [D, ED, RGB+D, RGB+…

### DIFF
--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -317,8 +317,12 @@ def rasterization(
     # Rasterize to pixels
     if render_mode in ["RGB+D", "RGB+ED"]:
         colors = torch.cat((colors, depths[..., None]), dim=-1)
+        if backgrounds is not None:
+            backgrounds = torch.cat([backgrounds, torch.zeros(C, 1, device=backgrounds.device)], dim=-1)
     elif render_mode in ["D", "ED"]:
         colors = depths[..., None]
+        if backgrounds is not None:
+            backgrounds = torch.zeros(C, 1, device=backgrounds.device)
     else:  # RGB
         pass
     if colors.shape[-1] > channel_chunk:


### PR DESCRIPTION
…ED] to be compatible for rasterization

make sure that if a background color is passed in, we update it in accordance to the rendering mode before passing into `rasterize_to_pixels`.