### PR TITLE
Fix scaling image space grads

### DIFF
--- a/gsplat/strategy/default.py
+++ b/gsplat/strategy/default.py
@@ -210,8 +210,7 @@ class DefaultStrategy(Strategy):
             grads = info["means2d"].absgrad.clone()
         else:
             grads = info["means2d"].grad.clone()
-        grads[..., 0] *= info["width"] / 2.0 * info["n_cameras"]
-        grads[..., 1] *= info["height"] / 2.0 * info["n_cameras"]
+        grads *= max(info["width"], info["height"]) / 2.0 * info["n_cameras"]
 
         # initialize state on the first run
         n_gaussian = len(list(params.values())[0])


### PR DESCRIPTION
I think the correct implementation when scaling grads is to multiply the `max(width, height)` (unless the training image aspect ratio is not 1). There is no good reason to scale them separately and then computes the norm for densification purpose. (Maybe a better choice than `max(width, height)` is `focal`, but again x,y dimension grad should be scaled together.)

See splatfacto implementation: https://github.com/nerfstudio-project/nerfstudio/blob/main/nerfstudio/models/splatfacto.py#L472

I know the original Inria implementation seems to be scaling grads separately because they convert points into NDC instead of image space. 

