### PR TITLE
Fix bit-wise 'and' preventing opacity reset

### DIFF
--- a/gsplat/strategy/default.py
+++ b/gsplat/strategy/default.py
@@ -192,7 +192,7 @@ class DefaultStrategy(Strategy):
                 state["radii"].zero_()
             torch.cuda.empty_cache()
 
-        if step % self.reset_every == 0 & step > 0:
+        if step % self.reset_every == 0 and step > 0:
             reset_opa(
                 params=params,
                 optimizers=optimizers,


### PR DESCRIPTION
The bit-wise 'and' instead of regular 'and' in the default strategy prevents opacity reset.

