### PR TITLE
Fix proj.cuh include guard

### DIFF
--- a/gsplat/cuda/include/proj.cuh
+++ b/gsplat/cuda/include/proj.cuh
@@ -1,5 +1,5 @@
-#ifndef GSPLAT_CUDA_PROJ_H
-#define GSPLAT_CUDA_PROJ_H
+#ifndef GSPLAT_CUDA_PROJ_CUH
+#define GSPLAT_CUDA_PROJ_CUH
 
 #include "types.cuh"
 
@@ -344,4 +344,4 @@ inline __device__ void fisheye_proj_vjp(
 
 } // namespace gsplat
 
-#endif // GSPLAT_CUDA_PROJ_H
+#endif // GSPLAT_CUDA_PROJ_CUH

--- a/gsplat/cuda/include/proj.cuh
+++ b/gsplat/cuda/include/proj.cuh
@@ -1,5 +1,5 @@
-#ifndef GSPLAT_CUDA_UTILS_H
-#define GSPLAT_CUDA_UTILS_H
+#ifndef GSPLAT_CUDA_PROJ_H
+#define GSPLAT_CUDA_PROJ_H
 
 #include "types.cuh"
 
@@ -344,4 +344,4 @@ inline __device__ void fisheye_proj_vjp(
 
 } // namespace gsplat
 
-#endif // GSPLAT_CUDA_UTILS_H
+#endif // GSPLAT_CUDA_PROJ_H


### PR DESCRIPTION
The include guard's name in `proj.cuh` appears to be inconsistent with the file's. Might cause minor building issues when trying to include this header.