### PR TITLE
Fix up side down flipping for most of the cases

### DIFF
--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -276,7 +276,7 @@ def rasterization(
     if absgrad:
         assert not distributed, "AbsGrad is not supported in distributed mode."
 
-    # Implement the multi-GPU strategy proposed in 
+    # Implement the multi-GPU strategy proposed in
     # `On Scaling Up 3D Gaussian Splatting Training <https://arxiv.org/abs/2406.18533>`.
     #
     # If in distributed mode, we distribute the projection computation over Gaussians
@@ -397,7 +397,7 @@ def rasterization(
 
     # If in distributed mode, we need to scatter the GSs to the destination ranks, based
     # on which cameras they are visible to, which we already figured out in the projection
-    # stage. 
+    # stage.
     if distributed:
         if packed:
             # count how many elements need to be sent to each rank


### PR DESCRIPTION
Assuming more colmap points towards -z direction (which is mostly true esp when ground floor is captured), we could figure out the up direction and disambiguate the scene normalization process