### PR TITLE
Optionally leverage opacity to tight the radii bounding box 

### DIFF
--- a/gsplat/cuda/csrc/Projection.cpp
+++ b/gsplat/cuda/csrc/Projection.cpp
@@ -97,6 +97,7 @@ projection_ewa_3dgs_fused_fwd(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,
@@ -139,6 +140,7 @@ projection_ewa_3dgs_fused_fwd(
         covars,
         quats,
         scales,
+        opacities,
         viewmats,
         Ks,
         image_width,
@@ -265,6 +267,7 @@ projection_ewa_3dgs_packed_fwd(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,
@@ -308,6 +311,7 @@ projection_ewa_3dgs_packed_fwd(
             covars,
             quats,
             scales,
+            opacities,
             viewmats,
             Ks,
             image_width,
@@ -356,6 +360,7 @@ projection_ewa_3dgs_packed_fwd(
             covars,
             quats,
             scales,
+            opacities,
             viewmats,
             Ks,
             image_width,

--- a/gsplat/cuda/csrc/Projection.h
+++ b/gsplat/cuda/csrc/Projection.h
@@ -41,6 +41,7 @@ void launch_projection_ewa_3dgs_fused_fwd_kernel(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,
@@ -94,6 +95,7 @@ void launch_projection_ewa_3dgs_packed_fwd_kernel(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,

--- a/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
+++ b/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
@@ -21,6 +21,7 @@ __global__ void projection_ewa_3dgs_packed_fwd_kernel(
     const scalar_t *__restrict__ covars,   // [N, 6] Optional
     const scalar_t *__restrict__ quats,    // [N, 4] Optional
     const scalar_t *__restrict__ scales,   // [N, 3] Optional
+    const scalar_t *__restrict__ opacities, // [N] optional
     const scalar_t *__restrict__ viewmats, // [C, 4, 4]
     const scalar_t *__restrict__ Ks,       // [C, 3, 3]
     const int32_t image_width,
@@ -173,15 +174,27 @@ __global__ void projection_ewa_3dgs_packed_fwd_kernel(
 
     // check if the points are in the image region
     float radius_x, radius_y;
-    if (valid) {    
+    if (valid) {
+        float extend = 3.33f;
+        if (opacities != nullptr) {
+            float opacity = opacities[col_idx];
+            opacity *= compensation;
+            if (opacity < ALPHA_THRESHOLD) {
+                valid = false;
+            }
+            // Compute opacity-aware bounding box.
+            // https://arxiv.org/pdf/2402.00525 Section B.2
+            extend = min(extend, sqrt(2.0f * logf(opacity / ALPHA_THRESHOLD)));
+        }
+        
         // compute tight rectangular bounding box (non differentiable)
         // https://arxiv.org/pdf/2402.00525
         float b = 0.5f * (covar2d[0][0] + covar2d[1][1]);
         float tmp = sqrtf(max(0.01f, b * b - det));
         float v1 = b + tmp; // larger eigenvalue
-        float r1 = 3.33f * sqrtf(v1);
-        radius_x = ceilf(min(3.33f * sqrtf(covar2d[0][0]), r1));
-        radius_y = ceilf(min(3.33f * sqrtf(covar2d[1][1]), r1));
+        float r1 = extend * sqrtf(v1);
+        radius_x = ceilf(min(extend * sqrtf(covar2d[0][0]), r1));
+        radius_y = ceilf(min(extend * sqrtf(covar2d[1][1]), r1));
         
         if (radius_x <= radius_clip && radius_y <= radius_clip) {
             valid = false;
@@ -253,6 +266,7 @@ void launch_projection_ewa_3dgs_packed_fwd_kernel(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,
@@ -309,6 +323,8 @@ void launch_projection_ewa_3dgs_packed_fwd_kernel(
                     quats.has_value() ? quats.value().data_ptr<scalar_t>()
                                       : nullptr,
                     scales.has_value() ? scales.value().data_ptr<scalar_t>()
+                                       : nullptr,
+                    opacities.has_value() ? opacities.value().data_ptr<scalar_t>()
                                        : nullptr,
                     viewmats.data_ptr<scalar_t>(),
                     Ks.data_ptr<scalar_t>(),

--- a/gsplat/cuda/csrc/RasterizeToIndices2DGS.cu
+++ b/gsplat/cuda/csrc/RasterizeToIndices2DGS.cu
@@ -178,7 +178,7 @@ __global__ void rasterize_to_indices_2dgs_kernel(
             const float sigma = 0.5f * gauss_weight;
             float alpha = min(0.999f, opac * __expf(-sigma));
 
-            if (sigma < 0.f || alpha < 1.f / 255.f) {
+            if (sigma < 0.f || alpha < ALPHA_THRESHOLD) {
                 continue;
             }
 

--- a/gsplat/cuda/csrc/RasterizeToIndices3DGS.cu
+++ b/gsplat/cuda/csrc/RasterizeToIndices3DGS.cu
@@ -140,7 +140,7 @@ __global__ void rasterize_to_indices_3dgs_kernel(
                                 conic.y * delta.x * delta.y;
             float alpha = min(0.999f, opac * __expf(-sigma));
 
-            if (sigma < 0.f || alpha < 1.f / 255.f) {
+            if (sigma < 0.f || alpha < ALPHA_THRESHOLD) {
                 continue;
             }
 

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSBwd.cu
@@ -387,7 +387,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
                 alpha = min(0.999f, opac * vis); // clipped alpha
 
                 // gaussian throw out
-                if (sigma < 0.f || alpha < 1.f / 255.f) {
+                if (sigma < 0.f || alpha < ALPHA_THRESHOLD) {
                     valid = false;
                 }
             }

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSFwd.cu
@@ -361,7 +361,7 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
             float alpha = min(0.999f, opac * __expf(-sigma));
 
             // ignore transparent gaussians
-            if (sigma < 0.f || alpha < 1.f / 255.f) {
+            if (sigma < 0.f || alpha < ALPHA_THRESHOLD) {
                 continue;
             }
 

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSBwd.cu
@@ -175,7 +175,7 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
                               conic.y * delta.x * delta.y;
                 vis = __expf(-sigma);
                 alpha = min(0.999f, opac * vis);
-                if (sigma < 0.f || alpha < 1.f / 255.f) {
+                if (sigma < 0.f || alpha < ALPHA_THRESHOLD) {
                     valid = false;
                 }
             }

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSFwd.cu
@@ -146,7 +146,7 @@ __global__ void rasterize_to_pixels_3dgs_fwd_kernel(
                                         conic.z * delta.y * delta.y) +
                                 conic.y * delta.x * delta.y;
             float alpha = min(0.999f, opac * __expf(-sigma));
-            if (sigma < 0.f || alpha < 1.f / 255.f) {
+            if (sigma < 0.f || alpha < ALPHA_THRESHOLD) {
                 continue;
             }
 

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -50,5 +50,6 @@ enum CameraModelType {
 };
 
 #define N_THREADS_PACKED 256
+#define ALPHA_THRESHOLD 1.f / 255.f
 
 } // namespace gsplat

--- a/gsplat/cuda/include/Ops.h
+++ b/gsplat/cuda/include/Ops.h
@@ -45,13 +45,13 @@ std::tuple<
     at::Tensor,
     at::Tensor>
 projection_ewa_3dgs_fused_fwd(
-    const at::Tensor means,                // [N, 3]
-    const at::optional<at::Tensor> covars, // [N, 6] optional
-    const at::optional<at::Tensor> quats,  // [N, 4] optional
-    const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::Tensor means,                   // [N, 3]
+    const at::optional<at::Tensor> covars,    // [N, 6] optional
+    const at::optional<at::Tensor> quats,     // [N, 4] optional
+    const at::optional<at::Tensor> scales,    // [N, 3] optional
     const at::optional<at::Tensor> opacities, // [N] optional
-    const at::Tensor viewmats,             // [C, 4, 4]
-    const at::Tensor Ks,                   // [C, 3, 3]
+    const at::Tensor viewmats,                // [C, 4, 4]
+    const at::Tensor Ks,                      // [C, 3, 3]
     const uint32_t image_width,
     const uint32_t image_height,
     const float eps2d,
@@ -104,13 +104,13 @@ std::tuple<
     at::Tensor,
     at::Tensor>
 projection_ewa_3dgs_packed_fwd(
-    const at::Tensor means,                // [N, 3]
-    const at::optional<at::Tensor> covars, // [N, 6] optional
-    const at::optional<at::Tensor> quats,  // [N, 4] optional
-    const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::Tensor means,                   // [N, 3]
+    const at::optional<at::Tensor> covars,    // [N, 6] optional
+    const at::optional<at::Tensor> quats,     // [N, 4] optional
+    const at::optional<at::Tensor> scales,    // [N, 3] optional
     const at::optional<at::Tensor> opacities, // [N] optional
-    const at::Tensor viewmats,             // [C, 4, 4]
-    const at::Tensor Ks,                   // [C, 3, 3]
+    const at::Tensor viewmats,                // [C, 4, 4]
+    const at::Tensor Ks,                      // [C, 3, 3]
     const uint32_t image_width,
     const uint32_t image_height,
     const float eps2d,

--- a/gsplat/cuda/include/Ops.h
+++ b/gsplat/cuda/include/Ops.h
@@ -49,6 +49,7 @@ projection_ewa_3dgs_fused_fwd(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,
@@ -107,6 +108,7 @@ projection_ewa_3dgs_packed_fwd(
     const at::optional<at::Tensor> covars, // [N, 6] optional
     const at::optional<at::Tensor> quats,  // [N, 4] optional
     const at::optional<at::Tensor> scales, // [N, 3] optional
+    const at::optional<at::Tensor> opacities, // [N] optional
     const at::Tensor viewmats,             // [C, 4, 4]
     const at::Tensor Ks,                   // [C, 3, 3]
     const uint32_t image_width,

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -311,7 +311,7 @@ def rasterization(
         sparse_grad=sparse_grad,
         calc_compensations=(rasterize_mode == "antialiased"),
         camera_model=camera_model,
-        opacities=opacities, # use opacities to compute a tigher bound for radii.
+        opacities=opacities,  # use opacities to compute a tigher bound for radii.
     )
 
     if packed:

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -311,6 +311,7 @@ def rasterization(
         sparse_grad=sparse_grad,
         calc_compensations=(rasterize_mode == "antialiased"),
         camera_model=camera_model,
+        opacities=opacities, # use opacities to compute a tigher bound for radii.
     )
 
     if packed:


### PR DESCRIPTION
Results of Bonsai on 2080 Ti (30K):

before:
{"psnr": 32.73397445678711, "ssim": 0.9539318084716797, "lpips": 0.10592443495988846, "ellipse_time": 0.039723467182468726, "num_GS": 1000000}
{"mem": 1.4332904815673828, "ellipse_time": 1328.6909635066986, "num_GS": 1000000}

after:
{"psnr": 32.765872955322266, "ssim": 0.9539581537246704, "lpips": 0.10562926530838013, "ellipse_time": 0.03738962637411582, "num_GS": 1000000}
{"mem": 1.4448914527893066, "ellipse_time": 1309.4831788539886, "num_GS": 1000000}
