### PR TITLE
Remove unnecessary abs() calls in scale/opacity loss calculation

### DIFF
--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -710,16 +710,9 @@ class Runner:
 
             # regularizations
             if cfg.opacity_reg > 0.0:
-                loss = (
-                    loss
-                    + cfg.opacity_reg
-                    * torch.abs(torch.sigmoid(self.splats["opacities"])).mean()
-                )
+                loss += cfg.opacity_reg * torch.sigmoid(self.splats["opacities"]).mean()
             if cfg.scale_reg > 0.0:
-                loss = (
-                    loss
-                    + cfg.scale_reg * torch.abs(torch.exp(self.splats["scales"])).mean()
-                )
+                loss += cfg.scale_reg * torch.exp(self.splats["scales"]).mean()
 
             loss.backward()
 


### PR DESCRIPTION
the outputs of torch.sigmoid and torch.exp are always positive, therefore we need not call torch.abs on their results.