### PR TITLE
Fix minor typo in documentation about rasterization

### DIFF
--- a/docs/source/apis/rasterization.rst
+++ b/docs/source/apis/rasterization.rst
@@ -29,8 +29,8 @@ projection equation:
 .. math::
 
     J = \begin{bmatrix}
-        f_{x}/z & 0 & -f_{x} t_{x}/z^{2} \\
-        0 & f_{y}/z & -f_{y} t_{y}/z^{2} \\
+        f_{x}/z & 0 & -f_{x} x/z^{2} \\
+        0 & f_{y}/z & -f_{y} y/z^{2} \\
         0 & 0 & 0
     \end{bmatrix}
 


### PR DESCRIPTION
The jacobian for the perspective projection (with principal point int the center) $u=f_x x/z$ and $v=f_y y/z$ is 

$$J = \begin{bmatrix}
\frac{\partial u}{\partial x} & \frac{\partial u}{\partial y} & \frac{\partial u}{\partial z} \\
\frac{\partial v}{\partial x} & \frac{\partial v}{\partial y} & \frac{\partial v}{\partial z} \end{bmatrix}=\begin{bmatrix}
    f_{x}/z & 0 & -f_{x} x/z^{2} \\
    0 & f_{y}/z & -f_{y} y/z^{2} \\
    0 & 0 & 0
\end{bmatrix}$$