### PR TITLE
Add an option to disable world space normalization in examples/simple_trainer.py

### DIFF
--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -51,6 +51,8 @@ class Config:
     patch_size: Optional[int] = None
     # A global scaler that applies to the scene size related parameters
     global_scale: float = 1.0
+    # Normalize the world space
+    normalize_world_space: bool = True
 
     # Port for the viewer server
     port: int = 8080
@@ -268,7 +270,7 @@ class Runner:
         self.parser = Parser(
             data_dir=cfg.data_dir,
             factor=cfg.data_factor,
-            normalize=True,
+            normalize=cfg.normalize_world_space,
             test_every=cfg.test_every,
         )
         self.trainset = Dataset(


### PR DESCRIPTION
Add an option to disable world space normalization in simple_trainer