### PR TITLE
Make commands easier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ To install gsplat on Windows, please check [this instruction](docs/INSTALL_WIN.m
 This repo comes with a standalone script that reproduces the official Gaussian Splatting with exactly the same performance on PSNR, SSIM, LPIPS, and converged number of Gaussians. Powered by gsplat’s efficient CUDA implementation, the training takes up to **4x less GPU memory** with up to **15% less time** to finish than the official implementation. Full report can be found [here](https://docs.gsplat.studio/main/tests/eval.html).
 
 ```bash
-# under examples/
-pip install -r requirements.txt
+pip install -r examples/requirements.txt
 # download mipnerf_360 benchmark data
-python datasets/download_dataset.py
+python examples/datasets/download_dataset.py
 # run batch evaluation
-bash benchmarks/basic.sh
+bash examples/benchmarks/basic.sh
 ```
 
 ## Examples


### PR DESCRIPTION
Not sure if this is to your liking, but I prefer handling everything from the root. You can simply paste these commands into Bash and run them. It streamlines the process.

If this approach doesn't align with your preferences, feel free to disregard this PR.