### PR TITLE
float3 -> vec3<float>; float2 -> vec2<float>;

### DIFF
--- a/gsplat/cuda/csrc/compute_sh_bwd.cu
+++ b/gsplat/cuda/csrc/compute_sh_bwd.cu
@@ -1,5 +1,6 @@
 #include "bindings.h"
 #include "spherical_harmonics.cuh"
+#include "types.cuh"
 
 #include <cooperative_groups.h>
 #include <cuda_runtime.h>
@@ -7,16 +8,14 @@
 namespace cg = cooperative_groups;
 
 template <typename T>
-__global__ void compute_sh_bwd_kernel(
-    const uint32_t N,
-    const uint32_t K,
-    const uint32_t degrees_to_use,
-    const typename Float3<T>::type *__restrict__ dirs, // [N, 3]
-    const T *__restrict__ coeffs,                      // [N, K, 3]
-    const bool *__restrict__ masks,                    // [N]
-    const T *__restrict__ v_colors,                    // [N, 3
-    T *__restrict__ v_coeffs,                          // [N, K, 3]
-    T *__restrict__ v_dirs                             // [N, 3] optional
+__global__ void compute_sh_bwd_kernel(const uint32_t N, const uint32_t K,
+                                      const uint32_t degrees_to_use,
+                                      const vec3<T> *__restrict__ dirs, // [N, 3]
+                                      const T *__restrict__ coeffs,     // [N, K, 3]
+                                      const bool *__restrict__ masks,   // [N]
+                                      const T *__restrict__ v_colors,   // [N, 3
+                                      T *__restrict__ v_coeffs,         // [N, K, 3]
+                                      T *__restrict__ v_dirs // [N, 3] optional
 ) {
     // parallelize over N * 3
     uint32_t idx = cg::this_grid().thread_rank();
@@ -29,16 +28,11 @@ __global__ void compute_sh_bwd_kernel(
         return;
     }
 
-    typename Float3<T>::type v_dir = {0.f, 0.f, 0.f};
-    sh_coeffs_to_color_fast_vjp(
-        degrees_to_use,
-        c,
-        dirs[elem_id],
-        coeffs + elem_id * K * 3,
-        v_colors + elem_id * 3,
-        v_coeffs + elem_id * K * 3,
-        v_dirs == nullptr ? nullptr : &v_dir
-    );
+    vec3<T> v_dir = {0.f, 0.f, 0.f};
+    sh_coeffs_to_color_fast_vjp(degrees_to_use, c, dirs[elem_id],
+                                coeffs + elem_id * K * 3, v_colors + elem_id * 3,
+                                v_coeffs + elem_id * K * 3,
+                                v_dirs == nullptr ? nullptr : &v_dir);
     if (v_dirs != nullptr) {
         atomicAdd(v_dirs + elem_id * 3, v_dir.x);
         atomicAdd(v_dirs + elem_id * 3 + 1, v_dir.y);
@@ -46,15 +40,13 @@ __global__ void compute_sh_bwd_kernel(
     }
 }
 
-std::tuple<torch::Tensor, torch::Tensor> compute_sh_bwd_tensor(
-    const uint32_t K,
-    const uint32_t degrees_to_use,
-    torch::Tensor &dirs,               // [..., 3]
-    torch::Tensor &coeffs,             // [..., K, 3]
-    at::optional<torch::Tensor> masks, // [...]
-    torch::Tensor &v_colors,           // [..., 3]
-    bool compute_v_dirs
-) {
+std::tuple<torch::Tensor, torch::Tensor>
+compute_sh_bwd_tensor(const uint32_t K, const uint32_t degrees_to_use,
+                      torch::Tensor &dirs,               // [..., 3]
+                      torch::Tensor &coeffs,             // [..., K, 3]
+                      at::optional<torch::Tensor> masks, // [...]
+                      torch::Tensor &v_colors,           // [..., 3]
+                      bool compute_v_dirs) {
     DEVICE_GUARD(dirs);
     CHECK_INPUT(dirs);
     CHECK_INPUT(coeffs);
@@ -75,16 +67,12 @@ std::tuple<torch::Tensor, torch::Tensor> compute_sh_bwd_tensor(
     if (N) {
         compute_sh_bwd_kernel<float>
             <<<(N * 3 + N_THREADS - 1) / N_THREADS, N_THREADS>>>(
-                N,
-                K,
-                degrees_to_use,
-                (float3 *)dirs.data_ptr<float>(),
+                N, K, degrees_to_use,
+                reinterpret_cast<vec3<float> *>(dirs.data_ptr<float>()),
                 coeffs.data_ptr<float>(),
                 masks.has_value() ? masks.value().data_ptr<bool>() : nullptr,
-                v_colors.data_ptr<float>(),
-                v_coeffs.data_ptr<float>(),
-                compute_v_dirs ? v_dirs.data_ptr<float>() : nullptr
-            );
+                v_colors.data_ptr<float>(), v_coeffs.data_ptr<float>(),
+                compute_v_dirs ? v_dirs.data_ptr<float>() : nullptr);
     }
     return std::make_tuple(v_coeffs, v_dirs); // [..., K, 3], [..., 3]
 }

--- a/gsplat/cuda/csrc/helpers.cuh
+++ b/gsplat/cuda/csrc/helpers.cuh
@@ -18,58 +18,55 @@ inline __device__ void warpSum(T *val, WarpT &warp) {
     }
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(typename Float3<ScalarT>::type &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<ScalarT>());
-    val.y = cg::reduce(warp, val.y, cg::plus<ScalarT>());
-    val.z = cg::reduce(warp, val.z, cg::plus<ScalarT>());
-}
-
-template <class WarpT, class ScalarT> inline __device__ void warpSum(typename Float2<ScalarT>::type &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<ScalarT>());
-    val.y = cg::reduce(warp, val.y, cg::plus<ScalarT>());
-}
-
-template <class WarpT, class ScalarT> inline __device__ void warpSum(ScalarT &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(ScalarT &val, WarpT &warp) {
     val = cg::reduce(warp, val, cg::plus<ScalarT>());
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(vec4<ScalarT> &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(vec4<ScalarT> &val, WarpT &warp) {
     val.x = cg::reduce(warp, val.x, cg::plus<ScalarT>());
     val.y = cg::reduce(warp, val.y, cg::plus<ScalarT>());
     val.z = cg::reduce(warp, val.z, cg::plus<ScalarT>());
     val.w = cg::reduce(warp, val.w, cg::plus<ScalarT>());
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(vec3<ScalarT> &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(vec3<ScalarT> &val, WarpT &warp) {
     val.x = cg::reduce(warp, val.x, cg::plus<ScalarT>());
     val.y = cg::reduce(warp, val.y, cg::plus<ScalarT>());
     val.z = cg::reduce(warp, val.z, cg::plus<ScalarT>());
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(vec2<ScalarT> &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(vec2<ScalarT> &val, WarpT &warp) {
     val.x = cg::reduce(warp, val.x, cg::plus<ScalarT>());
     val.y = cg::reduce(warp, val.y, cg::plus<ScalarT>());
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(mat4<ScalarT> &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(mat4<ScalarT> &val, WarpT &warp) {
     warpSum(val[0], warp);
     warpSum(val[1], warp);
     warpSum(val[2], warp);
     warpSum(val[3], warp);
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(mat3<ScalarT> &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(mat3<ScalarT> &val, WarpT &warp) {
     warpSum(val[0], warp);
     warpSum(val[1], warp);
     warpSum(val[2], warp);
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpSum(mat2<ScalarT> &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpSum(mat2<ScalarT> &val, WarpT &warp) {
     warpSum(val[0], warp);
     warpSum(val[1], warp);
 }
 
-template <class WarpT, class ScalarT> inline __device__ void warpMax(ScalarT &val, WarpT &warp) {
+template <class WarpT, class ScalarT>
+inline __device__ void warpMax(ScalarT &val, WarpT &warp) {
     val = cg::reduce(warp, val, cg::greater<ScalarT>());
 }
 

--- a/gsplat/cuda/csrc/isect_tiles.cu
+++ b/gsplat/cuda/csrc/isect_tiles.cu
@@ -15,17 +15,21 @@ __global__ void isect_tiles(
     // if the data is [C, N, ...] or [nnz, ...] (packed)
     const bool packed,
     // parallelize over C * N, only used if packed is False
-    const uint32_t C, const uint32_t N,
+    const uint32_t C,
+    const uint32_t N,
     // parallelize over nnz, only used if packed is True
     const uint32_t nnz,
     const int64_t *__restrict__ camera_ids,   // [nnz] optional
     const int64_t *__restrict__ gaussian_ids, // [nnz] optional
     // data
-    const typename Float2<T>::type *__restrict__ means2d,              // [C, N, 2] or [nnz, 2]
+    const typename Float2<T>::type
+        *__restrict__ means2d,                       // [C, N, 2] or [nnz, 2]
     const int32_t *__restrict__ radii,               // [C, N] or [nnz]
-    const T *__restrict__ depths,                // [C, N] or [nnz]
+    const T *__restrict__ depths,                    // [C, N] or [nnz]
     const int64_t *__restrict__ cum_tiles_per_gauss, // [C, N] or [nnz]
-    const uint32_t tile_size, const uint32_t tile_width, const uint32_t tile_height,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
     const uint32_t tile_n_bits,
     int32_t *__restrict__ tiles_per_gauss, // [C, N] or [nnz]
     int64_t *__restrict__ isect_ids,       // [n_isects]
@@ -49,14 +53,16 @@ __global__ void isect_tiles(
     // tile_min is inclusive, tile_max is exclusive
     uint2 tile_min, tile_max;
     tile_min.x = min(max(0, (uint32_t)floor(tile_x - tile_radius)), tile_width);
-    tile_min.y = min(max(0, (uint32_t)floor(tile_y - tile_radius)), tile_height);
+    tile_min.y =
+        min(max(0, (uint32_t)floor(tile_y - tile_radius)), tile_height);
     tile_max.x = min(max(0, (uint32_t)ceil(tile_x + tile_radius)), tile_width);
     tile_max.y = min(max(0, (uint32_t)ceil(tile_y + tile_radius)), tile_height);
 
     if (first_pass) {
         // first pass only writes out tiles_per_gauss
-        tiles_per_gauss[idx] =
-            static_cast<int32_t>((tile_max.y - tile_min.y) * (tile_max.x - tile_min.x));
+        tiles_per_gauss[idx] = static_cast<int32_t>(
+            (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
+        );
         return;
     }
 
@@ -87,15 +93,19 @@ __global__ void isect_tiles(
     }
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
-isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
-                   const torch::Tensor &radii,   // [C, N] or [nnz]
-                   const torch::Tensor &depths,  // [C, N] or [nnz]
-                   const at::optional<torch::Tensor> &camera_ids,   // [nnz]
-                   const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
-                   const uint32_t C, const uint32_t tile_size,
-                   const uint32_t tile_width, const uint32_t tile_height,
-                   const bool sort, const bool double_buffer) {
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
+    const torch::Tensor &means2d,                    // [C, N, 2] or [nnz, 2]
+    const torch::Tensor &radii,                      // [C, N] or [nnz]
+    const torch::Tensor &depths,                     // [C, N] or [nnz]
+    const at::optional<torch::Tensor> &camera_ids,   // [nnz]
+    const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
+    const uint32_t C,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const bool sort,
+    const bool double_buffer
+) {
     DEVICE_GUARD(means2d);
     CHECK_INPUT(means2d);
     CHECK_INPUT(radii);
@@ -131,8 +141,8 @@ isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
     // uint32_t cam_n_bits = std::bit_width(C);
     uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
     uint32_t cam_n_bits = (uint32_t)floor(log2(C)) + 1;
-    // the first 32 bits are used for the camera id and tile id altogether, so check if
-    // we have enough bits for them.
+    // the first 32 bits are used for the camera id and tile id altogether, so
+    // check if we have enough bits for them.
     assert(tile_n_bits + cam_n_bits <= 32);
 
     // first pass: compute number of tiles per gaussian
@@ -142,12 +152,29 @@ isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
     int64_t n_isects;
     torch::Tensor cum_tiles_per_gauss;
     if (total_elems) {
-        isect_tiles<<<(total_elems + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
-                      stream>>>(
-            packed, C, N, nnz, camera_ids_ptr, gaussian_ids_ptr,
-            (float2 *)means2d.data_ptr<float>(), radii.data_ptr<int32_t>(),
-            depths.data_ptr<float>(), nullptr, tile_size, tile_width, tile_height,
-            tile_n_bits, tiles_per_gauss.data_ptr<int32_t>(), nullptr, nullptr);
+        isect_tiles<<<
+            (total_elems + N_THREADS - 1) / N_THREADS,
+            N_THREADS,
+            0,
+            stream>>>(
+            packed,
+            C,
+            N,
+            nnz,
+            camera_ids_ptr,
+            gaussian_ids_ptr,
+            (float2 *)means2d.data_ptr<float>(),
+            radii.data_ptr<int32_t>(),
+            depths.data_ptr<float>(),
+            nullptr,
+            tile_size,
+            tile_width,
+            tile_height,
+            tile_n_bits,
+            tiles_per_gauss.data_ptr<int32_t>(),
+            nullptr,
+            nullptr
+        );
         cum_tiles_per_gauss = torch::cumsum(tiles_per_gauss.view({-1}), 0);
         n_isects = cum_tiles_per_gauss[-1].item<int64_t>();
     } else {
@@ -160,13 +187,29 @@ isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
     torch::Tensor flatten_ids =
         torch::empty({n_isects}, depths.options().dtype(torch::kInt32));
     if (n_isects) {
-        isect_tiles<<<(total_elems + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
-                      stream>>>(
-            packed, C, N, nnz, camera_ids_ptr, gaussian_ids_ptr,
-            (float2 *)means2d.data_ptr<float>(), radii.data_ptr<int32_t>(),
-            depths.data_ptr<float>(), cum_tiles_per_gauss.data_ptr<int64_t>(),
-            tile_size, tile_width, tile_height, tile_n_bits, nullptr,
-            isect_ids.data_ptr<int64_t>(), flatten_ids.data_ptr<int32_t>());
+        isect_tiles<<<
+            (total_elems + N_THREADS - 1) / N_THREADS,
+            N_THREADS,
+            0,
+            stream>>>(
+            packed,
+            C,
+            N,
+            nnz,
+            camera_ids_ptr,
+            gaussian_ids_ptr,
+            (float2 *)means2d.data_ptr<float>(),
+            radii.data_ptr<int32_t>(),
+            depths.data_ptr<float>(),
+            cum_tiles_per_gauss.data_ptr<int64_t>(),
+            tile_size,
+            tile_width,
+            tile_height,
+            tile_n_bits,
+            nullptr,
+            isect_ids.data_ptr<int64_t>(),
+            flatten_ids.data_ptr<int32_t>()
+        );
     }
 
     // optionally sort the Gaussians by isect_ids
@@ -178,12 +221,23 @@ isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
         // DoubleBuffer reduce the auxiliary memory usage from O(N+P) to O(P)
         if (double_buffer) {
             // Create a set of DoubleBuffers to wrap pairs of device pointers
-            cub::DoubleBuffer<int64_t> d_keys(isect_ids.data_ptr<int64_t>(),
-                                              isect_ids_sorted.data_ptr<int64_t>());
-            cub::DoubleBuffer<int32_t> d_values(flatten_ids.data_ptr<int32_t>(),
-                                                flatten_ids_sorted.data_ptr<int32_t>());
-            CUB_WRAPPER(cub::DeviceRadixSort::SortPairs, d_keys, d_values, n_isects, 0,
-                        32 + tile_n_bits + cam_n_bits, stream);
+            cub::DoubleBuffer<int64_t> d_keys(
+                isect_ids.data_ptr<int64_t>(),
+                isect_ids_sorted.data_ptr<int64_t>()
+            );
+            cub::DoubleBuffer<int32_t> d_values(
+                flatten_ids.data_ptr<int32_t>(),
+                flatten_ids_sorted.data_ptr<int32_t>()
+            );
+            CUB_WRAPPER(
+                cub::DeviceRadixSort::SortPairs,
+                d_keys,
+                d_values,
+                n_isects,
+                0,
+                32 + tile_n_bits + cam_n_bits,
+                stream
+            );
             switch (d_keys.selector) {
             case 0: // sorted items are stored in isect_ids
                 isect_ids_sorted = isect_ids;
@@ -199,25 +253,36 @@ isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
                 break;
             }
             // printf("DoubleBuffer d_keys selector: %d\n", d_keys.selector);
-            // printf("DoubleBuffer d_values selector: %d\n", d_values.selector);
+            // printf("DoubleBuffer d_values selector: %d\n",
+            // d_values.selector);
         } else {
-            CUB_WRAPPER(cub::DeviceRadixSort::SortPairs, isect_ids.data_ptr<int64_t>(),
-                        isect_ids_sorted.data_ptr<int64_t>(),
-                        flatten_ids.data_ptr<int32_t>(),
-                        flatten_ids_sorted.data_ptr<int32_t>(), n_isects, 0,
-                        32 + tile_n_bits + cam_n_bits, stream);
+            CUB_WRAPPER(
+                cub::DeviceRadixSort::SortPairs,
+                isect_ids.data_ptr<int64_t>(),
+                isect_ids_sorted.data_ptr<int64_t>(),
+                flatten_ids.data_ptr<int32_t>(),
+                flatten_ids_sorted.data_ptr<int32_t>(),
+                n_isects,
+                0,
+                32 + tile_n_bits + cam_n_bits,
+                stream
+            );
         }
-        return std::make_tuple(tiles_per_gauss, isect_ids_sorted, flatten_ids_sorted);
+        return std::make_tuple(
+            tiles_per_gauss, isect_ids_sorted, flatten_ids_sorted
+        );
     } else {
         return std::make_tuple(tiles_per_gauss, isect_ids, flatten_ids);
     }
 }
 
-__global__ void isect_offset_encode(const uint32_t n_isects,
-                                    const int64_t *__restrict__ isect_ids,
-                                    const uint32_t C, const uint32_t n_tiles,
-                                    const uint32_t tile_n_bits,
-                                    int32_t *__restrict__ offsets // [C, n_tiles]
+__global__ void isect_offset_encode(
+    const uint32_t n_isects,
+    const int64_t *__restrict__ isect_ids,
+    const uint32_t C,
+    const uint32_t n_tiles,
+    const uint32_t tile_n_bits,
+    int32_t *__restrict__ offsets // [C, n_tiles]
 ) {
     // e.g., ids: [1, 1, 1, 3, 3], n_tiles = 6
     // counts: [0, 3, 0, 2, 0, 0]
@@ -244,8 +309,8 @@ __global__ void isect_offset_encode(const uint32_t n_isects,
     }
 
     if (idx > 0) {
-        // visit the current and previous isect_id and check if the (cid, tile_id)
-        // pair changes.
+        // visit the current and previous isect_id and check if the (cid,
+        // tile_id) pair changes.
         int64_t isect_id_prev = isect_ids[idx - 1] >> 32; // shift out the depth
         if (isect_id_prev == isect_id_curr)
             return;
@@ -259,23 +324,35 @@ __global__ void isect_offset_encode(const uint32_t n_isects,
     }
 }
 
-torch::Tensor isect_offset_encode_tensor(const torch::Tensor &isect_ids, // [n_isects]
-                                         const uint32_t C, const uint32_t tile_width,
-                                         const uint32_t tile_height) {
+torch::Tensor isect_offset_encode_tensor(
+    const torch::Tensor &isect_ids, // [n_isects]
+    const uint32_t C,
+    const uint32_t tile_width,
+    const uint32_t tile_height
+) {
     DEVICE_GUARD(isect_ids);
     CHECK_INPUT(isect_ids);
 
     uint32_t n_isects = isect_ids.size(0);
-    torch::Tensor offsets = torch::empty({C, tile_height, tile_width},
-                                         isect_ids.options().dtype(torch::kInt32));
+    torch::Tensor offsets = torch::empty(
+        {C, tile_height, tile_width}, isect_ids.options().dtype(torch::kInt32)
+    );
     if (n_isects) {
         uint32_t n_tiles = tile_width * tile_height;
         uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
-        isect_offset_encode<<<(n_isects + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
-                              stream>>>(n_isects, isect_ids.data_ptr<int64_t>(), C,
-                                        n_tiles, tile_n_bits,
-                                        offsets.data_ptr<int32_t>());
+        isect_offset_encode<<<
+            (n_isects + N_THREADS - 1) / N_THREADS,
+            N_THREADS,
+            0,
+            stream>>>(
+            n_isects,
+            isect_ids.data_ptr<int64_t>(),
+            C,
+            n_tiles,
+            tile_n_bits,
+            offsets.data_ptr<int32_t>()
+        );
     } else {
         offsets.fill_(0);
     }

--- a/gsplat/cuda/csrc/isect_tiles.cu
+++ b/gsplat/cuda/csrc/isect_tiles.cu
@@ -1,5 +1,6 @@
 #include "bindings.h"
 #include "helpers.cuh"
+#include "types.cuh"
 #include <cooperative_groups.h>
 #include <cub/cub.cuh>
 #include <cuda_runtime.h>
@@ -15,21 +16,17 @@ __global__ void isect_tiles(
     // if the data is [C, N, ...] or [nnz, ...] (packed)
     const bool packed,
     // parallelize over C * N, only used if packed is False
-    const uint32_t C,
-    const uint32_t N,
+    const uint32_t C, const uint32_t N,
     // parallelize over nnz, only used if packed is True
     const uint32_t nnz,
     const int64_t *__restrict__ camera_ids,   // [nnz] optional
     const int64_t *__restrict__ gaussian_ids, // [nnz] optional
     // data
-    const typename Float2<T>::type
-        *__restrict__ means2d,                       // [C, N, 2] or [nnz, 2]
+    const vec2<T> *__restrict__ means2d,             // [C, N, 2] or [nnz, 2]
     const int32_t *__restrict__ radii,               // [C, N] or [nnz]
     const T *__restrict__ depths,                    // [C, N] or [nnz]
     const int64_t *__restrict__ cum_tiles_per_gauss, // [C, N] or [nnz]
-    const uint32_t tile_size,
-    const uint32_t tile_width,
-    const uint32_t tile_height,
+    const uint32_t tile_size, const uint32_t tile_width, const uint32_t tile_height,
     const uint32_t tile_n_bits,
     int32_t *__restrict__ tiles_per_gauss, // [C, N] or [nnz]
     int64_t *__restrict__ isect_ids,       // [n_isects]
@@ -53,16 +50,14 @@ __global__ void isect_tiles(
     // tile_min is inclusive, tile_max is exclusive
     uint2 tile_min, tile_max;
     tile_min.x = min(max(0, (uint32_t)floor(tile_x - tile_radius)), tile_width);
-    tile_min.y =
-        min(max(0, (uint32_t)floor(tile_y - tile_radius)), tile_height);
+    tile_min.y = min(max(0, (uint32_t)floor(tile_y - tile_radius)), tile_height);
     tile_max.x = min(max(0, (uint32_t)ceil(tile_x + tile_radius)), tile_width);
     tile_max.y = min(max(0, (uint32_t)ceil(tile_y + tile_radius)), tile_height);
 
     if (first_pass) {
         // first pass only writes out tiles_per_gauss
-        tiles_per_gauss[idx] = static_cast<int32_t>(
-            (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
-        );
+        tiles_per_gauss[idx] =
+            static_cast<int32_t>((tile_max.y - tile_min.y) * (tile_max.x - tile_min.x));
         return;
     }
 
@@ -93,19 +88,15 @@ __global__ void isect_tiles(
     }
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
-    const torch::Tensor &means2d,                    // [C, N, 2] or [nnz, 2]
-    const torch::Tensor &radii,                      // [C, N] or [nnz]
-    const torch::Tensor &depths,                     // [C, N] or [nnz]
-    const at::optional<torch::Tensor> &camera_ids,   // [nnz]
-    const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
-    const uint32_t C,
-    const uint32_t tile_size,
-    const uint32_t tile_width,
-    const uint32_t tile_height,
-    const bool sort,
-    const bool double_buffer
-) {
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+isect_tiles_tensor(const torch::Tensor &means2d, // [C, N, 2] or [nnz, 2]
+                   const torch::Tensor &radii,   // [C, N] or [nnz]
+                   const torch::Tensor &depths,  // [C, N] or [nnz]
+                   const at::optional<torch::Tensor> &camera_ids,   // [nnz]
+                   const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
+                   const uint32_t C, const uint32_t tile_size,
+                   const uint32_t tile_width, const uint32_t tile_height,
+                   const bool sort, const bool double_buffer) {
     DEVICE_GUARD(means2d);
     CHECK_INPUT(means2d);
     CHECK_INPUT(radii);
@@ -152,29 +143,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     int64_t n_isects;
     torch::Tensor cum_tiles_per_gauss;
     if (total_elems) {
-        isect_tiles<<<
-            (total_elems + N_THREADS - 1) / N_THREADS,
-            N_THREADS,
-            0,
-            stream>>>(
-            packed,
-            C,
-            N,
-            nnz,
-            camera_ids_ptr,
-            gaussian_ids_ptr,
-            (float2 *)means2d.data_ptr<float>(),
-            radii.data_ptr<int32_t>(),
-            depths.data_ptr<float>(),
-            nullptr,
-            tile_size,
-            tile_width,
-            tile_height,
-            tile_n_bits,
-            tiles_per_gauss.data_ptr<int32_t>(),
-            nullptr,
-            nullptr
-        );
+        isect_tiles<<<(total_elems + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
+                      stream>>>(
+            packed, C, N, nnz, camera_ids_ptr, gaussian_ids_ptr,
+            reinterpret_cast<vec2<float> *>(means2d.data_ptr<float>()),
+            radii.data_ptr<int32_t>(), depths.data_ptr<float>(), nullptr, tile_size,
+            tile_width, tile_height, tile_n_bits, tiles_per_gauss.data_ptr<int32_t>(),
+            nullptr, nullptr);
         cum_tiles_per_gauss = torch::cumsum(tiles_per_gauss.view({-1}), 0);
         n_isects = cum_tiles_per_gauss[-1].item<int64_t>();
     } else {
@@ -187,29 +162,14 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     torch::Tensor flatten_ids =
         torch::empty({n_isects}, depths.options().dtype(torch::kInt32));
     if (n_isects) {
-        isect_tiles<<<
-            (total_elems + N_THREADS - 1) / N_THREADS,
-            N_THREADS,
-            0,
-            stream>>>(
-            packed,
-            C,
-            N,
-            nnz,
-            camera_ids_ptr,
-            gaussian_ids_ptr,
-            (float2 *)means2d.data_ptr<float>(),
-            radii.data_ptr<int32_t>(),
-            depths.data_ptr<float>(),
-            cum_tiles_per_gauss.data_ptr<int64_t>(),
-            tile_size,
-            tile_width,
-            tile_height,
-            tile_n_bits,
-            nullptr,
-            isect_ids.data_ptr<int64_t>(),
-            flatten_ids.data_ptr<int32_t>()
-        );
+        isect_tiles<<<(total_elems + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
+                      stream>>>(
+            packed, C, N, nnz, camera_ids_ptr, gaussian_ids_ptr,
+            reinterpret_cast<vec2<float> *>(means2d.data_ptr<float>()),
+            radii.data_ptr<int32_t>(), depths.data_ptr<float>(),
+            cum_tiles_per_gauss.data_ptr<int64_t>(), tile_size, tile_width, tile_height,
+            tile_n_bits, nullptr, isect_ids.data_ptr<int64_t>(),
+            flatten_ids.data_ptr<int32_t>());
     }
 
     // optionally sort the Gaussians by isect_ids
@@ -221,23 +181,12 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
         // DoubleBuffer reduce the auxiliary memory usage from O(N+P) to O(P)
         if (double_buffer) {
             // Create a set of DoubleBuffers to wrap pairs of device pointers
-            cub::DoubleBuffer<int64_t> d_keys(
-                isect_ids.data_ptr<int64_t>(),
-                isect_ids_sorted.data_ptr<int64_t>()
-            );
-            cub::DoubleBuffer<int32_t> d_values(
-                flatten_ids.data_ptr<int32_t>(),
-                flatten_ids_sorted.data_ptr<int32_t>()
-            );
-            CUB_WRAPPER(
-                cub::DeviceRadixSort::SortPairs,
-                d_keys,
-                d_values,
-                n_isects,
-                0,
-                32 + tile_n_bits + cam_n_bits,
-                stream
-            );
+            cub::DoubleBuffer<int64_t> d_keys(isect_ids.data_ptr<int64_t>(),
+                                              isect_ids_sorted.data_ptr<int64_t>());
+            cub::DoubleBuffer<int32_t> d_values(flatten_ids.data_ptr<int32_t>(),
+                                                flatten_ids_sorted.data_ptr<int32_t>());
+            CUB_WRAPPER(cub::DeviceRadixSort::SortPairs, d_keys, d_values, n_isects, 0,
+                        32 + tile_n_bits + cam_n_bits, stream);
             switch (d_keys.selector) {
             case 0: // sorted items are stored in isect_ids
                 isect_ids_sorted = isect_ids;
@@ -256,33 +205,23 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
             // printf("DoubleBuffer d_values selector: %d\n",
             // d_values.selector);
         } else {
-            CUB_WRAPPER(
-                cub::DeviceRadixSort::SortPairs,
-                isect_ids.data_ptr<int64_t>(),
-                isect_ids_sorted.data_ptr<int64_t>(),
-                flatten_ids.data_ptr<int32_t>(),
-                flatten_ids_sorted.data_ptr<int32_t>(),
-                n_isects,
-                0,
-                32 + tile_n_bits + cam_n_bits,
-                stream
-            );
+            CUB_WRAPPER(cub::DeviceRadixSort::SortPairs, isect_ids.data_ptr<int64_t>(),
+                        isect_ids_sorted.data_ptr<int64_t>(),
+                        flatten_ids.data_ptr<int32_t>(),
+                        flatten_ids_sorted.data_ptr<int32_t>(), n_isects, 0,
+                        32 + tile_n_bits + cam_n_bits, stream);
         }
-        return std::make_tuple(
-            tiles_per_gauss, isect_ids_sorted, flatten_ids_sorted
-        );
+        return std::make_tuple(tiles_per_gauss, isect_ids_sorted, flatten_ids_sorted);
     } else {
         return std::make_tuple(tiles_per_gauss, isect_ids, flatten_ids);
     }
 }
 
-__global__ void isect_offset_encode(
-    const uint32_t n_isects,
-    const int64_t *__restrict__ isect_ids,
-    const uint32_t C,
-    const uint32_t n_tiles,
-    const uint32_t tile_n_bits,
-    int32_t *__restrict__ offsets // [C, n_tiles]
+__global__ void isect_offset_encode(const uint32_t n_isects,
+                                    const int64_t *__restrict__ isect_ids,
+                                    const uint32_t C, const uint32_t n_tiles,
+                                    const uint32_t tile_n_bits,
+                                    int32_t *__restrict__ offsets // [C, n_tiles]
 ) {
     // e.g., ids: [1, 1, 1, 3, 3], n_tiles = 6
     // counts: [0, 3, 0, 2, 0, 0]
@@ -324,35 +263,23 @@ __global__ void isect_offset_encode(
     }
 }
 
-torch::Tensor isect_offset_encode_tensor(
-    const torch::Tensor &isect_ids, // [n_isects]
-    const uint32_t C,
-    const uint32_t tile_width,
-    const uint32_t tile_height
-) {
+torch::Tensor isect_offset_encode_tensor(const torch::Tensor &isect_ids, // [n_isects]
+                                         const uint32_t C, const uint32_t tile_width,
+                                         const uint32_t tile_height) {
     DEVICE_GUARD(isect_ids);
     CHECK_INPUT(isect_ids);
 
     uint32_t n_isects = isect_ids.size(0);
-    torch::Tensor offsets = torch::empty(
-        {C, tile_height, tile_width}, isect_ids.options().dtype(torch::kInt32)
-    );
+    torch::Tensor offsets = torch::empty({C, tile_height, tile_width},
+                                         isect_ids.options().dtype(torch::kInt32));
     if (n_isects) {
         uint32_t n_tiles = tile_width * tile_height;
         uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
-        isect_offset_encode<<<
-            (n_isects + N_THREADS - 1) / N_THREADS,
-            N_THREADS,
-            0,
-            stream>>>(
-            n_isects,
-            isect_ids.data_ptr<int64_t>(),
-            C,
-            n_tiles,
-            tile_n_bits,
-            offsets.data_ptr<int32_t>()
-        );
+        isect_offset_encode<<<(n_isects + N_THREADS - 1) / N_THREADS, N_THREADS, 0,
+                              stream>>>(n_isects, isect_ids.data_ptr<int64_t>(), C,
+                                        n_tiles, tile_n_bits,
+                                        offsets.data_ptr<int32_t>());
     } else {
         offsets.fill_(0);
     }

--- a/gsplat/cuda/csrc/rasterize_to_indices_in_range.cu
+++ b/gsplat/cuda/csrc/rasterize_to_indices_in_range.cu
@@ -1,5 +1,6 @@
 #include "bindings.h"
 #include "helpers.cuh"
+#include "types.cuh"
 #include <cooperative_groups.h>
 #include <cub/cub.cuh>
 #include <cuda_runtime.h>
@@ -12,19 +13,13 @@ namespace cg = cooperative_groups;
 
 template <typename T>
 __global__ void rasterize_to_indices_in_range_kernel(
-    const uint32_t range_start,
-    const uint32_t range_end,
-    const uint32_t C,
-    const uint32_t N,
-    const uint32_t n_isects,
-    const typename Float2<T>::type *__restrict__ means2d, // [C, N, 2]
-    const typename Float3<T>::type *__restrict__ conics,  // [C, N, 3]
-    const T *__restrict__ opacities,                      // [C, N]
-    const uint32_t image_width,
-    const uint32_t image_height,
-    const uint32_t tile_size,
-    const uint32_t tile_width,
-    const uint32_t tile_height,
+    const uint32_t range_start, const uint32_t range_end, const uint32_t C,
+    const uint32_t N, const uint32_t n_isects,
+    const vec2<T> *__restrict__ means2d, // [C, N, 2]
+    const vec3<T> *__restrict__ conics,  // [C, N, 3]
+    const T *__restrict__ opacities,     // [C, N]
+    const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
+    const uint32_t tile_width, const uint32_t tile_height,
     const int32_t *__restrict__ tile_offsets, // [C, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     const T *__restrict__ transmittances,     // [C, image_height, image_width]
@@ -38,8 +33,7 @@ __global__ void rasterize_to_indices_in_range_kernel(
 
     auto block = cg::this_thread_block();
     uint32_t camera_id = block.group_index().x;
-    uint32_t tile_id =
-        block.group_index().y * tile_width + block.group_index().z;
+    uint32_t tile_id = block.group_index().y * tile_width + block.group_index().z;
     uint32_t i = block.group_index().y * tile_size + block.thread_index().y;
     uint32_t j = block.group_index().z * tile_size + block.thread_index().x;
 
@@ -83,11 +77,10 @@ __global__ void rasterize_to_indices_in_range_kernel(
 
     extern __shared__ int s[];
     int32_t *id_batch = (int32_t *)s; // [block_size]
-    typename Float3<T>::type *xy_opacity_batch =
-        (typename Float3<T>::type *)&id_batch[block_size]; // [block_size]
-    typename Float3<T>::type *conic_batch =
-        (typename Float3<T>::type
-             *)&xy_opacity_batch[block_size]; // [block_size]
+    vec3<T> *xy_opacity_batch =
+        reinterpret_cast<vec3<float> *>(&id_batch[block_size]); // [block_size]
+    vec3<T> *conic_batch =
+        reinterpret_cast<vec3<float> *>(&xy_opacity_batch[block_size]); // [block_size]
 
     // current visibility left to render
     // transmittance is gonna be used in the backward pass which requires a high
@@ -119,7 +112,7 @@ __global__ void rasterize_to_indices_in_range_kernel(
         if (idx < isect_range_end) {
             int32_t g = flatten_ids[idx];
             id_batch[tr] = g;
-            const typename Float2<T>::type xy = means2d[g];
+            const vec2<T> xy = means2d[g];
             const T opac = opacities[g];
             xy_opacity_batch[tr] = {xy.x, xy.y, opac};
             conic_batch[tr] = conics[g];
@@ -131,15 +124,13 @@ __global__ void rasterize_to_indices_in_range_kernel(
         // process gaussians in the current batch for this pixel
         uint32_t batch_size = min(block_size, isect_range_end - batch_start);
         for (uint32_t t = 0; (t < batch_size) && !done; ++t) {
-            const typename Float3<T>::type conic = conic_batch[t];
-            const typename Float3<T>::type xy_opac = xy_opacity_batch[t];
+            const vec3<T> conic = conic_batch[t];
+            const vec3<T> xy_opac = xy_opacity_batch[t];
             const T opac = xy_opac.z;
-            const typename Float2<T>::type delta = {
-                xy_opac.x - px, xy_opac.y - py
-            };
-            const T sigma = 0.5f * (conic.x * delta.x * delta.x +
-                                    conic.z * delta.y * delta.y) +
-                            conic.y * delta.x * delta.y;
+            const vec2<T> delta = {xy_opac.x - px, xy_opac.y - py};
+            const T sigma =
+                0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) +
+                conic.y * delta.x * delta.y;
             T alpha = min(0.999f, opac * __expf(-sigma));
 
             if (sigma < 0.f || alpha < 1.f / 255.f) {
@@ -160,8 +151,7 @@ __global__ void rasterize_to_indices_in_range_kernel(
                 // Second pass we write out the gaussian ids and pixel ids
                 int32_t g = id_batch[t]; // flatten index in [C * N]
                 gaussian_ids[base + cnt] = g % N;
-                pixel_ids[base + cnt] =
-                    pix_id + camera_id * image_height * image_width;
+                pixel_ids[base + cnt] = pix_id + camera_id * image_height * image_width;
                 cnt += 1;
             }
 
@@ -184,9 +174,7 @@ std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(
     const torch::Tensor &conics,    // [C, N, 3]
     const torch::Tensor &opacities, // [C, N]
     // image size
-    const uint32_t image_width,
-    const uint32_t image_height,
-    const uint32_t tile_size,
+    const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
     const torch::Tensor &tile_offsets, // [C, tile_height, tile_width]
     const torch::Tensor &flatten_ids   // [n_isects]
@@ -212,53 +200,31 @@ std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
     const uint32_t shared_mem =
         tile_size * tile_size *
-        (sizeof(int32_t) + sizeof(float3) + sizeof(float3));
-    if (cudaFuncSetAttribute(
-            rasterize_to_indices_in_range_kernel<float>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            shared_mem
-        ) != cudaSuccess) {
-        AT_ERROR(
-            "Failed to set maximum shared memory size (requested ",
-            shared_mem,
-            " bytes), try lowering tile_size."
-        );
+        (sizeof(int32_t) + sizeof(vec3<float>) + sizeof(vec3<float>));
+    if (cudaFuncSetAttribute(rasterize_to_indices_in_range_kernel<float>,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             shared_mem) != cudaSuccess) {
+        AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
+                 " bytes), try lowering tile_size.");
     }
 
     // First pass: count the number of gaussians that contribute to each pixel
     int64_t n_elems;
     torch::Tensor chunk_starts;
     if (n_isects) {
-        torch::Tensor chunk_cnts = torch::zeros(
-            {C * image_height * image_width},
-            means2d.options().dtype(torch::kInt32)
-        );
+        torch::Tensor chunk_cnts = torch::zeros({C * image_height * image_width},
+                                                means2d.options().dtype(torch::kInt32));
         rasterize_to_indices_in_range_kernel<float>
             <<<blocks, threads, shared_mem, stream>>>(
-                range_start,
-                range_end,
-                C,
-                N,
-                n_isects,
-                (float2 *)means2d.data_ptr<float>(),
-                (float3 *)conics.data_ptr<float>(),
-                opacities.data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_size,
-                tile_width,
-                tile_height,
-                tile_offsets.data_ptr<int32_t>(),
-                flatten_ids.data_ptr<int32_t>(),
-                transmittances.data_ptr<float>(),
-                nullptr,
-                chunk_cnts.data_ptr<int32_t>(),
-                nullptr,
-                nullptr
-            );
+                range_start, range_end, C, N, n_isects,
+                reinterpret_cast<vec2<float> *>(means2d.data_ptr<float>()),
+                reinterpret_cast<vec3<float> *>(conics.data_ptr<float>()),
+                opacities.data_ptr<float>(), image_width, image_height, tile_size,
+                tile_width, tile_height, tile_offsets.data_ptr<int32_t>(),
+                flatten_ids.data_ptr<int32_t>(), transmittances.data_ptr<float>(),
+                nullptr, chunk_cnts.data_ptr<int32_t>(), nullptr, nullptr);
 
-        torch::Tensor cumsum =
-            torch::cumsum(chunk_cnts, 0, chunk_cnts.scalar_type());
+        torch::Tensor cumsum = torch::cumsum(chunk_cnts, 0, chunk_cnts.scalar_type());
         n_elems = cumsum[-1].item<int64_t>();
         chunk_starts = cumsum - chunk_cnts;
     } else {
@@ -273,27 +239,14 @@ std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(
     if (n_elems) {
         rasterize_to_indices_in_range_kernel<float>
             <<<blocks, threads, shared_mem, stream>>>(
-                range_start,
-                range_end,
-                C,
-                N,
-                n_isects,
-                (float2 *)means2d.data_ptr<float>(),
-                (float3 *)conics.data_ptr<float>(),
-                opacities.data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_size,
-                tile_width,
-                tile_height,
-                tile_offsets.data_ptr<int32_t>(),
-                flatten_ids.data_ptr<int32_t>(),
-                transmittances.data_ptr<float>(),
-                chunk_starts.data_ptr<int32_t>(),
-                nullptr,
-                gaussian_ids.data_ptr<int64_t>(),
-                pixel_ids.data_ptr<int64_t>()
-            );
+                range_start, range_end, C, N, n_isects,
+                reinterpret_cast<vec2<float> *>(means2d.data_ptr<float>()),
+                reinterpret_cast<vec3<float> *>(conics.data_ptr<float>()),
+                opacities.data_ptr<float>(), image_width, image_height, tile_size,
+                tile_width, tile_height, tile_offsets.data_ptr<int32_t>(),
+                flatten_ids.data_ptr<int32_t>(), transmittances.data_ptr<float>(),
+                chunk_starts.data_ptr<int32_t>(), nullptr,
+                gaussian_ids.data_ptr<int64_t>(), pixel_ids.data_ptr<int64_t>());
     }
     return std::make_tuple(gaussian_ids, pixel_ids);
 }

--- a/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
@@ -6,41 +6,50 @@
 
 namespace cg = cooperative_groups;
 
-
 /****************************************************************************
  * Rasterization to Pixels Backward Pass
  ****************************************************************************/
 
 template <uint32_t COLOR_DIM, typename S>
 __global__ void rasterize_to_pixels_bwd_kernel(
-    const uint32_t C, const uint32_t N, const uint32_t n_isects, const bool packed,
+    const uint32_t C,
+    const uint32_t N,
+    const uint32_t n_isects,
+    const bool packed,
     // fwd inputs
-    const typename Float2<S>::type *__restrict__ means2d,    // [C, N, 2] or [nnz, 2]
-    const typename Float3<S>::type *__restrict__ conics,     // [C, N, 3] or [nnz, 3]
+    const typename Float2<S>::type
+        *__restrict__ means2d, // [C, N, 2] or [nnz, 2]
+    const typename Float3<S>::type
+        *__restrict__ conics,          // [C, N, 3] or [nnz, 3]
     const S *__restrict__ colors,      // [C, N, COLOR_DIM] or [nnz, COLOR_DIM]
     const S *__restrict__ opacities,   // [C, N] or [nnz]
     const S *__restrict__ backgrounds, // [C, COLOR_DIM] or [nnz, COLOR_DIM]
-    const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
-    const uint32_t tile_width, const uint32_t tile_height,
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
     const int32_t *__restrict__ tile_offsets, // [C, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     // fwd outputs
-    const S *__restrict__ render_alphas, // [C, image_height, image_width, 1]
-    const int32_t *__restrict__ last_ids,    // [C, image_height, image_width]
+    const S *__restrict__ render_alphas,  // [C, image_height, image_width, 1]
+    const int32_t *__restrict__ last_ids, // [C, image_height, image_width]
     // grad outputs
-    const S
-        *__restrict__ v_render_colors, // [C, image_height, image_width, COLOR_DIM]
+    const S *__restrict__ v_render_colors, // [C, image_height, image_width,
+                                           // COLOR_DIM]
     const S *__restrict__ v_render_alphas, // [C, image_height, image_width, 1]
     // grad inputs
-    typename Float2<S>::type *__restrict__ v_means2d_abs, // [C, N, 2] or [nnz, 2]
-    typename Float2<S>::type *__restrict__ v_means2d,     // [C, N, 2] or [nnz, 2]
-    typename Float3<S>::type *__restrict__ v_conics,      // [C, N, 3] or [nnz, 3]
-    S *__restrict__ v_colors,       // [C, N, COLOR_DIM] or [nnz, COLOR_DIM]
-    S *__restrict__ v_opacities     // [C, N] or [nnz]
+    typename Float2<S>::type
+        *__restrict__ v_means2d_abs,                  // [C, N, 2] or [nnz, 2]
+    typename Float2<S>::type *__restrict__ v_means2d, // [C, N, 2] or [nnz, 2]
+    typename Float3<S>::type *__restrict__ v_conics,  // [C, N, 3] or [nnz, 3]
+    S *__restrict__ v_colors,   // [C, N, COLOR_DIM] or [nnz, COLOR_DIM]
+    S *__restrict__ v_opacities // [C, N] or [nnz]
 ) {
     auto block = cg::this_thread_block();
     uint32_t camera_id = block.group_index().x;
-    uint32_t tile_id = block.group_index().y * tile_width + block.group_index().z;
+    uint32_t tile_id =
+        block.group_index().y * tile_width + block.group_index().z;
     uint32_t i = block.group_index().y * tile_size + block.thread_index().y;
     uint32_t j = block.group_index().z * tile_size + block.thread_index().x;
 
@@ -56,7 +65,8 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     const S px = (S)j + 0.5f;
     const S py = (S)i + 0.5f;
     // clamp this value to the last pixel
-    const int32_t pix_id = min(i * image_width + j, image_width * image_height - 1);
+    const int32_t pix_id =
+        min(i * image_width + j, image_width * image_height - 1);
 
     // keep not rasterizing threads around for reading data
     bool inside = (i < image_height && j < image_width);
@@ -74,9 +84,12 @@ __global__ void rasterize_to_pixels_bwd_kernel(
         (range_end - range_start + block_size - 1) / block_size;
 
     extern __shared__ int s[];
-    int32_t *id_batch = (int32_t *)s;                              // [block_size]
-    typename Float3<S>::type *xy_opacity_batch = (typename Float3<S>::type *)&id_batch[block_size];    // [block_size]
-    typename Float3<S>::type *conic_batch = (typename Float3<S>::type *)&xy_opacity_batch[block_size]; // [block_size]
+    int32_t *id_batch = (int32_t *)s; // [block_size]
+    typename Float3<S>::type *xy_opacity_batch =
+        (typename Float3<S>::type *)&id_batch[block_size]; // [block_size]
+    typename Float3<S>::type *conic_batch =
+        (typename Float3<S>::type
+             *)&xy_opacity_batch[block_size];      // [block_size]
     S *rgbs_batch = (S *)&conic_batch[block_size]; // [block_size * COLOR_DIM]
 
     // this is the T AFTER the last gaussian in this pixel
@@ -99,7 +112,8 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     // each thread loads one gaussian at a time before rasterizing
     const uint32_t tr = block.thread_rank();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
-    const int32_t warp_bin_final = cg::reduce(warp, bin_final, cg::greater<int>());
+    const int32_t warp_bin_final =
+        cg::reduce(warp, bin_final, cg::greater<int>());
     for (uint32_t b = 0; b < num_batches; ++b) {
         // resync all threads before writing next batch of shared mem
         block.sync();
@@ -128,7 +142,8 @@ __global__ void rasterize_to_pixels_bwd_kernel(
         block.sync();
         // process gaussians in the current batch for this pixel
         // 0 index is the furthest back gaussian in the batch
-        for (uint32_t t = max(0, batch_end - warp_bin_final); t < batch_size; ++t) {
+        for (uint32_t t = max(0, batch_end - warp_bin_final); t < batch_size;
+             ++t) {
             bool valid = inside;
             if (batch_end - t > bin_final) {
                 valid = 0;
@@ -144,9 +159,9 @@ __global__ void rasterize_to_pixels_bwd_kernel(
                 typename Float3<S>::type xy_opac = xy_opacity_batch[t];
                 opac = xy_opac.z;
                 delta = {xy_opac.x - px, xy_opac.y - py};
-                S sigma =
-                    0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) +
-                    conic.y * delta.x * delta.y;
+                S sigma = 0.5f * (conic.x * delta.x * delta.x +
+                                  conic.z * delta.y * delta.y) +
+                          conic.y * delta.x * delta.y;
                 vis = __expf(-sigma);
                 alpha = min(0.999f, opac * vis);
                 if (sigma < 0.f || alpha < 1.f / 255.f) {
@@ -177,8 +192,9 @@ __global__ void rasterize_to_pixels_bwd_kernel(
                 // contribution from this pixel
                 S v_alpha = 0.f;
                 for (uint32_t k = 0; k < COLOR_DIM; ++k) {
-                    v_alpha += (rgbs_batch[t * COLOR_DIM + k] * T - buffer[k] * ra) *
-                               v_render_c[k];
+                    v_alpha +=
+                        (rgbs_batch[t * COLOR_DIM + k] * T - buffer[k] * ra) *
+                        v_render_c[k];
                 }
 
                 v_alpha += T_final * ra * v_render_a;
@@ -194,11 +210,15 @@ __global__ void rasterize_to_pixels_bwd_kernel(
 
                 if (opac * vis <= 0.999f) {
                     const S v_sigma = -opac * vis * v_alpha;
-                    v_conic_local = {0.5f * v_sigma * delta.x * delta.x,
-                                     v_sigma * delta.x * delta.y,
-                                     0.5f * v_sigma * delta.y * delta.y};
-                    v_xy_local = {v_sigma * (conic.x * delta.x + conic.y * delta.y),
-                                  v_sigma * (conic.y * delta.x + conic.z * delta.y)};
+                    v_conic_local = {
+                        0.5f * v_sigma * delta.x * delta.x,
+                        v_sigma * delta.x * delta.y,
+                        0.5f * v_sigma * delta.y * delta.y
+                    };
+                    v_xy_local = {
+                        v_sigma * (conic.x * delta.x + conic.y * delta.y),
+                        v_sigma * (conic.y * delta.x + conic.z * delta.y)
+                    };
                     if (v_means2d_abs != nullptr) {
                         v_xy_abs_local = {abs(v_xy_local.x), abs(v_xy_local.y)};
                     }
@@ -246,11 +266,14 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     }
 }
 
-
-
-
 template <uint32_t CDIM>
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> call_kernel_with_dim(
+std::tuple<
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor>
+call_kernel_with_dim(
     // Gaussian parameters
     const torch::Tensor &means2d,                   // [C, N, 2] or [nnz, 2]
     const torch::Tensor &conics,                    // [C, N, 3] or [nnz, 3]
@@ -258,7 +281,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     const torch::Tensor &opacities,                 // [C, N] or [nnz]
     const at::optional<torch::Tensor> &backgrounds, // [C, 3]
     // image size
-    const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
     // intersections
     const torch::Tensor &tile_offsets, // [C, tile_height, tile_width]
     const torch::Tensor &flatten_ids,  // [n_isects]
@@ -269,8 +294,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     const torch::Tensor &v_render_colors, // [C, image_height, image_width, 3]
     const torch::Tensor &v_render_alphas, // [C, image_height, image_width, 1]
     // options
-    bool absgrad) {
-
+    bool absgrad
+) {
 
     DEVICE_GUARD(means2d);
     CHECK_INPUT(means2d);
@@ -311,38 +336,65 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     }
 
     if (n_isects) {
-        const uint32_t shared_mem = tile_size * tile_size *
-                                    (sizeof(int32_t) + sizeof(float3) + sizeof(float3) +
-                                     sizeof(float) * COLOR_DIM);
+        const uint32_t shared_mem =
+            tile_size * tile_size *
+            (sizeof(int32_t) + sizeof(float3) + sizeof(float3) +
+             sizeof(float) * COLOR_DIM);
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
 
-        if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<CDIM, float>,
-                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                    shared_mem) != cudaSuccess) {
-            AT_ERROR("Failed to set maximum shared memory size (requested ",
-                     shared_mem, " bytes), try lowering tile_size.");
+        if (cudaFuncSetAttribute(
+                rasterize_to_pixels_bwd_kernel<CDIM, float>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                shared_mem
+            ) != cudaSuccess) {
+            AT_ERROR(
+                "Failed to set maximum shared memory size (requested ",
+                shared_mem,
+                " bytes), try lowering tile_size."
+            );
         }
-        rasterize_to_pixels_bwd_kernel<CDIM, float><<<blocks, threads, shared_mem, stream>>>(
-            C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
-            (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
-            opacities.data_ptr<float>(),
-            backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
-                                    : nullptr,
-            image_width, image_height, tile_size, tile_width, tile_height,
-            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
-            render_alphas.data_ptr<float>(), last_ids.data_ptr<int32_t>(),
-            v_render_colors.data_ptr<float>(), v_render_alphas.data_ptr<float>(),
-            absgrad ? (float2 *)v_means2d_abs.data_ptr<float>() : nullptr,
-            (float2 *)v_means2d.data_ptr<float>(),
-            (float3 *)v_conics.data_ptr<float>(), v_colors.data_ptr<float>(),
-            v_opacities.data_ptr<float>());
+        rasterize_to_pixels_bwd_kernel<CDIM, float>
+            <<<blocks, threads, shared_mem, stream>>>(
+                C,
+                N,
+                n_isects,
+                packed,
+                (float2 *)means2d.data_ptr<float>(),
+                (float3 *)conics.data_ptr<float>(),
+                colors.data_ptr<float>(),
+                opacities.data_ptr<float>(),
+                backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
+                                        : nullptr,
+                image_width,
+                image_height,
+                tile_size,
+                tile_width,
+                tile_height,
+                tile_offsets.data_ptr<int32_t>(),
+                flatten_ids.data_ptr<int32_t>(),
+                render_alphas.data_ptr<float>(),
+                last_ids.data_ptr<int32_t>(),
+                v_render_colors.data_ptr<float>(),
+                v_render_alphas.data_ptr<float>(),
+                absgrad ? (float2 *)v_means2d_abs.data_ptr<float>() : nullptr,
+                (float2 *)v_means2d.data_ptr<float>(),
+                (float3 *)v_conics.data_ptr<float>(),
+                v_colors.data_ptr<float>(),
+                v_opacities.data_ptr<float>()
+            );
     }
 
-    return std::make_tuple(v_means2d_abs, v_means2d, v_conics, v_colors, v_opacities);
+    return std::make_tuple(
+        v_means2d_abs, v_means2d, v_conics, v_colors, v_opacities
+    );
 }
 
-
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor>
 rasterize_to_pixels_bwd_tensor(
     // Gaussian parameters
     const torch::Tensor &means2d,                   // [C, N, 2] or [nnz, 2]
@@ -351,7 +403,9 @@ rasterize_to_pixels_bwd_tensor(
     const torch::Tensor &opacities,                 // [C, N] or [nnz]
     const at::optional<torch::Tensor> &backgrounds, // [C, 3]
     // image size
-    const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
     // intersections
     const torch::Tensor &tile_offsets, // [C, tile_height, tile_width]
     const torch::Tensor &flatten_ids,  // [n_isects]
@@ -362,18 +416,31 @@ rasterize_to_pixels_bwd_tensor(
     const torch::Tensor &v_render_colors, // [C, image_height, image_width, 3]
     const torch::Tensor &v_render_alphas, // [C, image_height, image_width, 1]
     // options
-    bool absgrad) {
+    bool absgrad
+) {
 
     CHECK_INPUT(colors);
     uint32_t COLOR_DIM = colors.size(-1);
 
-#define __GS__CALL_(N) case N: \
-    return call_kernel_with_dim<N>( \
-        means2d, conics, colors, opacities, \
-        backgrounds, image_width, image_height, \
-        tile_size, tile_offsets, flatten_ids, \
-        render_alphas, last_ids, v_render_colors, \
-        v_render_alphas, absgrad);
+#define __GS__CALL_(N)                                                         \
+    case N:                                                                    \
+        return call_kernel_with_dim<N>(                                        \
+            means2d,                                                           \
+            conics,                                                            \
+            colors,                                                            \
+            opacities,                                                         \
+            backgrounds,                                                       \
+            image_width,                                                       \
+            image_height,                                                      \
+            tile_size,                                                         \
+            tile_offsets,                                                      \
+            flatten_ids,                                                       \
+            render_alphas,                                                     \
+            last_ids,                                                          \
+            v_render_colors,                                                   \
+            v_render_alphas,                                                   \
+            absgrad                                                            \
+        );
 
     switch (COLOR_DIM) {
         __GS__CALL_(1)

--- a/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
@@ -1,11 +1,11 @@
 #include "bindings.h"
 #include "helpers.cuh"
+#include "types.cuh"
 #include <cooperative_groups.h>
 #include <cub/cub.cuh>
 #include <cuda_runtime.h>
 
 namespace cg = cooperative_groups;
-
 
 /****************************************************************************
  * Rasterization to Pixels Forward Pass
@@ -14,18 +14,18 @@ namespace cg = cooperative_groups;
 template <uint32_t COLOR_DIM, typename S>
 __global__ void rasterize_to_pixels_fwd_kernel(
     const uint32_t C, const uint32_t N, const uint32_t n_isects, const bool packed,
-    const typename Float2<S>::type *__restrict__ means2d,    // [C, N, 2] or [nnz, 2]
-    const typename Float3<S>::type *__restrict__ conics,     // [C, N, 3] or [nnz, 3]
-    const S *__restrict__ colors,      // [C, N, COLOR_DIM] or [nnz, COLOR_DIM]
-    const S *__restrict__ opacities,   // [C, N] or [nnz]
-    const S *__restrict__ backgrounds, // [C, COLOR_DIM]
+    const vec2<S> *__restrict__ means2d, // [C, N, 2] or [nnz, 2]
+    const vec3<S> *__restrict__ conics,  // [C, N, 3] or [nnz, 3]
+    const S *__restrict__ colors,        // [C, N, COLOR_DIM] or [nnz, COLOR_DIM]
+    const S *__restrict__ opacities,     // [C, N] or [nnz]
+    const S *__restrict__ backgrounds,   // [C, COLOR_DIM]
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     const uint32_t tile_width, const uint32_t tile_height,
     const int32_t *__restrict__ tile_offsets, // [C, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     S *__restrict__ render_colors, // [C, image_height, image_width, COLOR_DIM]
     S *__restrict__ render_alphas, // [C, image_height, image_width, 1]
-    int32_t *__restrict__ last_ids     // [C, image_height, image_width]
+    int32_t *__restrict__ last_ids // [C, image_height, image_width]
 ) {
     // each thread draws one pixel, but also timeshares caching gaussians in a
     // shared tile
@@ -65,9 +65,11 @@ __global__ void rasterize_to_pixels_fwd_kernel(
     uint32_t num_batches = (range_end - range_start + block_size - 1) / block_size;
 
     extern __shared__ int s[];
-    int32_t *id_batch = (int32_t *)s;                              // [block_size]
-    typename Float3<S>::type *xy_opacity_batch = (typename Float3<S>::type *)&id_batch[block_size];    // [block_size]
-    typename Float3<S>::type *conic_batch = (typename Float3<S>::type *)&xy_opacity_batch[block_size]; // [block_size]
+    int32_t *id_batch = (int32_t *)s; // [block_size]
+    vec3<S> *xy_opacity_batch =
+        reinterpret_cast<vec3<float> *>(&id_batch[block_size]); // [block_size]
+    vec3<S> *conic_batch =
+        reinterpret_cast<vec3<float> *>(&xy_opacity_batch[block_size]); // [block_size]
 
     // current visibility left to render
     // transmittance is gonna be used in the backward pass which requires a high
@@ -97,7 +99,7 @@ __global__ void rasterize_to_pixels_fwd_kernel(
         if (idx < range_end) {
             int32_t g = flatten_ids[idx]; // flatten index in [C * N] or [nnz]
             id_batch[tr] = g;
-            const typename Float2<S>::type xy = means2d[g];
+            const vec2<S> xy = means2d[g];
             const S opac = opacities[g];
             xy_opacity_batch[tr] = {xy.x, xy.y, opac};
             conic_batch[tr] = conics[g];
@@ -109,10 +111,10 @@ __global__ void rasterize_to_pixels_fwd_kernel(
         // process gaussians in the current batch for this pixel
         uint32_t batch_size = min(block_size, range_end - batch_start);
         for (uint32_t t = 0; (t < batch_size) && !done; ++t) {
-            const typename Float3<S>::type conic = conic_batch[t];
-            const typename Float3<S>::type xy_opac = xy_opacity_batch[t];
+            const vec3<S> conic = conic_batch[t];
+            const vec3<S> xy_opac = xy_opacity_batch[t];
             const S opac = xy_opac.z;
-            const typename Float2<S>::type delta = {xy_opac.x - px, xy_opac.y - py};
+            const vec2<S> delta = {xy_opac.x - px, xy_opac.y - py};
             const S sigma =
                 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) +
                 conic.y * delta.x * delta.y;
@@ -204,32 +206,32 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> call_kernel_with_dim(
 
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
     const uint32_t shared_mem =
-        tile_size * tile_size * (sizeof(int32_t) + sizeof(float3) + sizeof(float3));
+        tile_size * tile_size *
+        (sizeof(int32_t) + sizeof(vec3<float>) + sizeof(vec3<float>));
 
     // TODO: an optimization can be done by passing the actual number of channels into
     // the kernel functions and avoid necessary global memory writes. This requires
     // moving the channel padding from python to C side.
     if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<CDIM, float>,
-                                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                shared_mem) != cudaSuccess) {
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             shared_mem) != cudaSuccess) {
         AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
-                    " bytes), try lowering tile_size.");
+                 " bytes), try lowering tile_size.");
     }
-    rasterize_to_pixels_fwd_kernel<CDIM, float><<<blocks, threads, shared_mem, stream>>>(
-        C, N, n_isects, packed, (float2 *)means2d.data_ptr<float>(),
-        (float3 *)conics.data_ptr<float>(), colors.data_ptr<float>(),
-        opacities.data_ptr<float>(),
-        backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
-        image_width, image_height, tile_size, tile_width, tile_height,
-        tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
-        renders.data_ptr<float>(), alphas.data_ptr<float>(),
-        last_ids.data_ptr<int32_t>());
- 
+    rasterize_to_pixels_fwd_kernel<CDIM, float>
+        <<<blocks, threads, shared_mem, stream>>>(
+            C, N, n_isects, packed,
+            reinterpret_cast<vec2<float> *>(means2d.data_ptr<float>()),
+            reinterpret_cast<vec3<float> *>(conics.data_ptr<float>()),
+            colors.data_ptr<float>(), opacities.data_ptr<float>(),
+            backgrounds.has_value() ? backgrounds.value().data_ptr<float>() : nullptr,
+            image_width, image_height, tile_size, tile_width, tile_height,
+            tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
+            renders.data_ptr<float>(), alphas.data_ptr<float>(),
+            last_ids.data_ptr<int32_t>());
+
     return std::make_tuple(renders, alphas, last_ids);
 }
-
-
-
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_tensor(
     // Gaussian parameters
@@ -247,11 +249,11 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
     CHECK_INPUT(colors);
     uint32_t channels = colors.size(-1);
 
-    #define __GS__CALL_(N) case N: \
-        return call_kernel_with_dim<N>( \
-            means2d, conics, colors, opacities, \
-            backgrounds, image_width, image_height, \
-            tile_size, tile_offsets, flatten_ids);
+#define __GS__CALL_(N)                                                                 \
+    case N:                                                                            \
+        return call_kernel_with_dim<N>(means2d, conics, colors, opacities,             \
+                                       backgrounds, image_width, image_height,         \
+                                       tile_size, tile_offsets, flatten_ids);
 
     // TODO: an optimization can be done by passing the actual number of channels into
     // the kernel functions and avoid necessary global memory writes. This requires

--- a/gsplat/cuda/csrc/spherical_harmonics.cuh
+++ b/gsplat/cuda/csrc/spherical_harmonics.cuh
@@ -1,4 +1,5 @@
 #include "bindings.h"
+#include "types.cuh"
 #include "utils.cuh"
 
 #include <cuda_runtime.h>
@@ -8,13 +9,13 @@
 // Sloan, JCGT 2013 See https://jcgt.org/published/0002/02/06/ for reference
 // implementation
 template <typename T>
-inline __device__ void sh_coeffs_to_color_fast(
-    const uint32_t degree,               // degree of SH to be evaluated
-    const uint32_t c,                    // color channel
-    const typename Float3<T>::type &dir, // [3]
-    const T *coeffs,                     // [K, 3]
-    // output
-    T *colors // [3]
+inline __device__ void
+sh_coeffs_to_color_fast(const uint32_t degree, // degree of SH to be evaluated
+                        const uint32_t c,      // color channel
+                        const vec3<T> &dir,    // [3]
+                        const T *coeffs,       // [K, 3]
+                        // output
+                        T *colors // [3]
 ) {
     T result = 0.2820947917738781f * coeffs[c];
     if (degree >= 1) {
@@ -25,9 +26,8 @@ inline __device__ void sh_coeffs_to_color_fast(
         T y = dir.y * inorm;
         T z = dir.z * inorm;
 
-        result +=
-            0.48860251190292f * (-y * coeffs[1 * 3 + c] +
-                                 z * coeffs[2 * 3 + c] - x * coeffs[3 * 3 + c]);
+        result += 0.48860251190292f * (-y * coeffs[1 * 3 + c] + z * coeffs[2 * 3 + c] -
+                                       x * coeffs[3 * 3 + c]);
         if (degree >= 2) {
             T z2 = z * z;
 
@@ -56,22 +56,19 @@ inline __device__ void sh_coeffs_to_color_fast(
                 T pSH15 = -0.5900435899266435f * fC2;
                 T pSH9 = -0.5900435899266435f * fS2;
 
-                result +=
-                    pSH9 * coeffs[9 * 3 + c] + pSH10 * coeffs[10 * 3 + c] +
-                    pSH11 * coeffs[11 * 3 + c] + pSH12 * coeffs[12 * 3 + c] +
-                    pSH13 * coeffs[13 * 3 + c] + pSH14 * coeffs[14 * 3 + c] +
-                    pSH15 * coeffs[15 * 3 + c];
+                result += pSH9 * coeffs[9 * 3 + c] + pSH10 * coeffs[10 * 3 + c] +
+                          pSH11 * coeffs[11 * 3 + c] + pSH12 * coeffs[12 * 3 + c] +
+                          pSH13 * coeffs[13 * 3 + c] + pSH14 * coeffs[14 * 3 + c] +
+                          pSH15 * coeffs[15 * 3 + c];
 
                 if (degree >= 4) {
-                    T fTmp0D =
-                        z * (-4.683325804901025f * z2 + 2.007139630671868f);
+                    T fTmp0D = z * (-4.683325804901025f * z2 + 2.007139630671868f);
                     T fTmp1C = 3.31161143515146f * z2 - 0.47308734787878f;
                     T fTmp2B = -1.770130769779931f * z;
                     T fC3 = x * fC2 - y * fS2;
                     T fS3 = x * fS2 + y * fC2;
                     T pSH20 =
-                        (1.984313483298443f * z * pSH12 -
-                         1.006230589874905f * pSH6);
+                        (1.984313483298443f * z * pSH12 - 1.006230589874905f * pSH6);
                     T pSH21 = fTmp0D * x;
                     T pSH19 = fTmp0D * y;
                     T pSH22 = fTmp1C * fC1;
@@ -81,14 +78,10 @@ inline __device__ void sh_coeffs_to_color_fast(
                     T pSH24 = 0.6258357354491763f * fC3;
                     T pSH16 = 0.6258357354491763f * fS3;
 
-                    result += pSH16 * coeffs[16 * 3 + c] +
-                              pSH17 * coeffs[17 * 3 + c] +
-                              pSH18 * coeffs[18 * 3 + c] +
-                              pSH19 * coeffs[19 * 3 + c] +
-                              pSH20 * coeffs[20 * 3 + c] +
-                              pSH21 * coeffs[21 * 3 + c] +
-                              pSH22 * coeffs[22 * 3 + c] +
-                              pSH23 * coeffs[23 * 3 + c] +
+                    result += pSH16 * coeffs[16 * 3 + c] + pSH17 * coeffs[17 * 3 + c] +
+                              pSH18 * coeffs[18 * 3 + c] + pSH19 * coeffs[19 * 3 + c] +
+                              pSH20 * coeffs[20 * 3 + c] + pSH21 * coeffs[21 * 3 + c] +
+                              pSH22 * coeffs[22 * 3 + c] + pSH23 * coeffs[23 * 3 + c] +
                               pSH24 * coeffs[24 * 3 + c];
                 }
             }
@@ -99,15 +92,15 @@ inline __device__ void sh_coeffs_to_color_fast(
 }
 
 template <typename T>
-inline __device__ void sh_coeffs_to_color_fast_vjp(
-    const uint32_t degree,               // degree of SH to be evaluated
-    const uint32_t c,                    // color channel
-    const typename Float3<T>::type &dir, // [3]
-    const T *coeffs,                     // [K, 3]
-    const T *v_colors,                   // [3]
-    // output
-    T *v_coeffs,                    // [K, 3]
-    typename Float3<T>::type *v_dir // [3] optional
+inline __device__ void
+sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluated
+                            const uint32_t c,      // color channel
+                            const vec3<T> &dir,    // [3]
+                            const T *coeffs,       // [K, 3]
+                            const T *v_colors,     // [3]
+                            // output
+                            T *v_coeffs,   // [K, 3]
+                            vec3<T> *v_dir // [3] optional
 ) {
     T v_colors_local = v_colors[c];
 
@@ -158,8 +151,8 @@ inline __device__ void sh_coeffs_to_color_fast_vjp(
     v_coeffs[7 * 3 + c] = pSH7 * v_colors_local;
     v_coeffs[8 * 3 + c] = pSH8 * v_colors_local;
 
-    T fTmp0B_z, fC1_x, fC1_y, fS1_x, fS1_y, pSH6_z, pSH7_x, pSH7_z, pSH5_y,
-        pSH5_z, pSH8_x, pSH8_y, pSH4_x, pSH4_y;
+    T fTmp0B_z, fC1_x, fC1_y, fS1_x, fS1_y, pSH6_z, pSH7_x, pSH7_z, pSH5_y, pSH5_z,
+        pSH8_x, pSH8_y, pSH4_x, pSH4_y;
     if (v_dir != nullptr) {
         fTmp0B_z = -1.092548430592079f;
         fC1_x = 2.f * x;
@@ -176,15 +169,15 @@ inline __device__ void sh_coeffs_to_color_fast_vjp(
         pSH4_x = 0.5462742152960395f * fS1_x;
         pSH4_y = 0.5462742152960395f * fS1_y;
 
-        v_x += v_colors_local *
-               (pSH4_x * coeffs[4 * 3 + c] + pSH8_x * coeffs[8 * 3 + c] +
-                pSH7_x * coeffs[7 * 3 + c]);
-        v_y += v_colors_local *
-               (pSH4_y * coeffs[4 * 3 + c] + pSH8_y * coeffs[8 * 3 + c] +
-                pSH5_y * coeffs[5 * 3 + c]);
-        v_z += v_colors_local *
-               (pSH6_z * coeffs[6 * 3 + c] + pSH7_z * coeffs[7 * 3 + c] +
-                pSH5_z * coeffs[5 * 3 + c]);
+        v_x +=
+            v_colors_local * (pSH4_x * coeffs[4 * 3 + c] + pSH8_x * coeffs[8 * 3 + c] +
+                              pSH7_x * coeffs[7 * 3 + c]);
+        v_y +=
+            v_colors_local * (pSH4_y * coeffs[4 * 3 + c] + pSH8_y * coeffs[8 * 3 + c] +
+                              pSH5_y * coeffs[5 * 3 + c]);
+        v_z +=
+            v_colors_local * (pSH6_z * coeffs[6 * 3 + c] + pSH7_z * coeffs[7 * 3 + c] +
+                              pSH5_z * coeffs[5 * 3 + c]);
     }
 
     if (degree < 3) {
@@ -220,8 +213,8 @@ inline __device__ void sh_coeffs_to_color_fast_vjp(
     v_coeffs[15 * 3 + c] = pSH15 * v_colors_local;
 
     T fTmp0C_z, fTmp1B_z, fC2_x, fC2_y, fS2_x, fS2_y, pSH12_z, pSH13_x, pSH13_z,
-        pSH11_y, pSH11_z, pSH14_x, pSH14_y, pSH14_z, pSH10_x, pSH10_y, pSH10_z,
-        pSH15_x, pSH15_y, pSH9_x, pSH9_y;
+        pSH11_y, pSH11_z, pSH14_x, pSH14_y, pSH14_z, pSH10_x, pSH10_y, pSH10_z, pSH15_x,
+        pSH15_y, pSH9_x, pSH9_y;
     if (v_dir != nullptr) {
         fTmp0C_z = -2.285228997322329f * 2.f * z;
         fTmp1B_z = 1.445305721320277f;
@@ -298,10 +291,10 @@ inline __device__ void sh_coeffs_to_color_fast_vjp(
     v_coeffs[23 * 3 + c] = pSH23 * v_colors_local;
     v_coeffs[24 * 3 + c] = pSH24 * v_colors_local;
 
-    T fTmp0D_z, fTmp1C_z, fTmp2B_z, fC3_x, fC3_y, fS3_x, fS3_y, pSH20_z,
-        pSH21_x, pSH21_z, pSH19_y, pSH19_z, pSH22_x, pSH22_y, pSH22_z, pSH18_x,
-        pSH18_y, pSH18_z, pSH23_x, pSH23_y, pSH23_z, pSH17_x, pSH17_y, pSH17_z,
-        pSH24_x, pSH24_y, pSH16_x, pSH16_y;
+    T fTmp0D_z, fTmp1C_z, fTmp2B_z, fC3_x, fC3_y, fS3_x, fS3_y, pSH20_z, pSH21_x,
+        pSH21_z, pSH19_y, pSH19_z, pSH22_x, pSH22_y, pSH22_z, pSH18_x, pSH18_y, pSH18_z,
+        pSH23_x, pSH23_y, pSH23_z, pSH17_x, pSH17_y, pSH17_z, pSH24_x, pSH24_y, pSH16_x,
+        pSH16_y;
     if (v_dir != nullptr) {
         fTmp0D_z = 3.f * -4.683325804901025f * z2 + 2.007139630671868f;
         fTmp1C_z = 2.f * 3.31161143515146f * z;
@@ -310,8 +303,8 @@ inline __device__ void sh_coeffs_to_color_fast_vjp(
         fC3_y = x * fC2_y - fS2 - y * fS2_y;
         fS3_x = fS2 + y * fC2_x + x * fS2_x;
         fS3_y = x * fS2_y + fC2 + y * fC2_y;
-        pSH20_z = 1.984313483298443f * (pSH12 + z * pSH12_z) +
-                  -1.006230589874905f * pSH6_z;
+        pSH20_z =
+            1.984313483298443f * (pSH12 + z * pSH12_z) + -1.006230589874905f * pSH6_z;
         pSH21_x = fTmp0D;
         pSH21_z = fTmp0D_z * x;
         pSH19_y = fTmp0D;

--- a/gsplat/cuda/csrc/spherical_harmonics.cuh
+++ b/gsplat/cuda/csrc/spherical_harmonics.cuh
@@ -3,29 +3,31 @@
 
 #include <cuda_runtime.h>
 
-// Evaluate spherical harmonics bases at unit direction for high orders using approach
-// described by Efficient Spherical Harmonic Evaluation, Peter-Pike Sloan, JCGT 2013 See
-// https://jcgt.org/published/0002/02/06/ for reference implementation
+// Evaluate spherical harmonics bases at unit direction for high orders using
+// approach described by Efficient Spherical Harmonic Evaluation, Peter-Pike
+// Sloan, JCGT 2013 See https://jcgt.org/published/0002/02/06/ for reference
+// implementation
 template <typename T>
-inline __device__ void
-sh_coeffs_to_color_fast(const uint32_t degree, // degree of SH to be evaluated
-                        const uint32_t c,      // color channel
-                        const typename Float3<T>::type &dir,     // [3]
-                        const T *coeffs,   // [K, 3]
-                        // output
-                        T *colors // [3]
+inline __device__ void sh_coeffs_to_color_fast(
+    const uint32_t degree,               // degree of SH to be evaluated
+    const uint32_t c,                    // color channel
+    const typename Float3<T>::type &dir, // [3]
+    const T *coeffs,                     // [K, 3]
+    // output
+    T *colors // [3]
 ) {
     T result = 0.2820947917738781f * coeffs[c];
     if (degree >= 1) {
-        // Normally rsqrt is faster than sqrt, but --use_fast_math will optimize sqrt
-        // on single precision, so we use sqrt here.
+        // Normally rsqrt is faster than sqrt, but --use_fast_math will optimize
+        // sqrt on single precision, so we use sqrt here.
         T inorm = rsqrtf(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
         T x = dir.x * inorm;
         T y = dir.y * inorm;
         T z = dir.z * inorm;
 
-        result += 0.48860251190292f * (-y * coeffs[1 * 3 + c] + z * coeffs[2 * 3 + c] -
-                                       x * coeffs[3 * 3 + c]);
+        result +=
+            0.48860251190292f * (-y * coeffs[1 * 3 + c] +
+                                 z * coeffs[2 * 3 + c] - x * coeffs[3 * 3 + c]);
         if (degree >= 2) {
             T z2 = z * z;
 
@@ -54,19 +56,22 @@ sh_coeffs_to_color_fast(const uint32_t degree, // degree of SH to be evaluated
                 T pSH15 = -0.5900435899266435f * fC2;
                 T pSH9 = -0.5900435899266435f * fS2;
 
-                result += pSH9 * coeffs[9 * 3 + c] + pSH10 * coeffs[10 * 3 + c] +
-                          pSH11 * coeffs[11 * 3 + c] + pSH12 * coeffs[12 * 3 + c] +
-                          pSH13 * coeffs[13 * 3 + c] + pSH14 * coeffs[14 * 3 + c] +
-                          pSH15 * coeffs[15 * 3 + c];
+                result +=
+                    pSH9 * coeffs[9 * 3 + c] + pSH10 * coeffs[10 * 3 + c] +
+                    pSH11 * coeffs[11 * 3 + c] + pSH12 * coeffs[12 * 3 + c] +
+                    pSH13 * coeffs[13 * 3 + c] + pSH14 * coeffs[14 * 3 + c] +
+                    pSH15 * coeffs[15 * 3 + c];
 
                 if (degree >= 4) {
-                    T fTmp0D = z * (-4.683325804901025f * z2 + 2.007139630671868f);
+                    T fTmp0D =
+                        z * (-4.683325804901025f * z2 + 2.007139630671868f);
                     T fTmp1C = 3.31161143515146f * z2 - 0.47308734787878f;
                     T fTmp2B = -1.770130769779931f * z;
                     T fC3 = x * fC2 - y * fS2;
                     T fS3 = x * fS2 + y * fC2;
                     T pSH20 =
-                        (1.984313483298443f * z * pSH12 - 1.006230589874905f * pSH6);
+                        (1.984313483298443f * z * pSH12 -
+                         1.006230589874905f * pSH6);
                     T pSH21 = fTmp0D * x;
                     T pSH19 = fTmp0D * y;
                     T pSH22 = fTmp1C * fC1;
@@ -76,10 +81,14 @@ sh_coeffs_to_color_fast(const uint32_t degree, // degree of SH to be evaluated
                     T pSH24 = 0.6258357354491763f * fC3;
                     T pSH16 = 0.6258357354491763f * fS3;
 
-                    result += pSH16 * coeffs[16 * 3 + c] + pSH17 * coeffs[17 * 3 + c] +
-                              pSH18 * coeffs[18 * 3 + c] + pSH19 * coeffs[19 * 3 + c] +
-                              pSH20 * coeffs[20 * 3 + c] + pSH21 * coeffs[21 * 3 + c] +
-                              pSH22 * coeffs[22 * 3 + c] + pSH23 * coeffs[23 * 3 + c] +
+                    result += pSH16 * coeffs[16 * 3 + c] +
+                              pSH17 * coeffs[17 * 3 + c] +
+                              pSH18 * coeffs[18 * 3 + c] +
+                              pSH19 * coeffs[19 * 3 + c] +
+                              pSH20 * coeffs[20 * 3 + c] +
+                              pSH21 * coeffs[21 * 3 + c] +
+                              pSH22 * coeffs[22 * 3 + c] +
+                              pSH23 * coeffs[23 * 3 + c] +
                               pSH24 * coeffs[24 * 3 + c];
                 }
             }
@@ -90,15 +99,15 @@ sh_coeffs_to_color_fast(const uint32_t degree, // degree of SH to be evaluated
 }
 
 template <typename T>
-inline __device__ void
-sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluated
-                            const uint32_t c,      // color channel
-                            const typename Float3<T>::type &dir,     // [3]
-                            const T *coeffs,   // [K, 3]
-                            const T *v_colors, // [3]
-                            // output
-                            T *v_coeffs, // [K, 3]
-                            typename Float3<T>::type *v_dir    // [3] optional
+inline __device__ void sh_coeffs_to_color_fast_vjp(
+    const uint32_t degree,               // degree of SH to be evaluated
+    const uint32_t c,                    // color channel
+    const typename Float3<T>::type &dir, // [3]
+    const T *coeffs,                     // [K, 3]
+    const T *v_colors,                   // [3]
+    // output
+    T *v_coeffs,                    // [K, 3]
+    typename Float3<T>::type *v_dir // [3] optional
 ) {
     T v_colors_local = v_colors[c];
 
@@ -149,8 +158,8 @@ sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluat
     v_coeffs[7 * 3 + c] = pSH7 * v_colors_local;
     v_coeffs[8 * 3 + c] = pSH8 * v_colors_local;
 
-    T fTmp0B_z, fC1_x, fC1_y, fS1_x, fS1_y, pSH6_z, pSH7_x, pSH7_z, pSH5_y, pSH5_z,
-        pSH8_x, pSH8_y, pSH4_x, pSH4_y;
+    T fTmp0B_z, fC1_x, fC1_y, fS1_x, fS1_y, pSH6_z, pSH7_x, pSH7_z, pSH5_y,
+        pSH5_z, pSH8_x, pSH8_y, pSH4_x, pSH4_y;
     if (v_dir != nullptr) {
         fTmp0B_z = -1.092548430592079f;
         fC1_x = 2.f * x;
@@ -167,15 +176,15 @@ sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluat
         pSH4_x = 0.5462742152960395f * fS1_x;
         pSH4_y = 0.5462742152960395f * fS1_y;
 
-        v_x +=
-            v_colors_local * (pSH4_x * coeffs[4 * 3 + c] + pSH8_x * coeffs[8 * 3 + c] +
-                              pSH7_x * coeffs[7 * 3 + c]);
-        v_y +=
-            v_colors_local * (pSH4_y * coeffs[4 * 3 + c] + pSH8_y * coeffs[8 * 3 + c] +
-                              pSH5_y * coeffs[5 * 3 + c]);
-        v_z +=
-            v_colors_local * (pSH6_z * coeffs[6 * 3 + c] + pSH7_z * coeffs[7 * 3 + c] +
-                              pSH5_z * coeffs[5 * 3 + c]);
+        v_x += v_colors_local *
+               (pSH4_x * coeffs[4 * 3 + c] + pSH8_x * coeffs[8 * 3 + c] +
+                pSH7_x * coeffs[7 * 3 + c]);
+        v_y += v_colors_local *
+               (pSH4_y * coeffs[4 * 3 + c] + pSH8_y * coeffs[8 * 3 + c] +
+                pSH5_y * coeffs[5 * 3 + c]);
+        v_z += v_colors_local *
+               (pSH6_z * coeffs[6 * 3 + c] + pSH7_z * coeffs[7 * 3 + c] +
+                pSH5_z * coeffs[5 * 3 + c]);
     }
 
     if (degree < 3) {
@@ -211,8 +220,8 @@ sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluat
     v_coeffs[15 * 3 + c] = pSH15 * v_colors_local;
 
     T fTmp0C_z, fTmp1B_z, fC2_x, fC2_y, fS2_x, fS2_y, pSH12_z, pSH13_x, pSH13_z,
-        pSH11_y, pSH11_z, pSH14_x, pSH14_y, pSH14_z, pSH10_x, pSH10_y, pSH10_z, pSH15_x,
-        pSH15_y, pSH9_x, pSH9_y;
+        pSH11_y, pSH11_z, pSH14_x, pSH14_y, pSH14_z, pSH10_x, pSH10_y, pSH10_z,
+        pSH15_x, pSH15_y, pSH9_x, pSH9_y;
     if (v_dir != nullptr) {
         fTmp0C_z = -2.285228997322329f * 2.f * z;
         fTmp1B_z = 1.445305721320277f;
@@ -289,10 +298,10 @@ sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluat
     v_coeffs[23 * 3 + c] = pSH23 * v_colors_local;
     v_coeffs[24 * 3 + c] = pSH24 * v_colors_local;
 
-    T fTmp0D_z, fTmp1C_z, fTmp2B_z, fC3_x, fC3_y, fS3_x, fS3_y, pSH20_z, pSH21_x,
-        pSH21_z, pSH19_y, pSH19_z, pSH22_x, pSH22_y, pSH22_z, pSH18_x, pSH18_y, pSH18_z,
-        pSH23_x, pSH23_y, pSH23_z, pSH17_x, pSH17_y, pSH17_z, pSH24_x, pSH24_y, pSH16_x,
-        pSH16_y;
+    T fTmp0D_z, fTmp1C_z, fTmp2B_z, fC3_x, fC3_y, fS3_x, fS3_y, pSH20_z,
+        pSH21_x, pSH21_z, pSH19_y, pSH19_z, pSH22_x, pSH22_y, pSH22_z, pSH18_x,
+        pSH18_y, pSH18_z, pSH23_x, pSH23_y, pSH23_z, pSH17_x, pSH17_y, pSH17_z,
+        pSH24_x, pSH24_y, pSH16_x, pSH16_y;
     if (v_dir != nullptr) {
         fTmp0D_z = 3.f * -4.683325804901025f * z2 + 2.007139630671868f;
         fTmp1C_z = 2.f * 3.31161143515146f * z;
@@ -301,8 +310,8 @@ sh_coeffs_to_color_fast_vjp(const uint32_t degree, // degree of SH to be evaluat
         fC3_y = x * fC2_y - fS2 - y * fS2_y;
         fS3_x = fS2 + y * fC2_x + x * fS2_x;
         fS3_y = x * fS2_y + fC2 + y * fC2_y;
-        pSH20_z =
-            1.984313483298443f * (pSH12 + z * pSH12_z) + -1.006230589874905f * pSH6_z;
+        pSH20_z = 1.984313483298443f * (pSH12 + z * pSH12_z) +
+                  -1.006230589874905f * pSH6_z;
         pSH21_x = fTmp0D;
         pSH21_z = fTmp0D_z * x;
         pSH19_y = fTmp0D;

--- a/gsplat/cuda/csrc/types.cuh
+++ b/gsplat/cuda/csrc/types.cuh
@@ -1,34 +1,11 @@
+#ifndef GSPLAT_CUDA_TYPES_H
+#define GSPLAT_CUDA_TYPES_H
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
-
-// Shim types to extract vector types from scalar types
-// e.g. using vec3f = Float3<float>::type; yields float3
-template <typename T> struct Float3 {};
-template <> struct Float3<float> {
-    typedef float3 type;
-};
-template <> struct Float3<double> {
-    typedef double3 type;
-};
-
-template <typename T> struct Float4 {};
-template <> struct Float4<float> {
-    typedef float4 type;
-};
-template <> struct Float4<double> {
-    typedef double4 type;
-};
-
-template <typename T> struct Float2 {};
-template <> struct Float2<float> {
-    typedef float2 type;
-};
-template <> struct Float2<double> {
-    typedef double2 type;
-};
 
 template <typename T> using vec2 = glm::vec<2, T>;
 
@@ -43,3 +20,5 @@ template <typename T> using mat3 = glm::mat<3, 3, T>;
 template <typename T> using mat4 = glm::mat<4, 4, T>;
 
 template <typename T> using mat3x2 = glm::mat<3, 2, T>;
+
+#endif // GSPLAT_CUDA_TYPES_H

--- a/gsplat/cuda/csrc/types.cuh
+++ b/gsplat/cuda/csrc/types.cuh
@@ -6,59 +6,40 @@
 
 // Shim types to extract vector types from scalar types
 // e.g. using vec3f = Float3<float>::type; yields float3
-template <typename T>
-struct Float3 {};
-template <>
-struct Float3<float> {
+template <typename T> struct Float3 {};
+template <> struct Float3<float> {
     typedef float3 type;
 };
-template <>
-struct Float3<double> {
+template <> struct Float3<double> {
     typedef double3 type;
 };
 
-template <typename T>
-struct Float4 {};
-template <>
-struct Float4<float> {
+template <typename T> struct Float4 {};
+template <> struct Float4<float> {
     typedef float4 type;
 };
-template <>
-struct Float4<double> {
+template <> struct Float4<double> {
     typedef double4 type;
 };
 
-template <typename T>
-struct Float2 {};
-template <>
-struct Float2<float> {
+template <typename T> struct Float2 {};
+template <> struct Float2<float> {
     typedef float2 type;
 };
-template <>
-struct Float2<double> {
+template <> struct Float2<double> {
     typedef double2 type;
 };
 
+template <typename T> using vec2 = glm::vec<2, T>;
 
+template <typename T> using vec3 = glm::vec<3, T>;
 
-template <typename T>
-using vec2 = glm::vec<2, T>;
+template <typename T> using vec4 = glm::vec<4, T>;
 
-template <typename T>
-using vec3 = glm::vec<3, T>;
+template <typename T> using mat2 = glm::mat<2, 2, T>;
 
-template <typename T>
-using vec4 = glm::vec<4, T>;
+template <typename T> using mat3 = glm::mat<3, 3, T>;
 
-template <typename T>
-using mat2 = glm::mat<2, 2, T>;
+template <typename T> using mat4 = glm::mat<4, 4, T>;
 
-template <typename T>
-using mat3 = glm::mat<3, 3, T>;
-
-template <typename T>
-using mat4 = glm::mat<4, 4, T>;
-
-template <typename T>
-using mat3x2 = glm::mat<3, 2, T>;
-
+template <typename T> using mat3x2 = glm::mat<3, 2, T>;


### PR DESCRIPTION
To embrace half in the future, and because there is no `half3` in native CUDA, we here migrate from `float3` to `glm::vec3` which has been templated for `half`.

Speed wise I didn't see a big change.

Before:
<img width="552" alt="Screenshot 2024-07-06 at 9 25 58 AM" src="https://github.com/nerfstudio-project/gsplat/assets/10151885/3bc3ee98-7b47-46bb-ba9e-56025eda4c80">


After:
<img width="540" alt="Screenshot 2024-07-06 at 9 25 50 AM" src="https://github.com/nerfstudio-project/gsplat/assets/10151885/2aa4527f-62bf-4ac1-856b-88dd3137bebc">
