### PR TITLE
[BugFix] fix image_ids bug in distributed + packed mode

### DIFF
--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -575,6 +575,9 @@ def rasterization(
                 output_splits=collected_splits,
             )
 
+            # image_ids must be updated after sparse_all_to_all, which is used in isect_tiles()
+            image_ids = camera_ids
+
             # Silently change C from global #Cameras to local #Cameras.
             C = C_world[world_rank]
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the bug where image_ids was not updated after sparse_all_to_all operation, causing shape mismatch errors during isect_tiles() in packed mode with multi-GPU training.

### Problem Description
Test Command
```
CUDA_VISIBLE_DEVICES=1,2,3,5 python examples/simple_trainer.py default \
    --data_dir data/360_v2/garden/ --data_factor 4 \
    --result_dir ./results/garden \
    --packed
```

When running distributed training with packed mode on multiple GPUs, the program crashes during the isect_tiles stage with the following error:

```
RuntimeError: CUDA error: operation not supported on global/shared address space
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

### Root Cause
The issue occurs because image_ids is not updated after sparse_all_to_all operation, causing a shape mismatch with other tensors like means2d.

Specifically, [codes:](https://github.com/nerfstudio-project/gsplat/blob/main/gsplat/rendering.py#L634) 

```
  torch.distributed.barrier()
  tiles_per_gauss, isect_ids, flatten_ids = isect_tiles(
      means2d,   # means2d.shape: torch.Size([67205, 2])
      radii,
      depths,
      tile_size,
      tile_width,
      tile_height,
      segmented=segmented,
      packed=packed,
      n_images=I,
      image_ids=image_ids,  # image_ids.shape : torch.Size([66317])
      gaussian_ids=gaussian_ids, # gaussian_ids.shape : torch.Size([67205])
  )
```