### PR TITLE
Fixed redundant PyTest mark that was applied to a fixture.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,8 +17,6 @@ from gsplat._helper import load_test_data
 
 device = torch.device("cuda:0")
 
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.fixture
 def test_data():
     (


### PR DESCRIPTION
Fixed redundant mark that was applied to a fixture that had no effect and was throwing a warning from PyTest (CUDA/Pytorch installs worked).


![Screenshot from 2025-04-18 11-37-05](https://github.com/user-attachments/assets/7480c6c1-4014-4430-a2a0-0f872fb4a5e8)
