### PR TITLE
(BUG FIX) Added Selective Adam bias corrections for momentums estimates

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -138,13 +138,14 @@ def adam(
     exp_avg: Tensor,
     exp_avg_sq: Tensor,
     valid: Tensor,
+    step_per_gaussian: Tensor, # Float[Tensor, N]
     lr: float,
     b1: float,
     b2: float,
     eps: float,
 ) -> None:
     _make_lazy_cuda_func("adam")(
-        param, param_grad, exp_avg, exp_avg_sq, valid, lr, b1, b2, eps
+        param, param_grad, exp_avg, exp_avg_sq, valid, step_per_gaussian, lr, b1, b2, eps
     )
 
 

--- a/gsplat/cuda/csrc/Adam.cpp
+++ b/gsplat/cuda/csrc/Adam.cpp
@@ -18,6 +18,7 @@ void adam(
     at::Tensor &exp_avg,                  // [N, ...]
     at::Tensor &exp_avg_sq,               // [N, ...]
     const at::optional<at::Tensor> valid, // [N]
+    at::Tensor &step_per_gaussian,        // [N]
     const float lr,
     const float b1,
     const float b2,
@@ -28,6 +29,7 @@ void adam(
     CHECK_INPUT(param_grad);
     CHECK_INPUT(exp_avg);
     CHECK_INPUT(exp_avg_sq);
+    CHECK_INPUT(step_per_gaussian);
     if (valid.has_value()) {
         CHECK_INPUT(valid.value());
         TORCH_CHECK(valid.value().dim() == 1, "valid should be 1D tensor");
@@ -38,7 +40,7 @@ void adam(
     }
 
     launch_adam_kernel(
-        param, param_grad, exp_avg, exp_avg_sq, valid, lr, b1, b2, eps
+        param, param_grad, exp_avg, exp_avg_sq, valid, step_per_gaussian, lr, b1, b2, eps
     );
 }
 

--- a/gsplat/cuda/csrc/Adam.h
+++ b/gsplat/cuda/csrc/Adam.h
@@ -14,6 +14,7 @@ void launch_adam_kernel(
     at::Tensor &exp_avg,                  // [N, ...]
     at::Tensor &exp_avg_sq,               // [N, ...]
     const at::optional<at::Tensor> valid, // [N]
+    at::Tensor &step_per_gaussian,        // [N]
     const float lr,
     const float b1,
     const float b2,

--- a/gsplat/cuda/csrc/AdamCUDA.cu
+++ b/gsplat/cuda/csrc/AdamCUDA.cu
@@ -18,6 +18,7 @@ __global__ void adam_kernel(
     scalar_t *__restrict__ exp_avg,
     scalar_t *__restrict__ exp_avg_sq,
     const bool *valid,
+    const scalar_t *__restrict__ step_per_gaussian,
     const float lr,
     const float b1,
     const float b2,
@@ -34,17 +35,42 @@ __global__ void adam_kernel(
     float register_param_grad = param_grad[p_idx];
     float register_exp_avg = exp_avg[p_idx];
     float register_exp_avg_sq = exp_avg_sq[p_idx];
+
+    // Update moments
     register_exp_avg =
         b1 * register_exp_avg + (1.0f - b1) * register_param_grad;
     register_exp_avg_sq = b2 * register_exp_avg_sq + (1.0f - b2) *
-                                                         register_param_grad *
-                                                         register_param_grad;
-    float step = -lr * register_exp_avg / (sqrt(register_exp_avg_sq) + eps);
+                                                     register_param_grad *
+                                                     register_param_grad;
+    // Bias correction
+    float bias_correction1 = 1.0f - powf(b1, step_per_gaussian[g_idx]);
+    float bias_correction2 = 1.0f - powf(b2, step_per_gaussian[g_idx]);
 
+    float m_hat = register_exp_avg / bias_correction1;
+    float v_hat = register_exp_avg_sq / bias_correction2;
+
+    // Parameter update
+    float step = -lr * m_hat / (sqrtf(v_hat) + eps);
+
+    // Apply update
     param[p_idx] += step;
     exp_avg[p_idx] = register_exp_avg;
     exp_avg_sq[p_idx] = register_exp_avg_sq;
 }
+
+template <typename scalar_t>
+__global__ void increment_step_kernel(
+    scalar_t *__restrict__ step_per_gaussian,
+    const bool* valid,
+    int N
+) {
+    int g_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (g_idx >= N) return;
+    if (valid == nullptr || valid[g_idx]) {
+        step_per_gaussian[g_idx]++;
+    }
+}
+
 
 void launch_adam_kernel(
     at::Tensor &param,                    // [N, ...]
@@ -52,6 +78,7 @@ void launch_adam_kernel(
     at::Tensor &exp_avg,                  // [N, ...]
     at::Tensor &exp_avg_sq,               // [N, ...]
     const at::optional<at::Tensor> valid, // [N]
+    at::Tensor &step_per_gaussian,        // [N]
     const float lr,
     const float b1,
     const float b2,
@@ -59,17 +86,27 @@ void launch_adam_kernel(
 ) {
     const uint32_t N = param.size(0);
     const uint32_t D = param.numel() / N;
+    if (N == 0 || D == 0) {
+        return;
+    }
 
+    int64_t shmem_size = 0;
+    // Step 1: increment step counter
+    dim3 threads_step(256);
+    dim3 grid_step((N + threads_step.x - 1) / threads_step.x);
+    AT_DISPATCH_FLOATING_TYPES(param.scalar_type(), "increment_step_kernel", [&]() {
+        increment_step_kernel<scalar_t>
+            <<<grid_step, threads_step, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
+            step_per_gaussian.data_ptr<scalar_t>(),
+            valid.value().data_ptr<bool>(),
+            N
+        );
+    });
+    // Step 2: Launch Adam kernel
     // parallel over [N, ...]
     int64_t n_elements = N * D;
     dim3 threads(256);
     dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
-
-    if (n_elements == 0) {
-        // skip the kernel launch if there are no elements
-        return;
-    }
 
     AT_DISPATCH_FLOATING_TYPES(param.scalar_type(), "adam_kernel", [&]() {
         adam_kernel<scalar_t>
@@ -81,6 +118,7 @@ void launch_adam_kernel(
                 exp_avg.data_ptr<scalar_t>(),
                 exp_avg_sq.data_ptr<scalar_t>(),
                 valid.has_value() ? valid.value().data_ptr<bool>() : nullptr,
+                step_per_gaussian.data_ptr<scalar_t>(),
                 lr,
                 b1,
                 b2,

--- a/gsplat/cuda/include/Ops.h
+++ b/gsplat/cuda/include/Ops.h
@@ -176,6 +176,7 @@ void adam(
     at::Tensor &exp_avg,                  // [..., D]
     at::Tensor &exp_avg_sq,               // [..., D]
     const at::optional<at::Tensor> valid, // [...]
+    at::Tensor &step_per_gaussian,        // [N]
     const float lr,
     const float b1,
     const float b2,

--- a/gsplat/optimizers/selective_adam.py
+++ b/gsplat/optimizers/selective_adam.py
@@ -60,18 +60,22 @@ class SelectiveAdam(torch.optim.Adam):
             # Lazy state initialization
             state = self.state[param]
             if len(state) == 0:
-                state["step"] = torch.tensor(0.0, dtype=torch.float32)
                 state["exp_avg"] = torch.zeros_like(
                     param, memory_format=torch.preserve_format
                 )
                 state["exp_avg_sq"] = torch.zeros_like(
                     param, memory_format=torch.preserve_format
                 )
+                state["step_per_gaussian"] = torch.zeros(
+                    param.shape[0],
+                    device=param.device,
+                    dtype=torch.float32
+                )
 
             stored_state = self.state.get(param, None)
             exp_avg = stored_state["exp_avg"]
             exp_avg_sq = stored_state["exp_avg_sq"]
-            M = param.numel() // N
+            step_per_gaussian = stored_state["step_per_gaussian"]
 
             adam(
                 param,
@@ -79,6 +83,7 @@ class SelectiveAdam(torch.optim.Adam):
                 exp_avg,
                 exp_avg_sq,
                 visibility,
+                step_per_gaussian,
                 lr,
                 beta1,
                 beta2,


### PR DESCRIPTION
As described in this [issue](https://github.com/nerfstudio-project/gsplat/issues/604``): Selective Adam does not implement bias corrections, as in the original Adam implementation.
This causes issues when starting training from a dense initialization (or after reinitialization).

This pull request introduces bias corrections for Selective Adam.
Adam optimizer 157 steps:

https://github.com/user-attachments/assets/6639c4bb-78c1-4b30-9f3a-bbffdbd351ee

Selective adam optimizer 157 steps:

https://github.com/user-attachments/assets/ac866c54-cd97-4f83-a6e3-f8cec3e20073

Selective adam optimizer with bias corrections 157 steps:

https://github.com/user-attachments/assets/259464b6-cc31-49cf-b114-df439e254c43





