### PR TITLE
Alpha shouldn't be normalized or inversed?

### DIFF
--- a/examples/gsplat_viewer.py
+++ b/examples/gsplat_viewer.py
@@ -21,7 +21,7 @@ class GsplatRenderTabState(RenderTabState):
         "rgb", "depth(accumulated)", "depth(expected)", "alpha"
     ] = "rgb"
     normalize_nearfar: bool = False
-    inverse: bool = True
+    inverse: bool = False
     colormap: Literal[
         "turbo", "viridis", "magma", "inferno", "cividis", "gray"
     ] = "turbo"
@@ -150,12 +150,10 @@ class GsplatViewer(Viewer):
                 def _(_) -> None:
                     if "depth" in render_mode_dropdown.value:
                         normalize_nearfar_checkbox.disabled = False
+                        inverse_checkbox.disabled = False
                     else:
                         normalize_nearfar_checkbox.disabled = True
-                    if render_mode_dropdown.value == "rgb":
                         inverse_checkbox.disabled = True
-                    else:
-                        inverse_checkbox.disabled = False
                     self.render_tab_state.render_mode = render_mode_dropdown.value
                     self.rerender(_)
 

--- a/examples/simple_viewer.py
+++ b/examples/simple_viewer.py
@@ -197,8 +197,6 @@ def main(local_rank: int, world_rank, world_size: int, args):
             )
         elif render_tab_state.render_mode == "alpha":
             alpha = render_alphas[0, ..., 0:1]
-            if render_tab_state.inverse:
-                alpha = 1 - alpha
             renders = (
                 apply_float_colormap(alpha, render_tab_state.colormap).cpu().numpy()
             )


### PR DESCRIPTION
<img width="1277" alt="Screenshot 2025-05-24 164121" src="https://github.com/user-attachments/assets/47a2ba3e-11d1-45a9-af1e-65dda15b0564" />
When I check this default alpha map, it looks quite counterintuitive. It means all my primitives are transparent.

I check the code and find that the alpha map is affected by depth normalize and inverse check boxes.
Per their hints, I think they should only affect the depth maps, not rgb and alpha.

This PR 
- Makes normalize and inverse check boxes enabled only when it's depth rendering.
- Switches Inverse to off by default, since having it on by default feels counterintuitive.