### PR TITLE
Clamp `ratios` in MCMC's `compute_relocation`

### DIFF
--- a/gsplat/relocation.py
+++ b/gsplat/relocation.py
@@ -38,6 +38,7 @@ def compute_relocation(
     assert ratios.shape == (N,), ratios.shape
     opacities = opacities.contiguous()
     scales = scales.contiguous()
+    ratios.clamp_(min=1, max=N_MAX)
     ratios = ratios.int().contiguous()
 
     new_opacities, new_scales = _make_lazy_cuda_func("compute_relocation")(


### PR DESCRIPTION
Relative issue and PR:
* https://github.com/ubc-vision/3dgs-mcmc/issues/8
* https://github.com/ubc-vision/3dgs-mcmc/pull/9

The `max` value here is different from the PR above. Because according to [compute_relocation in cuda](https://github.com/nerfstudio-project/gsplat/blob/fc92cc5efa4584f3f49eda37cd516f72aa8aa20c/gsplat/cuda/csrc/relocation.cu#L18-L25), I think the max valid value is `N_max` rather than `N_max - 1`.