### PR TITLE
Add blender dataset + alpha training support

### DIFF
--- a/examples/datasets/blender.py
+++ b/examples/datasets/blender.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Dict, Literal
+
+import imageio.v2 as imageio
+import numpy as np
+import torch
+
+
+@dataclass
+class Dataset:
+    """A simple dataset class for synthetic blender data."""
+
+    data_dir: str
+    """The path to the blender scene, consisting of renders and transforms.json"""
+    split: Literal["train", "test", "val"] = "train"
+    """Which split to use."""
+
+    def __post_init__(self):
+        self.data_dir = Path(self.data_dir)
+        transforms_path = self.data_dir / f"transforms_{self.split}.json"
+        with transforms_path.open("r") as transforms_handle:
+            transforms = json.load(transforms_handle)
+        image_ids = []
+        cam_to_worlds = []
+        images = []
+        for frame in transforms["frames"]:
+            image_id = frame["file_path"].replace("./", "")
+            image_ids.append(image_id)
+            file_path = self.data_dir / f"{image_id}.png"
+            images.append(imageio.imread(file_path))
+
+            c2w = torch.tensor(frame["transform_matrix"])
+            # Convert from OpenGL to OpenCV coordinate system
+            c2w[0:3, 1:3] *= -1
+            cam_to_worlds.append(c2w)
+
+        self.image_ids = image_ids
+        self.cam_to_worlds = cam_to_worlds
+        self.images = images
+
+        # all renders have the same intrinsics
+        # see also
+        # https://github.com/nerfstudio-project/nerfstudio/blob/main/nerfstudio/data/dataparsers/blender_dataparser.py
+        image_height, image_width = self.images[0].shape[:2]
+        cx = image_width / 2.0
+        cy = image_height / 2.0
+        fl = 0.5 * image_width / np.tan(0.5 * transforms["camera_angle_x"])
+        self.intrinsics = torch.tensor(
+            [[fl, 0, cx], [0, fl, cy], [0, 0, 1]], dtype=torch.float32
+        )
+        self.image_height = image_height
+        self.image_width = image_width
+
+        # compute scene scale (as is done in the colmap parser)
+        camera_locations = np.stack(self.cam_to_worlds, axis=0)[:, :3, 3]
+        scene_center = np.mean(camera_locations, axis=0)
+        dists = np.linalg.norm(camera_locations - scene_center, axis=1)
+        self.scene_scale = np.max(dists)
+
+    def __len__(self):
+        return len(self.image_ids)
+
+    def __getitem__(self, item: int) -> Dict[str, Any]:
+        data = dict(
+            K=self.intrinsics,
+            camtoworld=self.cam_to_worlds[item],
+            image=torch.from_numpy(self.images[item]).float(),
+            image_id=item,
+        )
+        return data


### PR DESCRIPTION
This pull request adds the following:

- Support for the commonly-used synthetic blender dataset
- Support for source images with alpha channels, and small changes to training and evaluation to accommodate this (more info below)

The latter is the main intended purpose of the pull request, and the former is to allow for convenient testing on a public dataset with transparent images. Building off of this work, users can train models using matted photos to only produce splats for the object of interest - however this would require a small additional change on the COLMAP parsing to load the alpha channel (and is not included in this pull request).

Alpha is handled in the following way:
- For evaluation, both the render and ground truth photo are composed on a fixed background (defined by a new configuration parameters, defaulting to white).
- For training
  - if the (existing but slightly repurposed) configuration setting `random_bkgd` is `True`: on each iteration the same random background color is applied for both the photo and render
  - otherwise: the fixed background color is used
  
Using the random background in training encourages better alpha consistency and reduces floaters. However, the final evaluation metrics are marginally worse than if using a fixed background. For this reason, I have not enforced a setting of `random_bkgd = True` when blender data is used.


The metrics are included below. `alpha_iou` is the intersection over union comparing the rendered alpha to the source image alpha channel (thresholding on `> 127`).  [nerfbaselines](https://nerfbaselines.github.io/) has also assessed the Blender dataset on an earlier version of `gsplat` (patching in the dataset compatibility on their end). Compared to their results, 6 scenes show marginally better PSNR while 2 (materials and ficus) have marginally worse PSNR.

| scene     | strategy   | background   |   psnr |   ssim |   lpips |   alpha_iou |
|:----------|:-----------|:-------------|-------:|-------:|--------:|------------:|
| chair     | default    | fixed_bkgd   | 35.823 |  0.987 |   0.008 |       0.991 |
| chair     | default    | random_bkgd  | 35.718 |  0.987 |   0.008 |       0.997 |
| chair     | mcmc       | fixed_bkgd   | 36.398 |  0.989 |   0.008 |       0.993 |
| chair     | mcmc       | random_bkgd  | 36.149 |  0.989 |   0.009 |       0.997 |
| drums     | default    | fixed_bkgd   | 26.121 |  0.954 |   0.039 |       0.982 |
| drums     | default    | random_bkgd  | 26.024 |  0.953 |   0.040 |       0.989 |
| drums     | mcmc       | fixed_bkgd   | 26.209 |  0.956 |   0.040 |       0.973 |
| drums     | mcmc       | random_bkgd  | 26.127 |  0.955 |   0.042 |       0.989 |
| ficus     | default    | fixed_bkgd   | 34.360 |  0.987 |   0.010 |       0.952 |
| ficus     | default    | random_bkgd  | 33.639 |  0.987 |   0.012 |       0.965 |
| ficus     | mcmc       | fixed_bkgd   | 34.957 |  0.988 |   0.008 |       0.958 |
| ficus     | mcmc       | random_bkgd  | 34.023 |  0.987 |   0.011 |       0.967 |
| hotdog    | default    | fixed_bkgd   | 37.668 |  0.985 |   0.014 |       0.981 |
| hotdog    | default    | random_bkgd  | 37.417 |  0.985 |   0.013 |       0.998 |
| hotdog    | mcmc       | fixed_bkgd   | 38.373 |  0.988 |   0.011 |       0.762 |
| hotdog    | mcmc       | random_bkgd  | 37.717 |  0.988 |   0.010 |       0.997 |
| lego      | default    | fixed_bkgd   | 35.286 |  0.981 |   0.012 |       0.996 |
| lego      | default    | random_bkgd  | 35.046 |  0.981 |   0.013 |       0.997 |
| lego      | mcmc       | fixed_bkgd   | 35.732 |  0.984 |   0.011 |       0.994 |
| lego      | mcmc       | random_bkgd  | 35.431 |  0.984 |   0.012 |       0.997 |
| materials | default    | fixed_bkgd   | 29.885 |  0.960 |   0.019 |       0.997 |
| materials | default    | random_bkgd  | 29.791 |  0.960 |   0.021 |       0.997 |
| materials | mcmc       | fixed_bkgd   | 30.577 |  0.965 |   0.018 |       0.997 |
| materials | mcmc       | random_bkgd  | 30.464 |  0.965 |   0.018 |       0.997 |
| mic       | default    | fixed_bkgd   | 35.335 |  0.991 |   0.006 |       0.992 |
| mic       | default    | random_bkgd  | 35.256 |  0.992 |   0.006 |       0.994 |
| mic       | mcmc       | fixed_bkgd   | 37.226 |  0.994 |   0.004 |       0.992 |
| mic       | mcmc       | random_bkgd  | 36.522 |  0.993 |   0.005 |       0.994 |
| ship      | default    | fixed_bkgd   | 30.764 |  0.906 |   0.088 |       0.955 |
| ship      | default    | random_bkgd  | 30.324 |  0.906 |   0.088 |       0.994 |
| ship      | mcmc       | fixed_bkgd   | 31.437 |  0.911 |   0.075 |       0.829 |
| ship      | mcmc       | random_bkgd  | 30.739 |  0.910 |   0.077 |       0.994 |
