### PR TITLE
Add option to render camera trajectory as an ellipse.

### DIFF
--- a/examples/benchmarks/basic.sh
+++ b/examples/benchmarks/basic.sh
@@ -1,6 +1,7 @@
 SCENE_DIR="data/360_v2"
 RESULT_DIR="results/benchmark"
 SCENE_LIST="garden bicycle stump bonsai counter kitchen room" # treehill flowers
+RENDER_TRAJ_PATH="ellipse"
 
 for SCENE in $SCENE_LIST;
 do
@@ -14,6 +15,7 @@ do
 
     # train without eval
     CUDA_VISIBLE_DEVICES=0 python simple_trainer.py default --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
+        --render_traj_path $RENDER_TRAJ_PATH \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
 
@@ -21,6 +23,7 @@ do
     for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
     do
         CUDA_VISIBLE_DEVICES=0 python simple_trainer.py default --disable_viewer --data_factor $DATA_FACTOR \
+            --render_traj_path $RENDER_TRAJ_PATH \
             --data_dir data/360_v2/$SCENE/ \
             --result_dir $RESULT_DIR/$SCENE/ \
             --ckpt $CKPT

--- a/examples/benchmarks/mcmc.sh
+++ b/examples/benchmarks/mcmc.sh
@@ -1,6 +1,7 @@
 SCENE_DIR="data/360_v2"
 RESULT_DIR="results/benchmark_mcmc_1M"
 SCENE_LIST="garden bicycle stump bonsai counter kitchen room" # treehill flowers
+RENDER_TRAJ_PATH="ellipse"
 
 CAP_MAX=1000000
 
@@ -15,20 +16,22 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
+        --render_traj_path $RENDER_TRAJ_PATH \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
 
     # run eval and render
-    for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
-    do
-        CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
-            --strategy.cap-max $CAP_MAX \
-            --data_dir $SCENE_DIR/$SCENE/ \
-            --result_dir $RESULT_DIR/$SCENE/ \
-            --ckpt $CKPT
-    done
+    # for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
+    # do
+    #     CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+    #         --strategy.cap-max $CAP_MAX \
+    #         --render_traj_path $RENDER_TRAJ_PATH \
+    #         --data_dir $SCENE_DIR/$SCENE/ \
+    #         --result_dir $RESULT_DIR/$SCENE/ \
+    #         --ckpt $CKPT
+    # done
 done
 
 

--- a/examples/benchmarks/mcmc.sh
+++ b/examples/benchmarks/mcmc.sh
@@ -16,22 +16,22 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
         --render_traj_path $RENDER_TRAJ_PATH \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
 
     # run eval and render
-    # for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
-    # do
-    #     CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
-    #         --strategy.cap-max $CAP_MAX \
-    #         --render_traj_path $RENDER_TRAJ_PATH \
-    #         --data_dir $SCENE_DIR/$SCENE/ \
-    #         --result_dir $RESULT_DIR/$SCENE/ \
-    #         --ckpt $CKPT
-    # done
+    for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
+    do
+        CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+            --strategy.cap-max $CAP_MAX \
+            --render_traj_path $RENDER_TRAJ_PATH \
+            --data_dir $SCENE_DIR/$SCENE/ \
+            --result_dir $RESULT_DIR/$SCENE/ \
+            --ckpt $CKPT
+    done
 done
 
 

--- a/examples/datasets/traj.py
+++ b/examples/datasets/traj.py
@@ -90,7 +90,7 @@ def generate_ellipse_path_z(
     ind_up = np.argmax(np.abs(avg_up))
     up = np.eye(3)[ind_up] * np.sign(avg_up[ind_up])
 
-    return np.stack([viewmatrix(p - center, up, p) for p in positions])
+    return np.stack([viewmatrix(center - p, up, p) for p in positions])
 
 
 def generate_ellipse_path_y(

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -65,7 +65,7 @@ class Config:
     # Number of training steps
     max_steps: int = 30_000
     # Steps to evaluate the model
-    eval_steps: List[int] = field(default_factory=lambda: [1_000, 7_000, 30_000])
+    eval_steps: List[int] = field(default_factory=lambda: [7_000, 30_000])
     # Steps to save the model
     save_steps: List[int] = field(default_factory=lambda: [7_000, 30_000])
 

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -923,7 +923,7 @@ def main(local_rank: int, world_rank, world_size: int, cfg: Config):
             runner.splats[k].data = torch.cat([ckpt["splats"][k] for ckpt in ckpts])
         step = ckpts[0]["step"]
         runner.eval(step=step)
-        # runner.render_traj(step=step)
+        runner.render_traj(step=step)
         if cfg.compression is not None:
             runner.run_compression(step=step)
     else:


### PR DESCRIPTION
The default camera trajectory rendering logic interpolates the training poses to make a video. For many MipNeRF360 scenes, this results in an unusable video. This PR introduces a new camera trajectory option called `ellipse` and renames the original trajectory option as `interp`. 

https://github.com/user-attachments/assets/6c59eb2c-7da7-4c67-89bf-715c5f8006b3

https://github.com/user-attachments/assets/fcd4f810-5216-4201-914f-d6f72049a3e2

