### PR TITLE
fix: solves issue, that opacity is reset at iteration 0

### DIFF
--- a/gsplat/strategy/default.py
+++ b/gsplat/strategy/default.py
@@ -192,7 +192,7 @@ class DefaultStrategy(Strategy):
                 state["radii"].zero_()
             torch.cuda.empty_cache()
 
-        if step % self.reset_every == 0:
+        if step % self.reset_every == 0 & step > 0:
             reset_opa(
                 params=params,
                 optimizers=optimizers,


### PR DESCRIPTION
When the iterations start at 0, the default strategy resets the opacity after iteration 0.
The reset opacity is 2*prune opacity and not the init opacity.
Therefore the init opacity was probably unwillingly ignored.

This fix could lead to unexpected changes for some people, when suddenly the init opacity value is used instead of 2 times the prune opacity.