### PR TITLE
Add np.random.choice fallback for many Gaussians exceeding torch.multinomial limits

### DIFF
--- a/gsplat/strategy/ops.py
+++ b/gsplat/strategy/ops.py
@@ -35,7 +35,9 @@ def _multinomial_sample(weights: Tensor, n: int, replacement: bool = True) -> Te
         # Fallback to numpy.random.choice for larger element spaces
         weights = weights / weights.sum()
         weights_np = weights.detach().cpu().numpy()
-        sampled_idxs_np = np.random.choice(num_elements, size=n, p=weights_np, replace=replacement)
+        sampled_idxs_np = np.random.choice(
+            num_elements, size=n, p=weights_np, replace=replacement
+        )
         sampled_idxs = torch.from_numpy(sampled_idxs_np)
 
         # Return the sampled indices on the original device


### PR DESCRIPTION
The current MCMCStrategy (relocate or sample_add) raises an error due to `torch.multinomial` when the number of Gaussians exceeds 2^24 = 16,777,216 (e.g., torch version is 2.0.1+cu117).

```
... gsplat/strategy/mcmc.py", line 158, in _relocate_gs
    relocate(
  File "/usr/local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File ".../.local/lib/python3.10/site-packages/gsplat/strategy/ops.py", line 228, in relocate
    sampled_idxs = torch.multinomial(probs, n, replacement=True)
RuntimeError: number of categories cannot exceed 2^24
```

This Pull Request introduces a fallback mechanism in the _multinomial_sample function to handle cases where the number of elements exceeds the limit. This is achieved by switching to np.random.choice when necessary, ensuring that the function can handle large element sets without encountering runtime errors.
Although np.random.choice may be slightly slower than torch.multinomial, it is not expected to become a bottleneck as long as refine_every is sufficiently large (e.g., 100; default).