### PR TITLE
Fix lack of submodules in CI/CD

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Strip unsupported tags in README
         run: |
           sed -i '/<!-- pypi-strip -->/,/<!-- \/pypi-strip -->/d' README.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Download packages
         id: download_artifacts
@@ -93,6 +95,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Currently, the CI/CD pipeline uses GitHub Actions to produce the distribution packages. Except for the wheels, the remaining deployment paths use the `checkout@v4` action without `submodules: recursive`, causing GLM to not be present in the generated packages. This causes issue #746.

This pull request fixes the CI/CD configuration. New packages need to be published, especially since the default target from PiPY (gsplat==1.5.2), that you get if you run `pip install gsplat`, is broken right now (#746).

Hope this is enough to fix the issue and let me know if I need to do something more!