### PR TITLE
Fix build action: Upgraded upload-artifact@v3 / download-artifact@v3 -> upload-artifact@v4 / download-artifact@v4

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,26 +1,24 @@
 name: Build Wheels
 
-
 on: [workflow_call, workflow_dispatch]
 jobs:
   build_sdist:
     name: Build source distribution and no binary wheel
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Strip unsupported tags in README
-      run: |
-        sed -i '/<!-- pypi-strip -->/,/<!-- \/pypi-strip -->/d' README.md
-    - name: Build sdist
-      run: BUILD_NO_CUDA=1 pipx run build --sdist
-    - name: Build wheel with no binaries
-      run:  BUILD_NO_CUDA=1 python setup.py bdist_wheel --dist-dir=dist
-    - uses: actions/upload-artifact@v3
-      with:
-        name: pypi_packages
-        path: dist/*.tar.gz
+      - uses: actions/checkout@v4
+      - name: Strip unsupported tags in README
+        run: |
+          sed -i '/<!-- pypi-strip -->/,/<!-- \/pypi-strip -->/d' README.md
+      - name: Build sdist
+        run: BUILD_NO_CUDA=1 pipx run build --sdist
+      - name: Build wheel with no binaries
+        run: BUILD_NO_CUDA=1 python setup.py bdist_wheel --dist-dir=dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi_packages
+          path: dist/*.tar.gz
  
-  
   build_wheels:
     runs-on: ${{ matrix.os }}
     environment: production
@@ -32,10 +30,6 @@ jobs:
         python-version: ['3.10']
         torch-version: ['2.0.0', '2.1.0', '2.2.0', '2.3.0', '2.4.0']
         cuda-version: ['cu118', 'cu121', 'cu124']
-        # python-version: ['3.8']
-        # torch-version: ['2.0.0']
-        # cuda-version: ['cu118']
-
         exclude:
           - python-version: 3.12
             torch-version: 2.0.0
@@ -78,7 +72,7 @@ jobs:
           - torch-version: 2.4.0
             cuda-version: 'cu116'
           - torch-version: 2.4.0
-            cuda-version: 'cu117'          
+            cuda-version: 'cu117'
           - os: windows-2019
             torch-version: 2.0.0
             cuda-version: 'cu121'
@@ -149,12 +143,11 @@ jobs:
         shell: bash
 
       - name: Build wheel
-        # build against architectures >= 7.0 (required by cooperative_groups::labeled_partition in gsplat)
-        run: |          
+        run: |
           pip install wheel
           source .github/workflows/cuda/${{ runner.os }}-env.sh ${{ matrix.cuda-version }}
           MAX_JOBS=2 python setup.py bdist_wheel --dist-dir=dist
-        shell: bash  # `source` does not exist in windows powershell
+        shell: bash
 
       - name: Test wheel
         run: |
@@ -163,11 +156,10 @@ jobs:
           pip install *.whl
           python -c "import gsplat; print('gsplat:', gsplat.__version__)"
           cd ..
-        shell: bash  # `ls -lah` does not exist in windows powershell
+        shell: bash
 
-        # v4 does not allow writing into the same folder, so stick with v3
-        # https://github.com/actions/upload-artifact/issues/478
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: compiled_wheels_python${{ matrix.python-version }}
+          # Include unique matrix values to avoid name collisions.
+          name: compiled_wheels_python${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.torch-version }}-${{ matrix.cuda-version }}
           path: dist/*.whl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
-# This workflows will upload a Python Package using twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# Build and Release Wheels
 
 name: Build and Release Wheels
 
@@ -11,14 +10,13 @@ permissions:
   contents: write
 
 jobs:
-
-  # Build the wheels using reusable_building.yml
+  # Build the wheels using the reusable building workflow
   build_wheels:
     name: Call reusable building workflow
     uses: ./.github/workflows/building.yml  
 
   create_release_and_upload_packages:
-    name: Uplodad to Github Release
+    name: Upload to GitHub Release
     needs: [build_wheels]
     runs-on: ubuntu-latest
     strategy:
@@ -26,53 +24,55 @@ jobs:
       matrix:
         python-version: ['3.10']
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Download packages
+        id: download_artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # The unique artifact names from building.yml all start with
+          # "compiled_wheels_python${{ matrix.python-version }}" so this pattern
+          # will match them all and merge them into the 'dist' directory.
+          pattern: compiled_wheels_python${{ matrix.python-version }}*
+          path: dist
+          merge-multiple: true
 
-    - name: Download packages
-      id: download_artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: compiled_wheels_python${{ matrix.python-version }}
-        path: dist
+      - name: Upload packages to GitHub Release
+        id: upload_assets
+        run: |
+          for file in $(ls ./dist/*.*); do
+            echo "Uploading $file..."
+            filename=$(basename "$file")
+            encoded_filename=$(echo "$filename" | sed 's/+/%2B/g')
+            curl -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Content-Type: application/zip" \
+              --data-binary @"$file" \
+              "${{ github.event.release.upload_url }}=$encoded_filename"
+          done
 
-    - name: Upload packages to GitHub Release
-      id: upload_assets
-      run: |
-        for file in $(ls ./dist/*.*); do
-          echo "Uploading $file..."
-          filename=$(basename "$file")
-          encoded_filename=$(echo "$filename" | sed 's/+/%2B/g')
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/zip" \
-            --data-binary @"$file" \
-            "${{ github.event.release.upload_url }}=$encoded_filename"
-        done
-    
   generate_simple_index_pages:
     name: Generate Simple Index Pages
     needs: [create_release_and_upload_packages]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Generate Simple Index Pages
+        run: python .github/workflows/generate_simple_index_pages.py --outdir ./whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Generate Simple Index Pages
-      run: python .github/workflows/generate_simple_index_pages.py --outdir ./whl
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
-
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./whl  # Directory where the simple index pages are located
-        destination_dir: whl  # The 'wh' folder in the GitHub Pages root
-        keep_files: false  # This will only erase the destination subdirectory.
-        cname: docs.gsplat.studio
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./whl
+          destination_dir: whl
+          keep_files: false
+          cname: docs.gsplat.studio
 
   upload_pypi:
     name: Upload to PyPi
@@ -80,32 +80,25 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi_packages
+          path: dist
 
-    - uses: actions/download-artifact@v3
-      with:
-        name: pypi_packages
-        path: dist
- 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.7'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
       
-    - name: Install dependencies
-      run: |
+      - name: Install dependencies
+        run: |
           python -m pip install build twine
-      shell: bash
+        shell: bash
 
-    # - name: Publish package to Test PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    #     repository-url: https://test.pypi.org/legacy/
-
-    - name: Publish package to PyPI
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |         
-        BUILD_NO_CUDA=1 python -m build
-        twine upload --username __token__ --password $PYPI_TOKEN dist/*
-      shell: bash
+      - name: Publish package to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          BUILD_NO_CUDA=1 python -m build
+          twine upload --username __token__ --password $PYPI_TOKEN dist/*
+        shell: bash


### PR DESCRIPTION
Migrated `upload-artifact` and `download-artifact` to migrate from v3 to v4, builds should work again now.
## Changes
- Updated all instances of actions/upload-artifact and actions/download-artifact from v3 to v4.
    - In v4, artifacts are immutable, so I modified the build workflow to append matrix values (OS, torch version, CUDA version) to the artifact names to avoid collisions.
- Adjusted the publish workflow to use a wildcard pattern and merge-multiple: true in the download step, ensuring that all individual wheel artifacts are merged into a single dist directory.