### PR TITLE
Support 2dgs with the latest viewer

### DIFF
--- a/examples/gsplat_viewer.py
+++ b/examples/gsplat_viewer.py
@@ -21,7 +21,7 @@ class GsplatRenderTabState(RenderTabState):
         "rgb", "depth(accumulated)", "depth(expected)", "alpha"
     ] = "rgb"
     normalize_nearfar: bool = False
-    inverse: bool = True
+    inverse: bool = False
     colormap: Literal[
         "turbo", "viridis", "magma", "inferno", "cividis", "gray"
     ] = "turbo"
@@ -150,12 +150,10 @@ class GsplatViewer(Viewer):
                 def _(_) -> None:
                     if "depth" in render_mode_dropdown.value:
                         normalize_nearfar_checkbox.disabled = False
+                        inverse_checkbox.disabled = False
                     else:
                         normalize_nearfar_checkbox.disabled = True
-                    if render_mode_dropdown.value == "rgb":
                         inverse_checkbox.disabled = True
-                    else:
-                        inverse_checkbox.disabled = False
                     self.render_tab_state.render_mode = render_mode_dropdown.value
                     self.rerender(_)
 

--- a/examples/gsplat_viewer_2dgs.py
+++ b/examples/gsplat_viewer_2dgs.py
@@ -1,0 +1,219 @@
+import viser
+from pathlib import Path
+from typing import Literal
+from typing import Tuple, Callable
+from nerfview import Viewer, RenderTabState
+
+
+class GsplatRenderTabState(RenderTabState):
+    # non-controlable parameters
+    total_gs_count: int = 0
+    rendered_gs_count: int = 0
+
+    # controlable parameters
+    max_sh_degree: int = 5
+    near_plane: float = 1e-2
+    far_plane: float = 1e2
+    radius_clip: float = 0.0
+    eps2d: float = 0.3
+    backgrounds: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    render_mode: Literal[
+        "rgb", "depth(accumulated)", "depth(expected)", "alpha"
+    ] = "rgb"
+    normalize_nearfar: bool = False
+    inverse: bool = False
+    colormap: Literal[
+        "turbo", "viridis", "magma", "inferno", "cividis", "gray"
+    ] = "turbo"
+
+
+class GsplatViewer(Viewer):
+    """
+    Viewer for gsplat 2dgs.
+    """
+
+    def __init__(
+        self,
+        server: viser.ViserServer,
+        render_fn: Callable,
+        output_dir: Path,
+        mode: Literal["rendering", "training"] = "rendering",
+    ):
+        super().__init__(server, render_fn, output_dir, mode)
+        server.gui.set_panel_label("gsplat 2dgs viewer")
+
+    def _init_rendering_tab(self):
+        self.render_tab_state = GsplatRenderTabState()
+        self._rendering_tab_handles = {}
+        self._rendering_folder = self.server.gui.add_folder("Rendering")
+
+    def _populate_rendering_tab(self):
+        server = self.server
+        with self._rendering_folder:
+            with server.gui.add_folder("Gsplat"):
+                total_gs_count_number = server.gui.add_number(
+                    "Total",
+                    initial_value=self.render_tab_state.total_gs_count,
+                    disabled=True,
+                    hint="Total number of splats in the scene.",
+                )
+                rendered_gs_count_number = server.gui.add_number(
+                    "Rendered",
+                    initial_value=self.render_tab_state.rendered_gs_count,
+                    disabled=True,
+                    hint="Number of splats rendered.",
+                )
+
+                max_sh_degree_number = server.gui.add_number(
+                    "Max SH",
+                    initial_value=self.render_tab_state.max_sh_degree,
+                    min=0,
+                    max=5,
+                    step=1,
+                    hint="Maximum SH degree used",
+                )
+
+                @max_sh_degree_number.on_update
+                def _(_) -> None:
+                    self.render_tab_state.max_sh_degree = int(
+                        max_sh_degree_number.value
+                    )
+                    self.rerender(_)
+
+                near_far_plane_vec2 = server.gui.add_vector2(
+                    "Near/Far",
+                    initial_value=(
+                        self.render_tab_state.near_plane,
+                        self.render_tab_state.far_plane,
+                    ),
+                    min=(1e-3, 1e1),
+                    max=(1e1, 1e3),
+                    step=1e-3,
+                    hint="Near and far plane for rendering.",
+                )
+
+                @near_far_plane_vec2.on_update
+                def _(_) -> None:
+                    self.render_tab_state.near_plane = near_far_plane_vec2.value[0]
+                    self.render_tab_state.far_plane = near_far_plane_vec2.value[1]
+                    self.rerender(_)
+
+                radius_clip_slider = server.gui.add_number(
+                    "Radius Clip",
+                    initial_value=self.render_tab_state.radius_clip,
+                    min=0.0,
+                    max=100.0,
+                    step=1.0,
+                    hint="2D radius clip for rendering.",
+                )
+
+                @radius_clip_slider.on_update
+                def _(_) -> None:
+                    self.render_tab_state.radius_clip = radius_clip_slider.value
+                    self.rerender(_)
+
+                eps2d_slider = server.gui.add_number(
+                    "2D Epsilon",
+                    initial_value=self.render_tab_state.eps2d,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    hint="Epsilon added to the egienvalues of projected 2D covariance matrices.",
+                )
+
+                @eps2d_slider.on_update
+                def _(_) -> None:
+                    self.render_tab_state.eps2d = eps2d_slider.value
+                    self.rerender(_)
+
+                backgrounds_slider = server.gui.add_rgb(
+                    "Background",
+                    initial_value=self.render_tab_state.backgrounds,
+                    hint="Background color for rendering.",
+                )
+
+                @backgrounds_slider.on_update
+                def _(_) -> None:
+                    self.render_tab_state.backgrounds = backgrounds_slider.value
+                    self.rerender(_)
+
+                render_mode_dropdown = server.gui.add_dropdown(
+                    "Render Mode",
+                    ("rgb", "depth", "normal", "alpha"),
+                    initial_value=self.render_tab_state.render_mode,
+                    hint="Render mode to use.",
+                )
+
+                @render_mode_dropdown.on_update
+                def _(_) -> None:
+                    if "depth" in render_mode_dropdown.value:
+                        normalize_nearfar_checkbox.disabled = False
+                        inverse_checkbox.disabled = False
+                    else:
+                        normalize_nearfar_checkbox.disabled = True
+                        inverse_checkbox.disabled = True
+                    self.render_tab_state.render_mode = render_mode_dropdown.value
+                    self.rerender(_)
+
+                normalize_nearfar_checkbox = server.gui.add_checkbox(
+                    "Normalize Near/Far",
+                    initial_value=self.render_tab_state.normalize_nearfar,
+                    disabled=True,
+                    hint="Normalize depth with near/far plane.",
+                )
+
+                @normalize_nearfar_checkbox.on_update
+                def _(_) -> None:
+                    self.render_tab_state.normalize_nearfar = (
+                        normalize_nearfar_checkbox.value
+                    )
+                    self.rerender(_)
+
+                inverse_checkbox = server.gui.add_checkbox(
+                    "Inverse",
+                    initial_value=self.render_tab_state.inverse,
+                    disabled=True,
+                    hint="Inverse the depth.",
+                )
+
+                @inverse_checkbox.on_update
+                def _(_) -> None:
+                    self.render_tab_state.inverse = inverse_checkbox.value
+                    self.rerender(_)
+
+                colormap_dropdown = server.gui.add_dropdown(
+                    "Colormap",
+                    ("turbo", "viridis", "magma", "inferno", "cividis", "gray"),
+                    initial_value=self.render_tab_state.colormap,
+                    hint="Colormap used for rendering depth/alpha.",
+                )
+
+                @colormap_dropdown.on_update
+                def _(_) -> None:
+                    self.render_tab_state.colormap = colormap_dropdown.value
+                    self.rerender(_)
+
+        self._rendering_tab_handles.update(
+            {
+                "total_gs_count_number": total_gs_count_number,
+                "rendered_gs_count_number": rendered_gs_count_number,
+                "near_far_plane_vec2": near_far_plane_vec2,
+                "radius_clip_slider": radius_clip_slider,
+                "eps2d_slider": eps2d_slider,
+                "backgrounds_slider": backgrounds_slider,
+                "render_mode_dropdown": render_mode_dropdown,
+                "normalize_nearfar_checkbox": normalize_nearfar_checkbox,
+                "inverse_checkbox": inverse_checkbox,
+                "colormap_dropdown": colormap_dropdown,
+            }
+        )
+        super()._populate_rendering_tab()
+
+    def _after_render(self):
+        # Update the GUI elements with current values
+        self._rendering_tab_handles[
+            "total_gs_count_number"
+        ].value = self.render_tab_state.total_gs_count
+        self._rendering_tab_handles[
+            "rendered_gs_count_number"
+        ].value = self.render_tab_state.rendered_gs_count

--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -965,6 +965,7 @@ class Runner:
             far_plane=render_tab_state.far_plane,
             radius_clip=render_tab_state.radius_clip,
             eps2d=render_tab_state.eps2d,
+            render_mode="RGB+ED",
             backgrounds=torch.tensor([render_tab_state.backgrounds], device=self.device)
             / 255.0,
         )  # [1, H, W, 3]

--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -4,6 +4,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Tuple
+from pathlib import Path
 
 import imageio
 import nerfview
@@ -28,9 +29,10 @@ from utils import (
     rgb_to_sh,
     set_random_seed,
 )
-
+from gsplat_viewer_2dgs import GsplatViewer, GsplatRenderTabState
 from gsplat.rendering import rasterization_2dgs, rasterization_2dgs_inria_wrapper
 from gsplat.strategy import DefaultStrategy
+from nerfview import CameraState, RenderTabState, apply_float_colormap
 
 
 @dataclass
@@ -375,9 +377,10 @@ class Runner:
         # Viewer
         if not self.cfg.disable_viewer:
             self.server = viser.ViserServer(port=cfg.port, verbose=False)
-            self.viewer = nerfview.Viewer(
+            self.viewer = GsplatViewer(
                 server=self.server,
                 render_fn=self._viewer_render_fn,
+                output_dir=Path(cfg.result_dir),
                 mode="training",
             )
 
@@ -507,7 +510,7 @@ class Runner:
         pbar = tqdm.tqdm(range(init_step, max_steps))
         for step in pbar:
             if not cfg.disable_viewer:
-                while self.viewer.state.status == "paused":
+                while self.viewer.state == "paused":
                     time.sleep(0.01)
                 self.viewer.lock.acquire()
                 tic = time.time()
@@ -736,7 +739,9 @@ class Runner:
                     num_train_rays_per_step * num_train_steps_per_sec
                 )
                 # Update the viewer state.
-                self.viewer.state.num_train_rays_per_sec = num_train_rays_per_sec
+                self.viewer.render_tab_state.num_train_rays_per_sec = (
+                    num_train_rays_per_sec
+                )
                 # Update the scene.
                 self.viewer.update(step, num_train_rays_per_step)
 
@@ -795,7 +800,7 @@ class Runner:
             )
             # render_median = render_median.detach().cpu().squeeze(0).unsqueeze(-1).repeat(1, 1, 3).numpy()
             render_median = (
-                render_median.detach().cpu().squeeze(0).repeat(1, 1, 3).numpy()
+                apply_float_colormap(render_median).detach().cpu().squeeze(0).numpy()
             )
 
             imageio.imwrite(
@@ -831,13 +836,11 @@ class Runner:
             dist_min = torch.min(render_dist)
             render_dist = (render_dist - dist_min) / (dist_max - dist_min)
             render_dist = (
-                colormap(render_dist.cpu().numpy()[0])
-                .permute((1, 2, 0))
-                .numpy()
-                .astype(np.uint8)
+                apply_float_colormap(render_dist).detach().cpu().squeeze(0).numpy()
             )
             imageio.imwrite(
-                f"{self.render_dir}/val_{i:04d}_distortions_{step}.png", render_dist
+                f"{self.render_dir}/val_{i:04d}_distortions_{step}.png",
+                (render_dist * 255).astype(np.uint8),
             )
 
             pixels = pixels.permute(0, 3, 1, 2)  # [1, 3, H, W]
@@ -930,24 +933,74 @@ class Runner:
 
     @torch.no_grad()
     def _viewer_render_fn(
-        self, camera_state: nerfview.CameraState, img_wh: Tuple[int, int]
+        self, camera_state: CameraState, render_tab_state: RenderTabState
     ):
-        """Callable function for the viewer."""
-        W, H = img_wh
+        assert isinstance(render_tab_state, GsplatRenderTabState)
+        if render_tab_state.preview_render:
+            width = render_tab_state.render_width
+            height = render_tab_state.render_height
+        else:
+            width = render_tab_state.viewer_width
+            height = render_tab_state.viewer_height
         c2w = camera_state.c2w
-        K = camera_state.get_K(img_wh)
+        K = camera_state.get_K((width, height))
         c2w = torch.from_numpy(c2w).float().to(self.device)
         K = torch.from_numpy(K).float().to(self.device)
 
-        render_colors, _, _, _, _, _, _ = self.rasterize_splats(
+        (
+            render_colors,
+            render_alphas,
+            render_normals,
+            normals_from_depth,
+            render_distort,
+            render_median,
+            info,
+        ) = self.rasterize_splats(
             camtoworlds=c2w[None],
             Ks=K[None],
-            width=W,
-            height=H,
-            sh_degree=self.cfg.sh_degree,  # active all SH degrees
-            radius_clip=3.0,  # skip GSs that have small image radius (in pixels)
+            width=width,
+            height=height,
+            sh_degree=min(render_tab_state.max_sh_degree, self.cfg.sh_degree),
+            near_plane=render_tab_state.near_plane,
+            far_plane=render_tab_state.far_plane,
+            radius_clip=render_tab_state.radius_clip,
+            eps2d=render_tab_state.eps2d,
+            backgrounds=torch.tensor([render_tab_state.backgrounds], device=self.device)
+            / 255.0,
         )  # [1, H, W, 3]
-        return render_colors[0].cpu().numpy()
+        render_tab_state.total_gs_count = len(self.splats["means"])
+        render_tab_state.rendered_gs_count = (info["radii"] > 0).all(-1).sum().item()
+
+        if render_tab_state.render_mode == "depth":
+            # normalize depth to [0, 1]
+            depth = render_median
+            if render_tab_state.normalize_nearfar:
+                near_plane = render_tab_state.near_plane
+                far_plane = render_tab_state.far_plane
+            else:
+                near_plane = depth.min()
+                far_plane = depth.max()
+            depth_norm = (depth - near_plane) / (far_plane - near_plane + 1e-10)
+            depth_norm = torch.clip(depth_norm, 0, 1)
+            if render_tab_state.inverse:
+                depth_norm = 1 - depth_norm
+            renders = (
+                apply_float_colormap(depth_norm, render_tab_state.colormap)
+                .cpu()
+                .numpy()
+            )
+        elif render_tab_state.render_mode == "normal":
+            render_normals = render_normals * 0.5 + 0.5  # normalize to [0, 1]
+            renders = render_normals.cpu().numpy()
+        elif render_tab_state.render_mode == "alpha":
+            alpha = render_alphas[0, ..., 0:1]
+            renders = (
+                apply_float_colormap(alpha, render_tab_state.colormap).cpu().numpy()
+            )
+        else:
+            render_colors = render_colors[0, ..., 0:3].clamp(0, 1)
+            renders = render_colors.cpu().numpy()
+        return renders
 
 
 def main(cfg: Config):

--- a/examples/simple_viewer.py
+++ b/examples/simple_viewer.py
@@ -197,8 +197,6 @@ def main(local_rank: int, world_rank, world_size: int, args):
             )
         elif render_tab_state.render_mode == "alpha":
             alpha = render_alphas[0, ..., 0:1]
-            if render_tab_state.inverse:
-                alpha = 1 - alpha
             renders = (
                 apply_float_colormap(alpha, render_tab_state.colormap).cpu().numpy()
             )

--- a/examples/simple_viewer_2dgs.py
+++ b/examples/simple_viewer_2dgs.py
@@ -1,0 +1,157 @@
+import argparse
+import math
+import time
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import viser
+from pathlib import Path
+from gsplat.distributed import cli
+from gsplat.rendering import rasterization_2dgs
+
+from nerfview import CameraState, RenderTabState, apply_float_colormap
+from gsplat_viewer_2dgs import GsplatViewer, GsplatRenderTabState
+
+
+def main(local_rank: int, world_rank, world_size: int, args):
+    torch.manual_seed(42)
+    device = torch.device("cuda", local_rank)
+
+    means, quats, scales, opacities, sh0, shN = [], [], [], [], [], []
+    for ckpt_path in args.ckpt:
+        ckpt = torch.load(ckpt_path, map_location=device)["splats"]
+        means.append(ckpt["means"])
+        quats.append(F.normalize(ckpt["quats"], p=2, dim=-1))
+        scales.append(torch.exp(ckpt["scales"]))
+        opacities.append(torch.sigmoid(ckpt["opacities"]))
+        sh0.append(ckpt["sh0"])
+        shN.append(ckpt["shN"])
+    means = torch.cat(means, dim=0)
+    quats = torch.cat(quats, dim=0)
+    scales = torch.cat(scales, dim=0)
+    opacities = torch.cat(opacities, dim=0)
+    sh0 = torch.cat(sh0, dim=0)
+    shN = torch.cat(shN, dim=0)
+    colors = torch.cat([sh0, shN], dim=-2)
+    sh_degree = int(math.sqrt(colors.shape[-2]) - 1)
+    print("Number of Gaussians:", len(means))
+
+    # register and open viewer
+    @torch.no_grad()
+    def viewer_render_fn(camera_state: CameraState, render_tab_state: RenderTabState):
+        assert isinstance(render_tab_state, GsplatRenderTabState)
+        if render_tab_state.preview_render:
+            width = render_tab_state.render_width
+            height = render_tab_state.render_height
+        else:
+            width = render_tab_state.viewer_width
+            height = render_tab_state.viewer_height
+        c2w = camera_state.c2w
+        K = camera_state.get_K((width, height))
+        c2w = torch.from_numpy(c2w).float().to(device)
+        K = torch.from_numpy(K).float().to(device)
+        viewmat = c2w.inverse()
+
+        (
+            render_colors,
+            render_alphas,
+            render_normals,
+            normals_from_depth,
+            render_distort,
+            render_median,
+            info,
+        ) = rasterization_2dgs(
+            means=means,
+            quats=quats,
+            scales=scales,
+            opacities=opacities,
+            colors=colors,
+            viewmats=viewmat[None],
+            Ks=K[None],
+            width=width,
+            height=height,
+            sh_degree=(
+                min(render_tab_state.max_sh_degree, sh_degree)
+                if sh_degree is not None
+                else None
+            )
+        )
+        render_tab_state.total_gs_count = len(means)
+        render_tab_state.rendered_gs_count = (info["radii"] > 0).all(-1).sum().item()
+
+        if render_tab_state.render_mode == "depth":
+            # normalize depth to [0, 1]
+            depth = render_median
+            if render_tab_state.normalize_nearfar:
+                near_plane = render_tab_state.near_plane
+                far_plane = render_tab_state.far_plane
+            else:
+                near_plane = depth.min()
+                far_plane = depth.max()
+            depth_norm = (depth - near_plane) / (far_plane - near_plane + 1e-10)
+            depth_norm = torch.clip(depth_norm, 0, 1)
+            if render_tab_state.inverse:
+                depth_norm = 1 - depth_norm
+            renders = (
+                apply_float_colormap(depth_norm, render_tab_state.colormap)
+                .cpu()
+                .numpy()
+            )
+        elif render_tab_state.render_mode == "normal":
+            render_normals = render_normals * 0.5 + 0.5  # normalize to [0, 1]
+            renders = render_normals.cpu().numpy()
+        elif render_tab_state.render_mode == "alpha":
+            alpha = render_alphas[0, ..., 0:1]
+            renders = (
+                apply_float_colormap(alpha, render_tab_state.colormap).cpu().numpy()
+            )
+        else:
+            render_colors = render_colors[0, ..., 0:3].clamp(0, 1)
+            renders = render_colors.cpu().numpy()
+        return renders
+
+    server = viser.ViserServer(port=args.port, verbose=False)
+    _ = GsplatViewer(
+        server=server,
+        render_fn=viewer_render_fn,
+        output_dir=Path(args.output_dir),
+        mode="rendering",
+    )
+    print("Viewer running... Ctrl+C to exit.")
+    time.sleep(100000)
+
+
+if __name__ == "__main__":
+    """
+    # Use single GPU to view the scene
+    CUDA_VISIBLE_DEVICES=9 python -m simple_viewer \
+        --ckpt results/garden/ckpts/ckpt_6999_rank0.pt \
+        --output_dir results/garden/ \
+        --port 8082
+    
+    CUDA_VISIBLE_DEVICES=9 python -m simple_viewer \
+        --output_dir results/garden/ \
+        --port 8082
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output_dir", type=str, default="results/", help="where to dump outputs"
+    )
+    parser.add_argument(
+        "--scene_grid", type=int, default=1, help="repeat the scene into a grid of NxN"
+    )
+    parser.add_argument(
+        "--ckpt", type=str, nargs="+", default=None, help="path to the .pt file"
+    )
+    parser.add_argument(
+        "--port", type=int, default=8080, help="port for the viewer server"
+    )
+    parser.add_argument(
+        "--with_ut", action="store_true", help="use uncentered transform"
+    )
+    parser.add_argument("--with_eval3d", action="store_true", help="use eval 3D")
+    args = parser.parse_args()
+    assert args.scene_grid % 2 == 1, "scene_grid must be odd"
+
+    cli(main, args, verbose=True)

--- a/examples/simple_viewer_2dgs.py
+++ b/examples/simple_viewer_2dgs.py
@@ -76,6 +76,13 @@ def main(local_rank: int, world_rank, world_size: int, args):
                 if sh_degree is not None
                 else None
             ),
+            near_plane=render_tab_state.near_plane,
+            far_plane=render_tab_state.far_plane,
+            radius_clip=render_tab_state.radius_clip,
+            eps2d=render_tab_state.eps2d,
+            render_mode="RGB+ED",
+            backgrounds=torch.tensor([render_tab_state.backgrounds], device=device)
+            / 255.0,
         )
         render_tab_state.total_gs_count = len(means)
         render_tab_state.rendered_gs_count = (info["radii"] > 0).all(-1).sum().item()
@@ -147,10 +154,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--port", type=int, default=8080, help="port for the viewer server"
     )
-    parser.add_argument(
-        "--with_ut", action="store_true", help="use uncentered transform"
-    )
-    parser.add_argument("--with_eval3d", action="store_true", help="use eval 3D")
     args = parser.parse_args()
     assert args.scene_grid % 2 == 1, "scene_grid must be odd"
 

--- a/examples/simple_viewer_2dgs.py
+++ b/examples/simple_viewer_2dgs.py
@@ -75,7 +75,7 @@ def main(local_rank: int, world_rank, world_size: int, args):
                 min(render_tab_state.max_sh_degree, sh_degree)
                 if sh_degree is not None
                 else None
-            )
+            ),
         )
         render_tab_state.total_gs_count = len(means)
         render_tab_state.rendered_gs_count = (info["radii"] > 0).all(-1).sum().item()

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -1529,7 +1529,7 @@ def rasterization_2dgs(
 
         if backgrounds is not None:
             backgrounds = torch.cat(
-                (backgrounds, torch.zeros_like(depths[..., None])), dim=-1
+                (backgrounds, torch.zeros_like(backgrounds[..., :1])), dim=-1
             )
     elif render_mode in ["D", "ED"]:
         colors = depths[..., None]


### PR DESCRIPTION


https://github.com/user-attachments/assets/d99545a6-84b2-4836-9f39-39fdf8731269



- This PR adds support for running 2DGS with the latest version of nerfview, ensuring compatibility and functionality. Without this update, 2DGS cannot be executed properly. Render mode supports rgb, depth, normal, and alpha.

- Replaced the use of colormap with apply_float_colormap. While both provide similar logic, colormap triggers runtime errors in my environment. Suggest to unify the function usage and stick to apply_float_colormap.