### PR TITLE
Create minimal pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Allow building with a pip version newer than pip 23.1.



To test if this commit helps, you can run successfully with a new environment 
`pip install git+https://github.com/kleinicke/gsplat@8b5dfa8fbd996be21738e635291e94c940514a1a`

While
`pip install git+https://github.com/nerfstudio-project/gsplat.git`
causes an torch not installed error, for a pip version 23.1 and newer even when torch is installed.