### PR TITLE
Avoid jpeg compression artifacts when training Mip-NeRF360.

### DIFF
--- a/examples/benchmarks/compression/mcmc.sh
+++ b/examples/benchmarks/compression/mcmc.sh
@@ -32,13 +32,13 @@ do
     # train without eval
     CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
-        --data_dir data/360_v2/$SCENE/ \
+        --data_dir $SCENE_DIR/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
 
     # eval: use vgg for lpips to align with other benchmarks
     CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
-        --data_dir data/360_v2/$SCENE/ \
+        --data_dir $SCENE_DIR/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/ \
         --lpips_net vgg \
         --compression png \
@@ -49,7 +49,7 @@ done
 if command -v zip &> /dev/null
 then
     echo "Zipping results"
-    python benchmarks/compression/summarize_stats.py --results_dir $RESULT_DIR
+    python benchmarks/compression/summarize_stats.py --results_dir $RESULT_DIR --scenes $SCENE_LIST
 else
     echo "zip command not found, skipping zipping"
 fi

--- a/examples/benchmarks/compression/mcmc_tt.sh
+++ b/examples/benchmarks/compression/mcmc_tt.sh
@@ -7,7 +7,7 @@ SCENE_LIST="train truck"
 # CAP_MAX=360000
 
 # # 0.49M GSs
-# RESULT_DIR="results/benchmark_tt_mcmc_tt_0_49M_png_compression"
+# RESULT_DIR="results/benchmark_tt_mcmc_0_49M_png_compression"
 # CAP_MAX=490000
 
 # 1M GSs

--- a/examples/benchmarks/compression/summarize_stats.py
+++ b/examples/benchmarks/compression/summarize_stats.py
@@ -8,9 +8,8 @@ import numpy as np
 import tyro
 
 
-def main(results_dir: str, scenes: List[str]):
+def main(results_dir: str, scenes: List[str], stage: str = "compress"):
     print("scenes:", scenes)
-    stage = "compress"
 
     summary = defaultdict(list)
     for scene in scenes:
@@ -33,7 +32,11 @@ def main(results_dir: str, scenes: List[str]):
                 summary[k].append(v)
 
     for k, v in summary.items():
-        print(k, np.mean(v))
+        summary[k] = np.mean(v)
+    summary["scenes"] = scenes
+
+    with open(os.path.join(results_dir, f"{stage}_summary.json"), "w") as f:
+        json.dump(summary, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -30,7 +30,7 @@ def _get_rel_paths(path_dir: str) -> List[str]:
 
 def _resize_image_folder(image_dir: str, resized_dir: str, factor: int) -> str:
     """Resize image folder."""
-    print("Downscaling full resolution images instead of provided jpgs.")
+    print(f"Downscaling images by {factor}x from {image_dir} to {resized_dir}.")
     os.makedirs(resized_dir, exist_ok=True)
 
     image_files = _get_rel_paths(image_dir)


### PR DESCRIPTION
As noted by https://nerfbaselines.github.io/, the original 3DGS work manually downscales the full-resolution images instead of using the dataset-provided downscaled images to avoid JPEG compression artifacts. This improves PSNR by ~0.27 and allows for a more fair comparison with work building on the original codebase.

<img width="524" alt="image" src="https://github.com/user-attachments/assets/d8de34cf-a7aa-4466-8b64-4c405a35dcd4">

Screenshot from 3DGS paper. https://arxiv.org/pdf/2308.04079

## Results
|  |  psnr | ssim | lpips (vgg) | size |
|--|--|--|--|--|
| mcmc-1M-compressed (Before) | 27.27 | 0.809| 0.229 | 15.8 MB |
| mcmc-1M-compressed (After) | 27.54 | 0.821| 0.214 |16.0 MB |
