### PR TITLE
Add option to disable world space normalization for 2DGS

### DIFF
--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -54,6 +54,8 @@ class Config:
     patch_size: Optional[int] = None
     # A global scaler that applies to the scene size related parameters
     global_scale: float = 1.0
+    # Normalize the world space
+    normalize_world_space: bool = True
 
     # Port for the viewer server
     port: int = 8080
@@ -275,7 +277,7 @@ class Runner:
         self.parser = Parser(
             data_dir=cfg.data_dir,
             factor=cfg.data_factor,
-            normalize=True,
+            normalize=cfg.normalize_world_space,
             test_every=cfg.test_every,
         )
         self.trainset = Dataset(


### PR DESCRIPTION
Add option to disable world space normalization for `examples/simple_trainer_2dgs.py` similar to that of `examples/simple_trainer.py`.