### PR TITLE
bugfix in transmittance based early stop criteria

### DIFF
--- a/gsplat/cuda/csrc/rasterize_to_pixels_2dgs_fwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_2dgs_fwd.cu
@@ -302,12 +302,6 @@ __global__ void rasterize_to_pixels_fwd_2dgs_kernel(
                 continue;
             }
 
-            const S next_T = T * (1.0f - alpha);
-            if (next_T <= 1e-4) { // this pixel is done: exclusive
-                done = true;
-                break;
-            }
-
             // run volumetric rendering..
             int32_t g = id_batch[t];
             const S vis = alpha * T;
@@ -343,6 +337,13 @@ __global__ void rasterize_to_pixels_fwd_2dgs_kernel(
             }
 
             cur_idx = batch_start + t;
+
+            const S next_T = T * (1.0f - alpha);
+            if (next_T <= 1e-4) { // this pixel is done: exclusive
+                T = next_T;
+                done = true;
+                break;
+            }
 
             T = next_T;
         }

--- a/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
@@ -147,12 +147,6 @@ __global__ void rasterize_to_pixels_fwd_kernel(
                 continue;
             }
 
-            const S next_T = T * (1.0f - alpha);
-            if (next_T <= 1e-4) { // this pixel is done: exclusive
-                done = true;
-                break;
-            }
-
             int32_t g = id_batch[t];
             const S vis = alpha * T;
             const S *c_ptr = colors + g * COLOR_DIM;
@@ -161,6 +155,13 @@ __global__ void rasterize_to_pixels_fwd_kernel(
                 pix_out[k] += c_ptr[k] * vis;
             }
             cur_idx = batch_start + t;
+
+            const S next_T = T * (1.0f - alpha);
+            if (next_T <= 1e-4) { // this pixel is done: exclusive
+                T = next_T;
+                done = true;
+                break;
+            }
 
             T = next_T;
         }


### PR DESCRIPTION
I think there's a bug in terms of when to stop rendering if the transmittance gets near zero.
Intuitively, the stopping criteria checks if the transmittance for rendering "next Gaussian" is very low or not.
Therefore, it should render the "current Gaussian" and then break out of the loop.
However, the current implementation instead checks the criteria and stop immediately, without rendering the current one.

To be more specific, say there are only two Gaussians to be rendered for a pixel, where the first one to be rendered has alpha of 0.5, and the other one has alpha of 1.0. Obviously, because the second Gaussian has alpha of 1.0, the rendered alpha of the pixel should be 1.0.
However, the current implementation only renders the first one because while trying to render the second one, it detects that T will get near zero and doesn't render the second one, leaving the pixel's rendered alpha 0.5.

This can be verified by manually rendering two very bright Gaussians (with the second one being very large):

```
self.means = torch.tensor([[0, 0, 1],
                            [0, 0, 1.5]], device=self.device)
self.scales = torch.tensor([[1.5e1, 1.5e1, 1.5e1],
                            [1e9, 1e9, 1e9]], device=self.device)
d = 3
self.rgbs = torch.ones(self.num_points, d, device=self.device) * 1e9

u = torch.ones(self.num_points, 1, device=self.device)
v = torch.ones(self.num_points, 1, device=self.device)
w = torch.ones(self.num_points, 1, device=self.device)

self.quats = torch.cat(
    [
        torch.sqrt(1.0 - u) * torch.sin(2.0 * math.pi * v),
        torch.sqrt(1.0 - u) * torch.cos(2.0 * math.pi * v),
        torch.sqrt(u) * torch.sin(2.0 * math.pi * w),
        torch.sqrt(u) * torch.cos(2.0 * math.pi * w),
    ],
    -1,
)

self.opacities = torch.tensor([1e9, 1e9], device=self.device)
```

It renders this weird gray ball, while after applying this bugfix, it correctly renders white image.
|  current | bugfix |
|:--:|:--:|
| ![current](https://github.com/user-attachments/assets/54aad938-4443-4edc-9f18-31e0f7f38c31) | ![bugfix](https://github.com/user-attachments/assets/13c90685-f843-4bd6-a89b-3a9313b9bbc4) |

If you cut and look at the middle section of the above image, it looks like this:

|  current | bugfix |
|:--:|:--:|
| ![current_midsection](https://github.com/user-attachments/assets/3fa32857-a85b-4e10-9498-a85af33b22eb)  |  ![bugfix_midsection](https://github.com/user-attachments/assets/7fe25d14-049f-45e2-8b45-2fdfab64e776) |

Here I made randomly initialized Gaussians to learn an all-white image. This behavior compromises stability of training, and it makes the 3DGS never be able to learn a truly saturated image. You can see this from the loss not being able to get reduced below a certain point. The output image has slightly different color because the current implementation struggles to render a truly white image.
|  current | bugfix |
|:--:|:--:|
| ![current_training](https://github.com/user-attachments/assets/9785e0cd-0cd6-4980-a3fe-4468e2fb7a17)  | ![training](https://github.com/user-attachments/assets/44e1a2d8-f7df-4399-b879-810d176693cd) |
| ![current_loss](https://github.com/user-attachments/assets/16b53c44-229f-41d1-8cf2-57828519f4df) | ![bugfix_loss](https://github.com/user-attachments/assets/a451119c-f09c-4f8e-9ab4-560659d92607) |

If you discard the color values below 250 and map [250, 255] to be [0, 255] to see the effect better, you can clearly see the current implementation struggles because of the weird gray blobs. 

|  current | bugfix |
|:--:|:--:|
| ![current_training_enhanced](https://github.com/user-attachments/assets/56cc44cf-e7f7-4112-ba9d-47472442eeb7) |![training_enhanced](https://github.com/user-attachments/assets/53678ea6-84c7-4c03-ab2f-cc0374f802b4) |
- (please ignore the RGB being crazy at the beginning. I didn't really discard the values below 250 so they became minus and got repeatedly underflown.)

Though I think this bug has minimal effect in practice, I still think it needs a fix ;)
