### PR TITLE
Fused differentiable SSIM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "gsplat/cuda/csrc/third_party/glm"]
 	path = gsplat/cuda/csrc/third_party/glm
 	url = https://github.com/g-truc/glm.git
+[submodule "third_party/fused-ssim"]
+	path = third_party/fused-ssim
+	url = git@github.com:rahul-goel/fused-ssim.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "gsplat/cuda/csrc/third_party/glm"]
 	path = gsplat/cuda/csrc/third_party/glm
 	url = https://github.com/g-truc/glm.git
-[submodule "third_party/fused-ssim"]
-	path = third_party/fused-ssim
-	url = git@github.com:rahul-goel/fused-ssim.git

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -17,3 +17,4 @@ tyro>=0.8.8
 Pillow
 tensorboard
 pyyaml
+git+https://github.com/rahul-goel/fused-ssim@84422e0da94c516220eb3acedb907e68809e9e01

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -20,6 +20,7 @@ from torch import Tensor
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.tensorboard import SummaryWriter
 from torchmetrics.image import PeakSignalNoiseRatio, StructuralSimilarityIndexMeasure
+from fused_ssim import fused_ssim
 from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 from typing_extensions import Literal, assert_never
 from utils import AppearanceOptModule, CameraOptModule, knn, rgb_to_sh, set_random_seed
@@ -552,8 +553,8 @@ class Runner:
 
             # loss
             l1loss = F.l1_loss(colors, pixels)
-            ssimloss = 1.0 - self.ssim(
-                pixels.permute(0, 3, 1, 2), colors.permute(0, 3, 1, 2)
+            ssimloss = 1.0 - fused_ssim(
+                colors.permute(0, 3, 1, 2), pixels.permute(0, 3, 1, 2), padding="valid"
             )
             loss = l1loss * (1.0 - cfg.ssim_lambda) + ssimloss * cfg.ssim_lambda
             if cfg.depth_loss:


### PR DESCRIPTION
I've made my Fused SSIM (from Taming 3DGS) implementation public: https://github.com/rahul-goel/fused-ssim. It is really beneficial to use this when the number of gaussians is less since SSIM has a major overhead. Currently, the pixel permutation will also take a lot of time but it is how the rasterizer is implemented and it will require a big re-work so I'm avoiding it.

I've tested the simple trainer on till 7k iterations on the garden scene from Mip-NeRF360 dataset. Using fused-ssim brings down the training time from 5:52 to 4:54 on my RTX 3080Ti.

I've added it as a submodule. But the instructions to install this submodule have not been added yet. Please let me know what exactly to do for it.