### PR TITLE
Make download script work on Windows, too

### DIFF
--- a/examples/datasets/download_dataset.py
+++ b/examples/datasets/download_dataset.py
@@ -34,9 +34,9 @@ class DownloadData:
 
         # download
         download_command = [
-            "wget",
-            "-P",
-            str(self.save_dir / dataset_rename_map[dataset]),
+            "curl",
+            "-o",
+            str(self.save_dir / dataset_rename_map[dataset] / file_name),
             urls[dataset],
         ]
         try:
@@ -47,12 +47,21 @@ class DownloadData:
 
         # if .zip
         if Path(urls[dataset]).suffix == ".zip":
-            extract_command = [
-                "unzip",
-                self.save_dir / dataset_rename_map[dataset] / file_name,
-                "-d",
-                self.save_dir / dataset_rename_map[dataset],
-            ]
+            if os.name == "nt":  # Windows doesn't have 'unzip' but 'tar' works
+                extract_command = [
+                    "tar",
+                    "-xvf",
+                    self.save_dir / dataset_rename_map[dataset] / file_name,
+                    "-C",
+                    self.save_dir / dataset_rename_map[dataset],
+                ]
+            else:
+                extract_command = [
+                    "unzip",
+                    self.save_dir / dataset_rename_map[dataset] / file_name,
+                    "-d",
+                    self.save_dir / dataset_rename_map[dataset],
+                ]
         # if .tar
         else:
             extract_command = [


### PR DESCRIPTION
1. Recent versions of Windows 10 don't have `wget` but do have `curl`, so now we can download files across the major platforms.
2. Windows 10 also doesn't have the `unzip` program, but a version of `tar` (apparently bsdtar), which supports `.zip` files (unlike the GNU tar on the Linux box I tested on). So need to use different code paths depending on platform.

Tested on Windows 10 22H2 and Linux.