### PR TITLE
Fix channel padding for distortion and median depth computation

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1694,8 +1694,13 @@ def rasterize_to_pixels_2dgs(
         raise ValueError(f"Unsupported number of color channels: {channels}")
     if channels not in (1, 2, 3, 4, 8, 16, 32, 64, 128, 256, 512):
         padded_channels = (1 << (channels - 1).bit_length()) - channels
+        # Make sure the depth (last channel if present) remains in the last channel after padding (for depth distortion and median depth in CUDA kernel)
         colors = torch.cat(
-            [colors, torch.empty(*colors.shape[:-1], padded_channels, device=device)],
+            [
+                colors[..., :-1],
+                torch.empty(*colors.shape[:-1], padded_channels, device=device),
+                colors[..., -1:],
+            ],
             dim=-1,
         )
         if backgrounds is not None:
@@ -1743,7 +1748,10 @@ def rasterize_to_pixels_2dgs(
     )
 
     if padded_channels > 0:
-        render_colors = render_colors[..., :-padded_channels]
+        render_colors = torch.cat(
+            [render_colors[..., : -padded_channels - 1], render_colors[..., -1:]],
+            dim=-1,
+        )
 
     return render_colors, render_alphas, render_normals, render_distort, render_median
 

--- a/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_fwd.cu
@@ -33,7 +33,8 @@ __global__ void rasterize_to_pixels_fwd_kernel(
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     S *__restrict__ render_colors, // [C, image_height, image_width, COLOR_DIM]
     S *__restrict__ render_alphas, // [C, image_height, image_width, 1]
-    int32_t *__restrict__ last_ids // [C, image_height, image_width]
+    int32_t *__restrict__ last_ids, // [C, image_height, image_width]
+    S *__restrict__ contributions // [C, N, 2]
 ) {
     // each thread draws one pixel, but also timeshares caching gaussians in a
     // shared tile
@@ -155,6 +156,11 @@ __global__ void rasterize_to_pixels_fwd_kernel(
 
             int32_t g = id_batch[t];
             const S vis = alpha * T;
+
+            S *contrib = contributions + g * 2;
+            atomicAdd(contrib, vis);
+            atomicAdd(contrib + 1, alpha);
+
             const S *c_ptr = colors + g * COLOR_DIM;
             GSPLAT_PRAGMA_UNROLL
             for (uint32_t k = 0; k < COLOR_DIM; ++k) {
@@ -185,7 +191,7 @@ __global__ void rasterize_to_pixels_fwd_kernel(
 }
 
 template <uint32_t CDIM>
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> call_kernel_with_dim(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> call_kernel_with_dim(
     // Gaussian parameters
     const torch::Tensor &means2d,   // [C, N, 2] or [nnz, 2]
     const torch::Tensor &conics,    // [C, N, 3] or [nnz, 3]
@@ -239,6 +245,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> call_kernel_with_dim(
     torch::Tensor last_ids = torch::empty(
         {C, image_height, image_width}, means2d.options().dtype(torch::kInt32)
     );
+    torch::Tensor contributions = torch::zeros(
+        {C, opacities.size(-1), 2}, means2d.options().dtype(torch::kFloat32).requires_grad(false)
+    );
 
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
     const uint32_t shared_mem =
@@ -281,13 +290,14 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> call_kernel_with_dim(
             flatten_ids.data_ptr<int32_t>(),
             renders.data_ptr<float>(),
             alphas.data_ptr<float>(),
-            last_ids.data_ptr<int32_t>()
+            last_ids.data_ptr<int32_t>(),
+            contributions.data_ptr<float>()
         );
 
-    return std::make_tuple(renders, alphas, last_ids);
+    return std::make_tuple(renders, alphas, last_ids, contributions);
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 rasterize_to_pixels_fwd_tensor(
     // Gaussian parameters
     const torch::Tensor &means2d,   // [C, N, 2] or [nnz, 2]

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -165,7 +165,7 @@ torch::Tensor isect_offset_encode_tensor(
     const uint32_t tile_height
 );
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 rasterize_to_pixels_fwd_tensor(
     // Gaussian parameters
     const torch::Tensor &means2d,                   // [C, N, 2]

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -536,7 +536,7 @@ def rasterization(
                 if backgrounds is not None
                 else None
             )
-            render_colors_, render_alphas_ = rasterize_to_pixels(
+            render_colors_, render_alphas_, contributions = rasterize_to_pixels(
                 means2d,
                 conics,
                 colors_chunk,
@@ -555,7 +555,7 @@ def rasterization(
         render_colors = torch.cat(render_colors, dim=-1)
         render_alphas = render_alphas[0]  # discard the rest
     else:
-        render_colors, render_alphas = rasterize_to_pixels(
+        render_colors, render_alphas, contributions = rasterize_to_pixels(
             means2d,
             conics,
             colors,
@@ -578,7 +578,9 @@ def rasterization(
             ],
             dim=-1,
         )
-
+    
+    meta["contributions"] = contributions
+    
     return render_colors, render_alphas, meta
 
 


### PR DESCRIPTION
The CUDA kernel requires the depth information used for calculating distortion loss and median depth to be located in the last channel of the tensor. However, because of zero-padding, the depth values for each Gaussian are no longer stored in the last channel. This results in incorrect computations for both the distortion loss and the median depth.