### PR TITLE
Selective Adam

### DIFF
--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -764,7 +764,7 @@ class Runner:
             # optimize
             for optimizer in self.optimizers.values():
                 if cfg.visible_adam:
-                    optimizer.step(visibility_mask, gaussian_cnt)
+                    optimizer.step(visibility_mask)
                 else:
                     optimizer.step()
                 optimizer.zero_grad(set_to_none=True)

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -40,7 +40,7 @@ from gsplat.compression import PngCompression
 from gsplat.distributed import cli
 from gsplat.rendering import rasterization
 from gsplat.strategy import DefaultStrategy, MCMCStrategy
-from gsplat.cuda._wrapper import SelectiveAdam
+from gsplat.optimizers import SelectiveAdam
 
 
 @dataclass
@@ -754,7 +754,9 @@ class Runner:
             if cfg.visible_adam:
                 gaussian_cnt = self.splats.means.shape[0]
                 if cfg.packed:
-                    visibility_mask = torch.zeros_like(self.splats["opacities"], dtype=bool)
+                    visibility_mask = torch.zeros_like(
+                        self.splats["opacities"], dtype=bool
+                    )
                     visibility_mask.scatter_(0, info["gaussian_ids"], 1)
                 else:
                     visibility_mask = (info["radii"] > 0).any(0)

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -752,8 +752,12 @@ class Runner:
                     )
 
             if cfg.visible_adam:
-                visibility_mask = info["radii"] > 0
                 gaussian_cnt = self.splats.means.shape[0]
+                if cfg.packed:
+                    visibility_mask = torch.zeros_like(self.splats["opacities"], dtype=bool)
+                    visibility_mask.scatter_(0, info["gaussian_ids"], 1)
+                else:
+                    visibility_mask = (info["radii"] > 0).any(0)
 
             # optimize
             for optimizer in self.optimizers.values():

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -40,7 +40,7 @@ from gsplat.compression import PngCompression
 from gsplat.distributed import cli
 from gsplat.rendering import rasterization
 from gsplat.strategy import DefaultStrategy, MCMCStrategy
-from gsplat.cuda._wrapper import SparseGaussianAdam
+from gsplat.cuda._wrapper import SelectiveAdam
 
 
 @dataclass
@@ -116,6 +116,8 @@ class Config:
     packed: bool = False
     # Use sparse gradients for optimization. (experimental)
     sparse_grad: bool = False
+    # Use visible adam from Taming 3DGS. (experimental)
+    visible_adam: bool = False
     # Anti-aliasing in rasterization. Might slightly hurt quantitative metrics.
     antialiased: bool = False
 
@@ -192,6 +194,7 @@ def create_splats_with_optimizers(
     scene_scale: float = 1.0,
     sh_degree: int = 3,
     sparse_grad: bool = False,
+    visible_adam: bool = False,
     batch_size: int = 1,
     feature_dim: Optional[int] = None,
     device: str = "cuda",
@@ -248,17 +251,15 @@ def create_splats_with_optimizers(
     # Note that this would not make the training exactly equivalent, see
     # https://arxiv.org/pdf/2402.18824v1
     BS = batch_size * world_size
-    # optimizers = {
-    #     name: (torch.optim.SparseAdam if sparse_grad else torch.optim.Adam)(
-    #         [{"params": splats[name], "lr": lr * math.sqrt(BS), "name": name}],
-    #         eps=1e-15 / math.sqrt(BS),
-    #         # TODO: check betas logic when BS is larger than 10 betas[0] will be zero.
-    #         betas=(1 - BS * (1 - 0.9), 1 - BS * (1 - 0.999)),
-    #     )
-    #     for name, _, lr in params
-    # }
+    optimizer_class = None
+    if sparse_grad:
+        optimizer_class = torch.optim.SparseAdam
+    elif visible_adam:
+        optimizer_class = SelectiveAdam
+    else:
+        optimizer_class = torch.optim.Adam
     optimizers = {
-        name: SparseGaussianAdam(
+        name: optimizer_class(
             [{"params": splats[name], "lr": lr * math.sqrt(BS), "name": name}],
             eps=1e-15 / math.sqrt(BS),
             # TODO: check betas logic when BS is larger than 10 betas[0] will be zero.
@@ -326,6 +327,7 @@ class Runner:
             scene_scale=self.scene_scale,
             sh_degree=cfg.sh_degree,
             sparse_grad=cfg.sparse_grad,
+            visible_adam=cfg.visible_adam,
             batch_size=cfg.batch_size,
             feature_dim=feature_dim,
             device=self.device,
@@ -749,10 +751,16 @@ class Runner:
                         is_coalesced=len(Ks) == 1,
                     )
 
+            if cfg.visible_adam:
+                visibility_mask = info["radii"] > 0
+                gaussian_cnt = self.splats.means.shape[0]
+
             # optimize
             for optimizer in self.optimizers.values():
-                N = self.splats.means.shape[0]
-                optimizer.step(info["radii"] > 0, N)
+                if cfg.visible_adam:
+                    optimizer.step(visibility_mask, gaussian_cnt)
+                else:
+                    optimizer.step()
                 optimizer.zero_grad(set_to_none=True)
             for optimizer in self.pose_optimizers:
                 optimizer.step()

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -15,6 +15,7 @@ def _make_lazy_cuda_func(name: str) -> Callable:
 
     return call_cuda
 
+
 def selective_adam_update(
     param: Tensor,
     param_grad: Tensor,
@@ -26,21 +27,12 @@ def selective_adam_update(
     b2: float,
     eps: float,
     N: int,
-    M: int
+    M: int,
 ) -> None:
     _make_lazy_cuda_func("selective_adam_update")(
-        param,
-        param_grad,
-        exp_avg,
-        exp_avg_sq,
-        tiles_touched,
-        lr,
-        b1,
-        b2,
-        eps,
-        N,
-        M
+        param, param_grad, exp_avg, exp_avg_sq, tiles_touched, lr, b1, b2, eps, N, M
     )
+
 
 def _make_lazy_cuda_obj(name: str) -> Any:
     # pylint: disable=import-outside-toplevel
@@ -1263,6 +1255,7 @@ class _SphericalHarmonics(torch.autograd.Function):
             v_dirs = None
         return None, v_dirs, v_coeffs, None
 
+
 ###### 2DGS ######
 def fully_fused_projection_2dgs(
     means: Tensor,  # [N, 3]
@@ -2001,34 +1994,3 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             None,
             None,
         )
-
-class SelectiveAdam(torch.optim.Adam):
-    def __init__(self, params, eps, betas):
-        super().__init__(params=params, eps=eps, betas=betas)
-    
-    @torch.no_grad()
-    def step(self, visibility, N):
-        for group in self.param_groups:
-            lr = group["lr"]
-            eps = group["eps"]
-            beta1, beta2 = group["betas"]
-
-            assert len(group["params"]) == 1, "more than one tensor in group"
-            param = group["params"][0]
-            if param.grad is None:
-                continue
-
-            # Lazy state initialization
-            state = self.state[param]
-            if len(state) == 0:
-                state['step'] = torch.tensor(0.0, dtype=torch.float32)
-                state['exp_avg'] = torch.zeros_like(param, memory_format=torch.preserve_format)
-                state['exp_avg_sq'] = torch.zeros_like(param, memory_format=torch.preserve_format)
-
-
-            stored_state = self.state.get(param, None)
-            exp_avg = stored_state["exp_avg"]
-            exp_avg_sq = stored_state["exp_avg_sq"]
-            M = param.numel() // N
-
-            selective_adam_update(param, param.grad, exp_avg, exp_avg_sq, visibility, lr, beta1, beta2, eps, N, M)

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -15,7 +15,7 @@ def _make_lazy_cuda_func(name: str) -> Callable:
 
     return call_cuda
 
-def adam_update(
+def selective_adam_update(
     param: Tensor,
     param_grad: Tensor,
     exp_avg: Tensor,
@@ -28,7 +28,7 @@ def adam_update(
     N: int,
     M: int
 ) -> None:
-    _make_lazy_cuda_func("adam_update")(
+    _make_lazy_cuda_func("selective_adam_update")(
         param,
         param_grad,
         exp_avg,
@@ -1263,6 +1263,7 @@ class _SphericalHarmonics(torch.autograd.Function):
             v_dirs = None
         return None, v_dirs, v_coeffs, None
 
+<<<<<<< HEAD
 
 ###### 2DGS ######
 def fully_fused_projection_2dgs(
@@ -2003,6 +2004,9 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             None,
         )
 class SparseGaussianAdam(torch.optim.Adam):
+=======
+class SelectiveAdam(torch.optim.Adam):
+>>>>>>> 4aef74b (update)
     def __init__(self, params, eps, betas):
         super().__init__(params=params, eps=eps, betas=betas)
     
@@ -2030,4 +2034,5 @@ class SparseGaussianAdam(torch.optim.Adam):
             exp_avg = stored_state["exp_avg"]
             exp_avg_sq = stored_state["exp_avg_sq"]
             M = param.numel() // N
-            adam_update(param, param.grad, exp_avg, exp_avg_sq, visibility, lr, beta1, beta2, eps, N, M)
+
+            selective_adam_update(param, param.grad, exp_avg, exp_avg_sq, visibility, lr, beta1, beta2, eps, N, M)

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1263,8 +1263,6 @@ class _SphericalHarmonics(torch.autograd.Function):
             v_dirs = None
         return None, v_dirs, v_coeffs, None
 
-<<<<<<< HEAD
-
 ###### 2DGS ######
 def fully_fused_projection_2dgs(
     means: Tensor,  # [N, 3]
@@ -2003,10 +2001,8 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             None,
             None,
         )
-class SparseGaussianAdam(torch.optim.Adam):
-=======
+
 class SelectiveAdam(torch.optim.Adam):
->>>>>>> 4aef74b (update)
     def __init__(self, params, eps, betas):
         super().__init__(params=params, eps=eps, betas=betas)
     

--- a/gsplat/cuda/csrc/adam.cu
+++ b/gsplat/cuda/csrc/adam.cu
@@ -1,0 +1,83 @@
+#include "bindings.h"
+#include "helpers.cuh"
+#include "utils.cuh"
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+#include <cub/cub.cuh>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+namespace gsplat {
+
+namespace cg = cooperative_groups;
+
+template<typename T>
+__global__ void adam_update_kernel(
+    T* __restrict__ param,
+    const T* __restrict__ param_grad,
+    T* __restrict__ exp_avg,
+    T* __restrict__ exp_avg_sq,
+    const bool* tiles_touched,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M
+) {
+    auto p_idx = cg::this_grid().thread_rank();
+    const uint32_t g_idx = p_idx / M;
+    if (g_idx >= N) return;
+    if (tiles_touched[g_idx]) {
+        T Register_param_grad = param_grad[p_idx];
+        T Register_exp_avg = exp_avg[p_idx];
+        T Register_exp_avg_sq = exp_avg_sq[p_idx];
+        Register_exp_avg = b1 * Register_exp_avg + (1.0f - b1) * Register_param_grad;
+        Register_exp_avg_sq = b2 * Register_exp_avg_sq + (1.0f - b2) * Register_param_grad * Register_param_grad;
+        T step = -lr * Register_exp_avg / (sqrt(Register_exp_avg_sq) + eps);
+
+        param[p_idx] += step;
+        exp_avg[p_idx] = Register_exp_avg;
+        exp_avg_sq[p_idx] = Register_exp_avg_sq;
+    }
+}
+
+void adam_update(
+    torch::Tensor &param,
+    torch::Tensor &param_grad,
+    torch::Tensor &exp_avg,
+    torch::Tensor &exp_avg_sq,
+    torch::Tensor &tiles_touched,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M
+) {
+    GSPLAT_DEVICE_GUARD(param);
+    GSPLAT_CHECK_INPUT(param);
+    GSPLAT_CHECK_INPUT(param_grad);
+    GSPLAT_CHECK_INPUT(exp_avg);
+    GSPLAT_CHECK_INPUT(exp_avg_sq);
+    GSPLAT_CHECK_INPUT(tiles_touched);
+
+    const uint32_t cnt = N * M;
+    at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
+    adam_update_kernel<float><<<(cnt + 255) / 256, 256, 0, stream>>>(
+        param.data_ptr<float>(),
+        param_grad.data_ptr<float>(),
+        exp_avg.data_ptr<float>(),
+        exp_avg_sq.data_ptr<float>(),
+        tiles_touched.data_ptr<bool>(),
+        lr,
+        b1,
+        b2,
+        eps,
+        N,
+        M
+    );
+}
+
+} // namespace gsplat

--- a/gsplat/cuda/csrc/adam.cu
+++ b/gsplat/cuda/csrc/adam.cu
@@ -13,7 +13,7 @@ namespace gsplat {
 namespace cg = cooperative_groups;
 
 template<typename T>
-__global__ void adam_update_kernel(
+__global__ void selective_adam_update_kernel(
     T* __restrict__ param,
     const T* __restrict__ param_grad,
     T* __restrict__ exp_avg,
@@ -43,7 +43,7 @@ __global__ void adam_update_kernel(
     }
 }
 
-void adam_update(
+void selective_adam_update(
     torch::Tensor &param,
     torch::Tensor &param_grad,
     torch::Tensor &exp_avg,
@@ -65,7 +65,7 @@ void adam_update(
 
     const uint32_t cnt = N * M;
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
-    adam_update_kernel<float><<<(cnt + 255) / 256, 256, 0, stream>>>(
+    selective_adam_update_kernel<float><<<(cnt + 255) / 256, 256, 0, stream>>>(
         param.data_ptr<float>(),
         param_grad.data_ptr<float>(),
         exp_avg.data_ptr<float>(),

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -316,6 +316,7 @@ std::tuple<torch::Tensor, torch::Tensor> compute_relocation_tensor(
     const int n_max
 );
 
+<<<<<<< HEAD
 //====== 2DGS ======//
 std::tuple<
     torch::Tensor,
@@ -487,6 +488,21 @@ fully_fused_projection_packed_bwd_2dgs_tensor(
     const bool viewmats_requires_grad,
     const bool sparse_grad
 );
+=======
+
+void adam_update(
+    torch::Tensor &param,
+    torch::Tensor &param_grad,
+    torch::Tensor &exp_avg,
+    torch::Tensor &exp_avg_sq,
+    torch::Tensor &tiles_touched,
+    const float lr,
+    const float b1,
+    const float b2,
+    const float eps,
+    const uint32_t N,
+    const uint32_t M);
+>>>>>>> 7fa96fb (gaussian sparse adam)
 
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -490,7 +490,7 @@ fully_fused_projection_packed_bwd_2dgs_tensor(
 );
 =======
 
-void adam_update(
+void selective_adam_update(
     torch::Tensor &param,
     torch::Tensor &param_grad,
     torch::Tensor &exp_avg,

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -316,7 +316,6 @@ std::tuple<torch::Tensor, torch::Tensor> compute_relocation_tensor(
     const int n_max
 );
 
-<<<<<<< HEAD
 //====== 2DGS ======//
 std::tuple<
     torch::Tensor,
@@ -488,7 +487,6 @@ fully_fused_projection_packed_bwd_2dgs_tensor(
     const bool viewmats_requires_grad,
     const bool sparse_grad
 );
-=======
 
 void selective_adam_update(
     torch::Tensor &param,
@@ -502,7 +500,6 @@ void selective_adam_update(
     const float eps,
     const uint32_t N,
     const uint32_t M);
->>>>>>> 7fa96fb (gaussian sparse adam)
 
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/ext.cpp
+++ b/gsplat/cuda/csrc/ext.cpp
@@ -87,4 +87,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "rasterize_to_indices_in_range_2dgs",
         &gsplat::rasterize_to_indices_in_range_2dgs_tensor
     );
+
+    m.def("adam_update", &gsplat::adam_update);
 }

--- a/gsplat/cuda/csrc/ext.cpp
+++ b/gsplat/cuda/csrc/ext.cpp
@@ -88,5 +88,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         &gsplat::rasterize_to_indices_in_range_2dgs_tensor
     );
 
-    m.def("adam_update", &gsplat::adam_update);
+    m.def("selective_adam_update", &gsplat::selective_adam_update);
 }

--- a/gsplat/optimizers/__init__.py
+++ b/gsplat/optimizers/__init__.py
@@ -1,0 +1,1 @@
+from .selective_adam import SelectiveAdam

--- a/gsplat/optimizers/selective_adam.py
+++ b/gsplat/optimizers/selective_adam.py
@@ -37,7 +37,7 @@ class SelectiveAdam(torch.optim.Adam):
         >>> loss.backward()
 
         >>> # Optimization step with selective updates
-        >>> optimizer.step(visibility=visibility_mask, N=N)
+        >>> optimizer.step(visibility=visibility_mask)
 
     """
 
@@ -45,7 +45,8 @@ class SelectiveAdam(torch.optim.Adam):
         super().__init__(params=params, eps=eps, betas=betas)
 
     @torch.no_grad()
-    def step(self, visibility, N):
+    def step(self, visibility):
+        N = visibility.numel()
         for group in self.param_groups:
             lr = group["lr"]
             eps = group["eps"]

--- a/gsplat/optimizers/selective_adam.py
+++ b/gsplat/optimizers/selective_adam.py
@@ -16,6 +16,8 @@ class SelectiveAdam(torch.optim.Adam):
     leverages the `selective_adam_update` function from a CUDA backend for
     optimized sparse updates.
 
+    This is one of the two optimizers mentioned in the Taming3DGS paper.
+
     Args:
         params (iterable): Iterable of parameters to optimize or dicts defining parameter groups.
         eps (float): Term added to the denominator to improve numerical stability (default: 1e-8).

--- a/gsplat/optimizers/selective_adam.py
+++ b/gsplat/optimizers/selective_adam.py
@@ -4,6 +4,41 @@ from ..cuda._wrapper import selective_adam_update
 
 
 class SelectiveAdam(torch.optim.Adam):
+    """
+    A custom optimizer that extends the standard Adam optimizer by
+    incorporating selective updates.
+
+    This class is useful for situations where only a subset of parameters
+    should be updated at each step, such as in sparse models or in cases where
+    parameter visibility is controlled by an external mask.
+
+    Additionally, the operations are fused into a single kernel. This optimizer
+    leverages the `selective_adam_update` function from a CUDA backend for
+    optimized sparse updates.
+
+    Args:
+        params (iterable): Iterable of parameters to optimize or dicts defining parameter groups.
+        eps (float): Term added to the denominator to improve numerical stability (default: 1e-8).
+        betas (Tuple[float, float]): Coefficients used for computing running averages of gradient and its square (default: (0.9, 0.999)).
+
+    Examples:
+
+        >>> N = 100
+        >>> param = torch.randn(N, requires_grad=True)
+        >>> optimizer = SelectiveAdam([param], eps=1e-8, betas=(0.9, 0.999))
+        >>> visibility_mask = torch.cat([torch.ones(50), torch.zeros(50)])  # Visible first half, hidden second half
+
+        >>> # Forward pass
+        >>> loss = torch.sum(param ** 2)
+
+        >>> # Backward pass
+        >>> loss.backward()
+
+        >>> # Optimization step with selective updates
+        >>> optimizer.step(visibility=visibility_mask, N=N)
+
+    """
+
     def __init__(self, params, eps, betas):
         super().__init__(params=params, eps=eps, betas=betas)
 

--- a/gsplat/optimizers/selective_adam.py
+++ b/gsplat/optimizers/selective_adam.py
@@ -1,0 +1,50 @@
+import torch
+
+from ..cuda._wrapper import selective_adam_update
+
+
+class SelectiveAdam(torch.optim.Adam):
+    def __init__(self, params, eps, betas):
+        super().__init__(params=params, eps=eps, betas=betas)
+
+    @torch.no_grad()
+    def step(self, visibility, N):
+        for group in self.param_groups:
+            lr = group["lr"]
+            eps = group["eps"]
+            beta1, beta2 = group["betas"]
+
+            assert len(group["params"]) == 1, "more than one tensor in group"
+            param = group["params"][0]
+            if param.grad is None:
+                continue
+
+            # Lazy state initialization
+            state = self.state[param]
+            if len(state) == 0:
+                state["step"] = torch.tensor(0.0, dtype=torch.float32)
+                state["exp_avg"] = torch.zeros_like(
+                    param, memory_format=torch.preserve_format
+                )
+                state["exp_avg_sq"] = torch.zeros_like(
+                    param, memory_format=torch.preserve_format
+                )
+
+            stored_state = self.state.get(param, None)
+            exp_avg = stored_state["exp_avg"]
+            exp_avg_sq = stored_state["exp_avg_sq"]
+            M = param.numel() // N
+
+            selective_adam_update(
+                param,
+                param.grad,
+                exp_avg,
+                exp_avg_sq,
+                visibility,
+                lr,
+                beta1,
+                beta2,
+                eps,
+                N,
+                M,
+            )


### PR DESCRIPTION
This is the same as the sparse adam described in the Taming3DGS paper. Right now the non-zero radii gaussians are optimized. Hence the flag `visible adam` is used in the command line argument. Any other kind of mask can be passed to the same optimizer backend for different behaviour.

This optimizer is compatible with `packed=True` as well. It gives a speed-up as briefly evaluated in the table below. I tried the bicycle scene till 7000 iterations on 3080Ti. Although, it leads to a different number of gaussians and slightly different evaluation metrics. The speed-up should be higher and more noticeable with higher number of iterations (due to higher number of gaussians).

|                     | Adam    | PyTorch Sparse Adam + Packed | Visible (Selective) Adam | Visible (Selective) Adam + Packed |
|---------------------|---------|------------------------------|--------------------------|-----------------------------------|
| Time                | 3m 16s  | 3m 16s                       | 2m 28s                   | 2m 37s                            |
| Count | 2642634 | 2234936                      | 2325614                  | 2337493                           |


PS: I've created a new optimizer directory similar to strategy directory. I expect different optimizers catering to 3DGS to show up as research progresses. So I think this is a good option.