### PR TITLE
fix: wrong torch cat dim when concatenating colors+depths in simple_trainer_2dgs.py

### DIFF
--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -914,7 +914,7 @@ class Runner:
 
             # write images
             canvas = torch.cat(
-                [colors, depths.repeat(1, 1, 3)], dim=1 if width > height else 1
+                [colors, depths.repeat(1, 1, 3)], dim=0 if width > height else 1
             )
             canvas = (canvas.cpu().numpy() * 255).astype(np.uint8)
             canvas_all.append(canvas)


### PR DESCRIPTION
A minor type in `example/simple_trainer_2dgs.py`

It was a useless `if` condition there. I thought you wanted to concatenate `colors` and `depths` along different directions based on their shape for better visualization:
- Vertical if `width > height`
- Horizontal else


Thanks for your time!