### PR TITLE
Minor fix

### DIFF
--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -866,7 +866,7 @@ class Runner:
 
             if not cfg.disable_viewer:
                 self.viewer.lock.release()
-                num_train_steps_per_sec = 1.0 / (time.time() - tic)
+                num_train_steps_per_sec = 1.0 / (max(time.time() - tic, 1e-10))
                 num_train_rays_per_sec = (
                     num_train_rays_per_step * num_train_steps_per_sec
                 )
@@ -911,7 +911,7 @@ class Runner:
                 masks=masks,
             )  # [1, H, W, 3]
             torch.cuda.synchronize()
-            ellipse_time += time.time() - tic
+            ellipse_time += max(time.time() - tic, 1e-10)
 
             colors = torch.clamp(colors, 0.0, 1.0)
             canvas_list = [pixels, colors]
@@ -1147,8 +1147,8 @@ def main(local_rank: int, world_rank, world_size: int, cfg: Config):
     else:
         runner.train()
 
-    runner.viewer.complete()
     if not cfg.disable_viewer:
+        runner.viewer.complete()
         print("Viewer running... Ctrl+C to exit.")
         time.sleep(1000000)
 

--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -731,7 +731,7 @@ class Runner:
 
             if not cfg.disable_viewer:
                 self.viewer.lock.release()
-                num_train_steps_per_sec = 1.0 / (time.time() - tic)
+                num_train_steps_per_sec = 1.0 / (max(time.time() - tic, 1e-10))
                 num_train_rays_per_sec = (
                     num_train_rays_per_step * num_train_steps_per_sec
                 )
@@ -781,7 +781,7 @@ class Runner:
             colors = torch.clamp(colors, 0.0, 1.0)
             colors = colors[..., :3]  # Take RGB channels
             torch.cuda.synchronize()
-            ellipse_time += time.time() - tic
+            ellipse_time += max(time.time() - tic, 1e-10)
 
             # write images
             canvas = torch.cat([pixels, colors], dim=2).squeeze(0).cpu().numpy()


### PR DESCRIPTION
Tested on Windows

### 1. ZeroDivisionError
```
num_train_steps_per_sec = 1.0 / (time.time() - tic)
```
ZeroDivisionError: float division by zero

### 2. Wrong runner.viewer.complete() call.
Original [call](https://github.com/nerfstudio-project/gsplat/blob/d28de38d09efb41a04eaa92c67cc1f5cda5d4978/examples/simple_trainer.py#L1150) is out of if not cfg.disable_viewer. If users specify ```--disable-viewer```, it leads to ```AttributeError: 'Runner' object has no attribute 'viewer'``` See definition [here](https://github.com/nerfstudio-project/gsplat/blob/d28de38d09efb41a04eaa92c67cc1f5cda5d4978/examples/simple_trainer.py#L446).
  