### PR TITLE
automatically add the micosoft visual studio compiler binary to the environment path

### DIFF
--- a/gsplat/cuda/_backend.py
+++ b/gsplat/cuda/_backend.py
@@ -10,6 +10,7 @@ from torch.utils.cpp_extension import (
     _import_module_from_library,
     load,
 )
+import sys, warnings
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 NO_FAST_MATH = os.getenv("NO_FAST_MATH", "0") == "1"
@@ -19,6 +20,38 @@ if not MAX_JOBS:
     need_to_unset_max_jobs = True
     os.environ["MAX_JOBS"] = "10"
 
+def _get_extra_path_for_msvc():
+    "copied from cupy/cuda/compiler.py"
+
+    cl_exe = shutil.which('cl.exe')
+    if cl_exe:
+        # The compiler is already on PATH, no extra path needed.
+        return None
+    try:
+        import setuptools
+        import platform
+        vctools = setuptools.msvc.EnvironmentInfo(platform.machine()).VCTools
+    except Exception as e:
+        warnings.warn(f'Failed to auto-detect cl.exe path: {type(e)}: {e}')
+        return None
+
+    for path in vctools:
+        cl_exe = os.path.join(path, 'cl.exe')
+        if os.path.exists(cl_exe):
+            return path
+    warnings.warn(f'cl.exe could not be found in {vctools}')
+    return None
+
+def add_msvc_path():
+    """Add MSVC path to PATH."""
+    extra_path = _get_extra_path_for_msvc()
+    if extra_path is not None:
+        # add path to PATH
+        os.environ['PATH'] = os.pathsep.join([extra_path, os.environ['PATH']])
+    assert shutil.which('cl.exe') is not None, "cl.exe not found in PATH"
+
+if sys.platform == "win32":
+    add_msvc_path()
 
 def load_extension(
     name,


### PR DESCRIPTION
In some case gsplat needs to compile cuda/c++ code on the fly (just-in-time compilation), 
to handle different number of color channels for example, like done in the test `test_rasterize_to_pixels` when using `channels=128`. 

In that case `cl.exe` needs to be on the path when on windows in order for pytorch to be able to do the compilation.
One can follow the step documented [here](https://github.com/nerfstudio-project/gsplat/blob/main/docs/INSTALL_WIN.md)
but that requires a manual step each time time one wants to use gsplat, which is not convenient.

We can instead add the folder automatically to the path at runtime using a mechanism used in Cupy to discover the folder that contains the `cl.exe` file.

Ideally this mechanism would be implemented in pytorch, but we can implement it in gsplat in the mean time. 
