### PR TITLE
Ply export and simple_viewer fixes for 2DGS

### DIFF
--- a/examples/simple_viewer.py
+++ b/examples/simple_viewer.py
@@ -21,7 +21,7 @@ import viser
 
 from gsplat._helper import load_test_data
 from gsplat.distributed import cli
-from gsplat.rendering import rasterization
+from gsplat.rendering import rasterization, rasterization_2dgs
 
 
 def main(local_rank: int, world_rank, world_size: int, args):
@@ -169,6 +169,8 @@ def main(local_rank: int, world_rank, world_size: int, args):
 
         if args.backend == "gsplat":
             rasterization_fn = rasterization
+        elif args.backend == "gsplat-2dgs":
+            rasterization_fn = rasterization_2dgs
         elif args.backend == "inria":
             from gsplat import rasterization_inria_wrapper
 
@@ -176,7 +178,7 @@ def main(local_rank: int, world_rank, world_size: int, args):
         else:
             raise ValueError
 
-        render_colors, render_alphas, meta = rasterization_fn(
+        render_colors, render_alphas, _, _, _, _, meta = rasterization_fn(
             means,  # [N, 3]
             quats,  # [N, 4]
             scales,  # [N, 3]

--- a/gsplat/utils.py
+++ b/gsplat/utils.py
@@ -7,13 +7,15 @@ from torch import Tensor
 import numpy as np
 
 
-def save_ply(splats: torch.nn.ParameterDict, dir: str, colors: torch.Tensor = None):
+def save_ply(splats: torch.nn.ParameterDict, dir: str, colors: torch.Tensor = None, is_2dgs: bool = False):
     # Convert all tensors to numpy arrays in one go
     print(f"Saving ply to {dir}")
     numpy_data = {k: v.detach().cpu().numpy() for k, v in splats.items()}
 
     means = numpy_data["means"]
     scales = numpy_data["scales"]
+    if is_2dgs:
+        scales[:, 2] = np.log(1e-6)
     quats = numpy_data["quats"]
     opacities = numpy_data["opacities"]
 


### PR DESCRIPTION
Hey, this is a quick addition to the current ply export to support 2DGS.

The simple viewer is now fixed to support the 2DGS rasterizer passing the backend with `--backend gsplat-2dgs`

It also supports supersplat viewer by forcing 3rd scales dimension to be close to 0.

Quick in supersplat 
![image](https://github.com/user-attachments/assets/f2346e49-e44d-41f4-b46d-2c967816bce3)
