### PR TITLE
Fix inverted scene when flipped

### DIFF
--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -230,10 +230,10 @@ class Parser:
             # the bottom of the scene which is true when ground floor is
             # present in the images.
             if np.median(points[:, 2]) > np.mean(points[:, 2]):
-                # rotate 180 degrees such that z is flipped
+                # rotate 180 degrees around x axis such that z is flipped
                 T3 = np.array(
                     [
-                        [-1.0, 0.0, 0.0, 0.0],
+                        [1.0, 0.0, 0.0, 0.0],
                         [0.0, -1.0, 0.0, 0.0],
                         [0.0, 0.0, -1.0, 0.0],
                         [0.0, 0.0, 0.0, 1.0],


### PR DESCRIPTION
Fix for: https://github.com/nerfstudio-project/gsplat/issues/655

It looks like, whenever the bulk of the points are above the middle, gsplat is trying to rotate everything 180 degrees. This makes sense, but the matrix that is being applied is:

[-1.0, 0.0, 0.0, 0.0],
[0.0, -1.0, 0.0, 0.0],
[0.0, 0.0, -1.0, 0.0],
[0.0, 0.0, 0.0, 1.0],

This transformation matrix mirrors all axes instead of rotating 180 degrees. This results in all text being backwards / mirrored whenever this scenario is hit. Instead I think we'd want to rotate 180 degrees around the X or Y axis (effectively flipping +Z to -Z). This way we won't invert everything, we instead flip it. The matrix would look like this:

X-axis rotation (flip Y and Z):

[1.0, 0.0, 0.0, 0.0],
[0.0, -1.0, 0.0, 0.0],
[0.0, 0.0, -1.0, 0.0],
[0.0, 0.0, 0.0, 1.0]

or Y-axis rotation (flip X and Z):

[-1.0, 0.0, 0.0, 0.0],
[0.0, 1.0, 0.0, 0.0],
[0.0, 0.0, -1.0, 0.0],
[0.0, 0.0, 0.0, 1.0]

I believe either of these matrices might work better for the intended purpose of flipping the scene 180 degrees.

Thank you for all your work on this project!

Old (notice the word YETI is inverted, and the scanned environment is a mirror image of what it is in reality!):

![438459898-d037a343-17bb-4449-8959-6b09044f6866](https://github.com/user-attachments/assets/9f4ab1fc-c830-471e-be7f-2ccb82d7527a)


New (my YETI cooler has the correct non-inverted text now!):

![438458133-7007d53e-c842-4408-bbe6-c2bf6daefccf](https://github.com/user-attachments/assets/ef707f7e-a95b-481e-9541-2ffbe60b379b)