### PR TITLE
fix save_ply deprication warning

### DIFF
--- a/gsplat/utils.py
+++ b/gsplat/utils.py
@@ -11,7 +11,7 @@ from torch import Tensor
 def save_ply(splats: torch.nn.ParameterDict, dir: str, colors: torch.Tensor = None):
     warnings.warn(
         "save_ply() is deprecated and may be removed in a future release. "
-        "Please use the new export_gaussian_splats() function instead.",
+        "Please use the new export_splats() function instead.",
         DeprecationWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
The deprecation warning talks about function export_gaussian_splats, but it's called export_splats