### PR TITLE
correct distCoeffs of SIMPLE_RADIAL

### DIFF
--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -86,7 +86,7 @@ class Parser:
                 params = np.empty(0, dtype=np.float32)
                 camtype = "perspective"
             if type_ == 2 or type_ == "SIMPLE_RADIAL":
-                params = np.array([cam.k1], dtype=np.float32)
+                params = np.array([cam.k1, 0.0, 0.0, 0.0], dtype=np.float32)
                 camtype = "perspective"
             elif type_ == 3 or type_ == "RADIAL":
                 params = np.array([cam.k1, cam.k2, 0.0, 0.0], dtype=np.float32)


### PR DESCRIPTION
Hi, there is a typo of the distCoeffs of "SIMPLE_RADIAL", which will cause
```
cv2.error:
OpenCV(4.7.0) /home/conda/feedstock_root/build_artifacts/libopencv_1674428302344/work/modules/calib3d/src/undistort.dispatch.cpp:411: error: (-215:Assertion failed) CV_IS_MAT(_distCoeffs) && (_distCoeffs->rows == 1 || _distCoeffs->cols == 1) && (_distCoeffs->rows*_distCoeffs->cols == 4 || _distCoeffs->rows*_distCoeffs->cols == 5 || _distCoeffs->rows*_distCoeffs->cols == 8 || _distCoeffs->rows*_distCoeffs->cols == 12 || _distCoeffs->rows*_distCoeffs->cols == 14) in function 'cvUndistortPointsInternal'
```
I have fixed it by padding the params.