### PR TITLE
Fix paths in training scripts

### DIFF
--- a/examples/benchmarks/basic.sh
+++ b/examples/benchmarks/basic.sh
@@ -14,7 +14,7 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py default --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py default --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
         --render_traj_path $RENDER_TRAJ_PATH \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
@@ -22,7 +22,7 @@ do
     # run eval and render
     for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
     do
-        CUDA_VISIBLE_DEVICES=0 python simple_trainer.py default --disable_viewer --data_factor $DATA_FACTOR \
+        CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py default --disable_viewer --data_factor $DATA_FACTOR \
             --render_traj_path $RENDER_TRAJ_PATH \
             --data_dir data/360_v2/$SCENE/ \
             --result_dir $RESULT_DIR/$SCENE/ \

--- a/examples/benchmarks/basic_2dgs.sh
+++ b/examples/benchmarks/basic_2dgs.sh
@@ -13,7 +13,7 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer_2dgs.py --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer_2dgs.py --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
         --model_type 2dgs \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
@@ -21,7 +21,7 @@ do
     # run eval and render
     for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
     do
-        CUDA_VISIBLE_DEVICES=0 python simple_trainer_2dgs.py --disable_viewer --data_factor $DATA_FACTOR \
+        CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer_2dgs.py --disable_viewer --data_factor $DATA_FACTOR \
             --model_type 2dgs \
             --data_dir data/360_v2/$SCENE/ \
             --result_dir $RESULT_DIR/$SCENE/ \

--- a/examples/benchmarks/basic_4gpus.sh
+++ b/examples/benchmarks/basic_4gpus.sh
@@ -13,7 +13,7 @@ do
     echo "Running $SCENE"
 
     # train and eval at the last step (30000)
-    CUDA_VISIBLE_DEVICES=0,1,2,3 python simple_trainer.py default --eval_steps 30000 --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0,1,2,3 python examples/simple_trainer.py default --eval_steps 30000 --disable_viewer --data_factor $DATA_FACTOR \
         # 4 GPUs is effectively 4x batch size so we scale down the steps by 4x as well.
         # "--packed" reduces the data transfer between GPUs, which leads to faster training. 
         --steps_scaler 0.25 --packed \

--- a/examples/benchmarks/bilarf/mcmc_bilarf.sh
+++ b/examples/benchmarks/bilarf/mcmc_bilarf.sh
@@ -13,7 +13,7 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
         --use_bilateral_grid \
         --render_traj_path $RENDER_TRAJ_PATH \
         --data_dir $SCENE_DIR/$SCENE/ \

--- a/examples/benchmarks/compression/mcmc.sh
+++ b/examples/benchmarks/compression/mcmc.sh
@@ -30,13 +30,13 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
 
     # eval: use vgg for lpips to align with other benchmarks
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
         --data_dir data/360_v2/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/ \

--- a/examples/benchmarks/compression/mcmc_tt.sh
+++ b/examples/benchmarks/compression/mcmc_tt.sh
@@ -23,13 +23,13 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor 1 \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor 1 \
         --strategy.cap-max $CAP_MAX \
         --data_dir $SCENE_DIR/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/
 
     # eval: use vgg for lpips to align with other benchmarks
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor 1 \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --disable_viewer --data_factor 1 \
         --strategy.cap-max $CAP_MAX \
         --data_dir $SCENE_DIR/$SCENE/ \
         --result_dir $RESULT_DIR/$SCENE/ \

--- a/examples/benchmarks/fisheye/mcmc_zipnerf.sh
+++ b/examples/benchmarks/fisheye/mcmc_zipnerf.sh
@@ -14,7 +14,7 @@ do
     echo "Running $SCENE"
 
     # train and eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
         --opacity_reg 0.001 \
         --use_bilateral_grid \

--- a/examples/benchmarks/fisheye/mcmc_zipnerf_undistorted.sh
+++ b/examples/benchmarks/fisheye/mcmc_zipnerf_undistorted.sh
@@ -14,7 +14,7 @@ do
     echo "Running $SCENE"
 
     # train and eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
         --opacity_reg 0.001 \
         --use_bilateral_grid \

--- a/examples/benchmarks/mcmc.sh
+++ b/examples/benchmarks/mcmc.sh
@@ -16,7 +16,7 @@ do
     echo "Running $SCENE"
 
     # train without eval
-    CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
+    CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --eval_steps -1 --disable_viewer --data_factor $DATA_FACTOR \
         --strategy.cap-max $CAP_MAX \
         --render_traj_path $RENDER_TRAJ_PATH \
         --data_dir $SCENE_DIR/$SCENE/ \
@@ -25,7 +25,7 @@ do
     # run eval and render
     for CKPT in $RESULT_DIR/$SCENE/ckpts/*;
     do
-        CUDA_VISIBLE_DEVICES=0 python simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
+        CUDA_VISIBLE_DEVICES=0 python examples/simple_trainer.py mcmc --disable_viewer --data_factor $DATA_FACTOR \
             --strategy.cap-max $CAP_MAX \
             --render_traj_path $RENDER_TRAJ_PATH \
             --data_dir $SCENE_DIR/$SCENE/ \


### PR DESCRIPTION
The README currently suggests running these commands to get started:

```
pip install -r examples/requirements.txt
# download mipnerf_360 benchmark data
python examples/datasets/download_dataset.py
# run batch evaluation
bash examples/benchmarks/basic.sh
```

I assume these commands should be run from the project's root directory. If that’s correct, the paths in the bash scripts need to include the examples/ folder. Otherwise, I have to manually adjust the paths to make training work on my end.

If the commands aren’t meant to be run from the root, it’d be helpful to clearly specify where they should be executed.