### PR TITLE
Simplify `tyro` usage in `simple_trainer.py`

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -13,7 +13,7 @@ scikit-learn
 tqdm
 torchmetrics[image]
 opencv-python
-tyro
+tyro>=0.8.8
 Pillow
 tensorboard
 pyyaml

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -943,19 +943,7 @@ if __name__ == "__main__":
             ),
         ),
     }
-
-    # We're going to do some advanced tyro stuff to make the CLI nicer.
-    #
-    # (1) Build a union type that lets us choose between the two config
-    # objects.
-    subcommand_type = tyro.extras.subcommand_type_from_defaults(
-        defaults={k: v[1] for k, v in configs.items()},
-        descriptions={k: v[0] for k, v in configs.items()},
-    )
-    # (2) Don't let the user override the strategy type provided by the default that they choose.
-    subcommand_type = tyro.conf.configure(tyro.conf.AvoidSubcommands)(subcommand_type)
-
-    cfg = tyro.cli(subcommand_type)
+    cfg = tyro.extras.overridable_config_cli(configs)
     cfg.adjust_steps(cfg.steps_scaler)
 
     # try import extra dependencies

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -933,7 +933,7 @@ if __name__ == "__main__":
             ),
         ),
         "mcmc": (
-            "Gaussian splatting training using densification  from the paper '3D Gaussian Splatting as Markov Chain Monte Carlo'.",
+            "Gaussian splatting training using densification from the paper '3D Gaussian Splatting as Markov Chain Monte Carlo'.",
             Config(
                 init_opa=0.5,
                 init_scale=0.1,

--- a/gsplat/compression/png_compression.py
+++ b/gsplat/compression/png_compression.py
@@ -368,7 +368,9 @@ def _compress_kmeans(
     maxs = torch.max(centroids)
     centroids_norm = (centroids - mins) / (maxs - mins)
     centroids_norm = centroids_norm.detach().cpu().numpy()
-    centroids_quant = (centroids_norm * (2**quantization - 1)).round().astype(np.uint8)
+    centroids_quant = (
+        (centroids_norm * (2**quantization - 1)).round().astype(np.uint8)
+    )
     labels = labels.astype(np.uint16)
 
     npz_dict = {

--- a/gsplat/compression/png_compression.py
+++ b/gsplat/compression/png_compression.py
@@ -368,9 +368,7 @@ def _compress_kmeans(
     maxs = torch.max(centroids)
     centroids_norm = (centroids - mins) / (maxs - mins)
     centroids_norm = centroids_norm.detach().cpu().numpy()
-    centroids_quant = (
-        (centroids_norm * (2**quantization - 1)).round().astype(np.uint8)
-    )
+    centroids_quant = (centroids_norm * (2**quantization - 1)).round().astype(np.uint8)
     labels = labels.astype(np.uint16)
 
     npz_dict = {


### PR DESCRIPTION
The subcommand pattern we were using is really common, but required some magic. I moved this to a helper inside of `tyro`. (unfortunately this requires upgrading)