### PR TITLE
New experimental feature: fused bilagrid

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -20,4 +20,5 @@ tensorly
 pyyaml
 matplotlib
 git+https://github.com/rahul-goel/fused-ssim@328dc9836f513d00c4b5bc38fe30478b4435cbb5
+git+https://github.com/harry7557558/fused-bilagrid@90f9788e57d3545e3a033c1038bb9986549632fe
 splines


### PR DESCRIPTION
This PR uses https://github.com/harry7557558/fused-bilagrid repo. 

I have benchmarked it with Mip360 dataset.

## MCMC-1 million splats
It is about 14.7 % faster (based on ellipse_time) and the original consumes 26% more VRAM.

Original Bilateral grid
![image](https://github.com/user-attachments/assets/cb80454f-b985-43a3-8cff-c02dff3cd306)

Fused Bilateral grid commit [90f9788](https://github.com/harry7557558/fused-bilagrid/commit/90f9788e57d3545e3a033c1038bb9986549632fe)
![image](https://github.com/user-attachments/assets/b87dbd78-a0e0-44f7-bf2f-44d5ad7bbd6a)

## 3DGUT-MCMC-1 million splats

This benchmark utilize 3DGUT. The code is same as before with extra `--with_ut --with_eval3d` arguments.
About 14.5% faster and the original consumes 26.1% more VRAM

Original bilateral grid
![image](https://github.com/user-attachments/assets/27ada5d7-98f3-42f0-87ac-2cfd91b6cb77)

Fused bilateral grid
![image](https://github.com/user-attachments/assets/7195c2cf-7435-4419-bce3-b2259f84bdc1)

## MULTI GPU WITH GSPLAT FOR 1K ITERS

It's 30% faster and the original consumes 29.6% more VRAM/GPU. Please Note, Every GPU uses same value of VRAM. So, the total VRAM is the average of VRAM times 2 GPUs.

```bash
SCENE_DIR="data/360_v2"
RESULT_DIR="results/benchmark_MCMC1M-FusedBilagrid-BS1"
SCENE_LIST="garden bicycle stump bonsai counter kitchen room" # treehill flowers is not available
RENDER_TRAJ_PATH="ellipse"
ITERS='1000'

for SCENE in $SCENE_LIST;
do
    if [ "$SCENE" = "bonsai" ] || [ "$SCENE" = "counter" ] || [ "$SCENE" = "kitchen" ] || [ "$SCENE" = "room" ]; then
        DATA_FACTOR=2
    else
        DATA_FACTOR=4
    fi
    CUDA_VISIBLE_DEVICES=0,1 python3 examples/simple_trainer_FusedBilagrid.py mcmc --eval_steps $ITERS --disable_viewer --data_factor $DATA_FACTOR \
        --render_traj_path $RENDER_TRAJ_PATH --max-steps $ITERS \
        --use-bilateral-grid \
        --data_dir data/360_v2/$SCENE/ \
        --result_dir $RESULT_DIR/$SCENE/ --steps_scaler 0.5 --disable-video
done
```

Original Bilateral Grid
![image](https://github.com/user-attachments/assets/9cd49f1d-a0c9-46a5-a9d6-26840ceb3f68)

Fused Bilateral Grid
![image](https://github.com/user-attachments/assets/8dd5f30d-ce60-49b8-ba8f-cc4857a883b9)

Additional info
```
Ubuntu 22.04.3 LTS
Python 3.10
Torch 2.1.2+cu118
Gsplat 1.5.1
RTX 4090 in Cloud GPU
```