### PR TITLE
fix 3dgut sample viewer

### DIFF
--- a/examples/simple_viewer_3dgut.py
+++ b/examples/simple_viewer_3dgut.py
@@ -167,8 +167,6 @@ def main(local_rank: int, world_rank, world_size: int, args):
                     [
                         gui_slider_thin_prism_coeffs1.value,  # s1
                         gui_slider_thin_prism_coeffs2.value,  # s2
-                        0.0,  # s3
-                        0.0,  # s4
                     ]
                 ],
                 device=device,


### PR DESCRIPTION
Clicking the top-right UI button in examples/simple_viewer_3dgut.py caused the viewer to crash due to an AssertionError related to the shape of thin_prism_coeffs:

`AssertionError: torch.Size([1, 4])
`

![image](https://github.com/user-attachments/assets/2a06bf2d-b923-4af5-93e4-8b905cfd7486)

The issue was that thin_prism_coeffs was not shaped as expected by the renderer ([1, C, 2]).
To fix this, the tensor was redefined as:

```
thin_prism_coeffs = torch.tensor(
    [
        [
            gui_slider_thin_prism_coeffs1.value,  # s1
            gui_slider_thin_prism_coeffs2.value,  # s2
        ]
    ],
    device=device,
)
```

This resolves the crash and the viewer now works as expected.
It’s unclear whether this bug affects all users or only specific environments.