### PR TITLE
Add optional masks in `rasterize_to_pixels()` to support Grendel

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -379,6 +379,7 @@ def rasterize_to_pixels(
     isect_offsets: Tensor,  # [C, tile_height, tile_width]
     flatten_ids: Tensor,  # [n_isects]
     backgrounds: Optional[Tensor] = None,  # [C, channels]
+    masks: Optional[Tensor] = None,  # [C, tile_height, tile_width]
     packed: bool = False,
     absgrad: bool = False,
 ) -> Tuple[Tensor, Tensor]:
@@ -395,6 +396,7 @@ def rasterize_to_pixels(
         isect_offsets: Intersection offsets outputs from `isect_offset_encode()`. [C, tile_height, tile_width]
         flatten_ids: The global flatten indices in [C * N] or [nnz] from  `isect_tiles()`. [n_isects]
         backgrounds: Background colors. [C, channels]. Default: None.
+        masks: Optional masks to support Grendel's local workload strategy. [C, tile_height, tile_width]. Default: None.
         packed: If True, the input tensors are expected to be packed with shape [nnz, ...]. Default: False.
         absgrad: If True, the backward pass will compute a `.absgrad` attribute for `means2d`. Default: False.
 
@@ -422,6 +424,9 @@ def rasterize_to_pixels(
     if backgrounds is not None:
         assert backgrounds.shape == (C, colors.shape[-1]), backgrounds.shape
         backgrounds = backgrounds.contiguous()
+    if masks is not None:
+        assert masks.shape[0] == C, masks.shape
+        masks = masks.contiguous()
 
     # Pad the channels to the nearest supported number if necessary
     channels = colors.shape[-1]
@@ -484,6 +489,7 @@ def rasterize_to_pixels(
         colors.contiguous(),
         opacities.contiguous(),
         backgrounds,
+        masks,
         image_width,
         image_height,
         tile_size,
@@ -814,6 +820,7 @@ class _RasterizeToPixels(torch.autograd.Function):
         colors: Tensor,  # [C, N, D]
         opacities: Tensor,  # [C, N]
         backgrounds: Tensor,  # [C, D], Optional
+        masks: Tensor,  # [C, tile_height, tile_width], Optional
         width: int,
         height: int,
         tile_size: int,
@@ -829,6 +836,7 @@ class _RasterizeToPixels(torch.autograd.Function):
             colors,
             opacities,
             backgrounds,
+            masks,
             width,
             height,
             tile_size,
@@ -842,6 +850,7 @@ class _RasterizeToPixels(torch.autograd.Function):
             colors,
             opacities,
             backgrounds,
+            masks,
             isect_offsets,
             flatten_ids,
             render_alphas,
@@ -868,6 +877,7 @@ class _RasterizeToPixels(torch.autograd.Function):
             colors,
             opacities,
             backgrounds,
+            masks,
             isect_offsets,
             flatten_ids,
             render_alphas,
@@ -890,6 +900,7 @@ class _RasterizeToPixels(torch.autograd.Function):
             colors,
             opacities,
             backgrounds,
+            masks,
             width,
             height,
             tile_size,
@@ -918,6 +929,7 @@ class _RasterizeToPixels(torch.autograd.Function):
             v_colors,
             v_opacities,
             v_backgrounds,
+            None,
             None,
             None,
             None,

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -396,7 +396,7 @@ def rasterize_to_pixels(
         isect_offsets: Intersection offsets outputs from `isect_offset_encode()`. [C, tile_height, tile_width]
         flatten_ids: The global flatten indices in [C * N] or [nnz] from  `isect_tiles()`. [n_isects]
         backgrounds: Background colors. [C, channels]. Default: None.
-        masks: Optional masks to support Grendel's local workload strategy. [C, tile_height, tile_width]. Default: None.
+        masks: Optional tile mask to skip rendering GS to masked tiles. [C, tile_height, tile_width]. Default: None.
         packed: If True, the input tensors are expected to be packed with shape [nnz, ...]. Default: False.
         absgrad: If True, the backward pass will compute a `.absgrad` attribute for `means2d`. Default: False.
 
@@ -425,7 +425,7 @@ def rasterize_to_pixels(
         assert backgrounds.shape == (C, colors.shape[-1]), backgrounds.shape
         backgrounds = backgrounds.contiguous()
     if masks is not None:
-        assert masks.shape[0] == C, masks.shape
+        assert masks.shape == isect_offsets.shape, masks.shape
         masks = masks.contiguous()
 
     # Pad the channels to the nearest supported number if necessary

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -119,6 +119,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rasterize_to_pixels_fwd_
     const torch::Tensor &colors,                    // [C, N, D]
     const torch::Tensor &opacities,                 // [N]
     const at::optional<torch::Tensor> &backgrounds, // [C, D]
+    const at::optional<torch::Tensor> &mask,        // [C, tile_height, tile_width]
     // image size
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
@@ -134,6 +135,7 @@ rasterize_to_pixels_bwd_tensor(
     const torch::Tensor &colors,                    // [C, N, 3]
     const torch::Tensor &opacities,                 // [N]
     const at::optional<torch::Tensor> &backgrounds, // [C, 3]
+    const at::optional<torch::Tensor> &mask,        // [C, tile_height, tile_width]
     // image size
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections

--- a/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
@@ -58,7 +58,7 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     }
 
     // when the mask is provided, do nothing and return if
-    // this tile is labeled as not local
+    // this tile is labeled as False
     if (masks != nullptr && !masks[tile_id]) {
         return;
     }

--- a/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
@@ -20,6 +20,7 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     const S *__restrict__ colors,        // [C, N, COLOR_DIM] or [nnz, COLOR_DIM]
     const S *__restrict__ opacities,     // [C, N] or [nnz]
     const S *__restrict__ backgrounds,   // [C, COLOR_DIM] or [nnz, COLOR_DIM]
+    const bool *__restrict__ masks,      // [C, tile_height, tile_width]
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     const uint32_t tile_width, const uint32_t tile_height,
     const int32_t *__restrict__ tile_offsets, // [C, tile_height, tile_width]
@@ -51,6 +52,15 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     v_render_alphas += camera_id * image_height * image_width;
     if (backgrounds != nullptr) {
         backgrounds += camera_id * COLOR_DIM;
+    }
+    if (masks != nullptr) {
+        masks += camera_id * tile_height * tile_width;
+    }
+
+    // when the mask is provided, do nothing and return if
+    // this tile is labeled as not local
+    if (masks != nullptr && !masks[tile_id]) {
+        return;
     }
 
     const S px = (S)j + 0.5f;
@@ -257,6 +267,7 @@ call_kernel_with_dim(
     const torch::Tensor &colors,                    // [C, N, 3] or [nnz, 3]
     const torch::Tensor &opacities,                 // [C, N] or [nnz]
     const at::optional<torch::Tensor> &backgrounds, // [C, 3]
+    const at::optional<torch::Tensor> &masks,       // [C, tile_height, tile_width]
     // image size
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
@@ -284,6 +295,9 @@ call_kernel_with_dim(
     CHECK_INPUT(v_render_alphas);
     if (backgrounds.has_value()) {
         CHECK_INPUT(backgrounds.value());
+    }
+    if (masks.has_value()) {
+        CHECK_INPUT(masks.value());
     }
 
     bool packed = means2d.dim() == 2;
@@ -329,6 +343,7 @@ call_kernel_with_dim(
                 colors.data_ptr<float>(), opacities.data_ptr<float>(),
                 backgrounds.has_value() ? backgrounds.value().data_ptr<float>()
                                         : nullptr,
+                masks.has_value() ? masks.value().data_ptr<bool>(): nullptr,
                 image_width, image_height, tile_size, tile_width, tile_height,
                 tile_offsets.data_ptr<int32_t>(), flatten_ids.data_ptr<int32_t>(),
                 render_alphas.data_ptr<float>(), last_ids.data_ptr<int32_t>(),
@@ -352,6 +367,7 @@ rasterize_to_pixels_bwd_tensor(
     const torch::Tensor &colors,                    // [C, N, 3] or [nnz, 3]
     const torch::Tensor &opacities,                 // [C, N] or [nnz]
     const at::optional<torch::Tensor> &backgrounds, // [C, 3]
+    const at::optional<torch::Tensor> &masks,       // [C, tile_height, tile_width]
     // image size
     const uint32_t image_width, const uint32_t image_height, const uint32_t tile_size,
     // intersections
@@ -372,7 +388,7 @@ rasterize_to_pixels_bwd_tensor(
 #define __GS__CALL_(N)                                                                 \
     case N:                                                                            \
         return call_kernel_with_dim<N>(                                                \
-            means2d, conics, colors, opacities, backgrounds, image_width,              \
+            means2d, conics, colors, opacities, backgrounds, masks, image_width,       \
             image_height, tile_size, tile_offsets, flatten_ids, render_alphas,         \
             last_ids, v_render_colors, v_render_alphas, absgrad);
 

--- a/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
@@ -57,11 +57,11 @@ __global__ void rasterize_to_pixels_fwd_kernel(
     bool inside = (i < image_height && j < image_width);
     bool done = !inside;
 
-    // when the mask is provided, render 0.0 and return if this tile
-    // is labeled as not local
+    // when the mask is provided, render the background color and return
+    // if this tile is labeled as False
     if (masks != nullptr && inside && !masks[tile_id]) {
         for (uint32_t k = 0; k < COLOR_DIM; ++k) {
-            render_colors[pix_id * COLOR_DIM + k] = 0.0f;
+            render_colors[pix_id * COLOR_DIM + k] = backgrounds == nullptr ? 0.0f : backgrounds[k];
         }
         return;
     }
@@ -73,7 +73,7 @@ __global__ void rasterize_to_pixels_fwd_kernel(
     int32_t range_end =
         (camera_id == C - 1) && (tile_id == tile_width * tile_height - 1)
             ? n_isects
-            : tile_offsets[tile_id + 1];
+            : tile_offsets[tile_id + 1];A
     const uint32_t block_size = block.size();
     uint32_t num_batches = (range_end - range_start + block_size - 1) / block_size;
 

--- a/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
@@ -73,7 +73,7 @@ __global__ void rasterize_to_pixels_fwd_kernel(
     int32_t range_end =
         (camera_id == C - 1) && (tile_id == tile_width * tile_height - 1)
             ? n_isects
-            : tile_offsets[tile_id + 1];A
+            : tile_offsets[tile_id + 1];
     const uint32_t block_size = block.size();
     uint32_t num_batches = (range_end - range_start + block_size - 1) / block_size;
 


### PR DESCRIPTION
Now `rasterize_to_pixels()` supports an optional argument `masks` to identify its local workload in a multi-GPU scenario, so it can better work with [Grendel](https://github.com/nyu-systems/Grendel-GS). When a tile is marked as false:
- In the forward pass, all channels of each pixel in that tile are set to zero.
- In the backward pass, no operations are performed on that tile.