### PR TITLE
Adaptive MAX_JOBS depending on cpu count

### DIFF
--- a/gsplat/cuda/_backend.py
+++ b/gsplat/cuda/_backend.py
@@ -31,7 +31,7 @@ USE_PRECOMPILED_HEADERS = os.getenv("USE_PRECOMPILED_HEADERS", "0") == "1"
 need_to_unset_max_jobs = False
 if not MAX_JOBS:
     need_to_unset_max_jobs = True
-    os.environ["MAX_JOBS"] = "10"
+    os.environ["MAX_JOBS"] = str(max(10, os.cpu_count()))
 
 # torch has bugs on precompiled headers before 2.2, see:
 # https://github.com/nerfstudio-project/gsplat/pull/583#issuecomment-2732597080

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ MAX_JOBS = os.getenv("MAX_JOBS")
 need_to_unset_max_jobs = False
 if not MAX_JOBS:
     need_to_unset_max_jobs = True
-    os.environ["MAX_JOBS"] = "10"
+    os.environ["MAX_JOBS"] = str(max(10, os.cpu_count()))
     print(f"Setting MAX_JOBS to {os.environ['MAX_JOBS']}")
 
 


### PR DESCRIPTION
Adaptively grow MAX_JOBS beyond 10 for systems with a larger number of cores.
This is purely for convenience, since MAX_JOBS can be set in the environment, but
probably a better default than a single value across all systems. 

For example, with a 9950x3d this reduces compile time from 45s to 30s.