### PR TITLE
Update nerfview version in  examples to avoid division by zero

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -6,7 +6,7 @@ git+https://github.com/rmbrualla/pycolmap@cc7ea4b7301720ac29287dbe450952511b3212
 # git+https://github.com/nerfstudio-project/nerfacc
 
 viser
-nerfview==0.0.2
+nerfview==0.0.3
 imageio[ffmpeg]
 numpy<2.0.0
 scikit-learn


### PR DESCRIPTION
In certain circumstances, NerfView could encounter a division by zero error. This issue has been resolved in the latest version of the library, ensuring more robust handling of edge cases.