### PR TITLE
Add gradients to intrinsics

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1108,7 +1108,7 @@ class _FullyFusedProjection(torch.autograd.Function):
         camera_model_type = ctx.camera_model_type
         if v_compensations is not None:
             v_compensations = v_compensations.contiguous()
-        v_means, v_covars, v_quats, v_scales, v_viewmats = _make_lazy_cuda_func(
+        v_means, v_covars, v_quats, v_scales, v_viewmats, v_Ks = _make_lazy_cuda_func(
             "projection_ewa_3dgs_fused_bwd"
         )(
             means,
@@ -1129,6 +1129,7 @@ class _FullyFusedProjection(torch.autograd.Function):
             v_conics.contiguous(),
             v_compensations,
             ctx.needs_input_grad[4],  # viewmats_requires_grad
+            ctx.needs_input_grad[5],  # Ks_requires_grad
         )
         if not ctx.needs_input_grad[0]:
             v_means = None
@@ -1140,12 +1141,15 @@ class _FullyFusedProjection(torch.autograd.Function):
             v_scales = None
         if not ctx.needs_input_grad[4]:
             v_viewmats = None
+        if not ctx.needs_input_grad[5]:
+            v_Ks = None
         return (
             v_means,
             v_covars,
             v_quats,
             v_scales,
             v_viewmats,
+            v_Ks,
             None,
             None,
             None,
@@ -2002,7 +2006,7 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
         width = ctx.width
         height = ctx.height
         eps2d = ctx.eps2d
-        v_means, v_quats, v_scales, v_viewmats = _make_lazy_cuda_func(
+        v_means, v_quats, v_scales, v_viewmats, v_Ks = _make_lazy_cuda_func(
             "projection_2dgs_fused_bwd"
         )(
             means,
@@ -2019,6 +2023,7 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
             v_normals.contiguous(),
             v_ray_transforms.contiguous(),
             ctx.needs_input_grad[3],  # viewmats_requires_grad
+            ctx.needs_input_grad[4],  # Ks_requires_grad
         )
         if not ctx.needs_input_grad[0]:
             v_means = None
@@ -2028,12 +2033,15 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
             v_scales = None
         if not ctx.needs_input_grad[3]:
             v_viewmats = None
+        if not ctx.needs_input_grad[4]:
+            v_Ks = None
 
         return (
             v_means,
             v_quats,
             v_scales,
             v_viewmats,
+            v_Ks,
             None,
             None,
             None,

--- a/gsplat/cuda/csrc/Projection.h
+++ b/gsplat/cuda/csrc/Projection.h
@@ -82,12 +82,14 @@ void launch_projection_ewa_3dgs_fused_bwd_kernel(
     const at::Tensor v_conics,                      // [..., C, N, 3]
     const at::optional<at::Tensor> v_compensations, // [..., C, N] optional
     const bool viewmats_requires_grad,
+    const bool Ks_requires_grad,
     // outputs
     at::Tensor v_means,   // [..., N, 3]
     at::Tensor v_covars,  // [..., N, 3, 3]
     at::Tensor v_quats,   // [..., N, 4]
     at::Tensor v_scales,  // [..., N, 3]
-    at::Tensor v_viewmats // [..., C, 4, 4]
+    at::Tensor v_viewmats, // [..., C, 4, 4]
+    at::Tensor v_Ks      // [..., C, 3, 3]
 );
 
 void launch_projection_ewa_3dgs_packed_fwd_kernel(
@@ -189,11 +191,13 @@ void launch_projection_2dgs_fused_bwd_kernel(
     const at::Tensor v_normals,        // [..., C, N, 3]
     const at::Tensor v_ray_transforms, // [..., C, N, 3, 3]
     const bool viewmats_requires_grad,
+    const bool Ks_requires_grad,
     // outputs
     at::Tensor v_means,   // [..., N, 3]
     at::Tensor v_quats,   // [..., N, 4]
     at::Tensor v_scales,  // [..., N, 3]
-    at::Tensor v_viewmats // [..., C, 4, 4]
+    at::Tensor v_viewmats, // [..., C, 4, 4]
+    at::Tensor v_Ks      // [..., C, 3, 3]
 );
 
 void launch_projection_2dgs_packed_fwd_kernel(
@@ -246,7 +250,8 @@ void launch_projection_2dgs_packed_bwd_kernel(
     at::Tensor v_means,                 // [..., N, 3] or [nnz, 3]
     at::Tensor v_quats,                 // [..., N, 4] or [nnz, 4]
     at::Tensor v_scales,                // [..., N, 3] or [nnz, 3]
-    at::optional<at::Tensor> v_viewmats // [..., C, 4, 4] Optional
+    at::optional<at::Tensor> v_viewmats, // [..., C, 4, 4] Optional
+    at::optional<at::Tensor> v_Ks      // [..., C, 3, 3] Optional
 );
 
 void launch_projection_ut_3dgs_fused_kernel(

--- a/gsplat/cuda/include/Ops.h
+++ b/gsplat/cuda/include/Ops.h
@@ -62,7 +62,7 @@ projection_ewa_3dgs_fused_fwd(
     const bool calc_compensations,
     const CameraModelType camera_model
 );
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
 projection_ewa_3dgs_fused_bwd(
     // fwd inputs
     const at::Tensor means,                // [..., N, 3]
@@ -84,7 +84,8 @@ projection_ewa_3dgs_fused_bwd(
     const at::Tensor v_depths,                      // [..., C, N]
     const at::Tensor v_conics,                      // [..., C, N, 3]
     const at::optional<at::Tensor> v_compensations, // [..., C, N] optional
-    const bool viewmats_requires_grad
+    const bool viewmats_requires_grad,
+    const bool Ks_requires_grad
 );
 
 // On top of fusing the operations like `projection_ewa_3dgs_fused_{fwd, bwd}`,
@@ -310,7 +311,7 @@ projection_2dgs_fused_fwd(
     const float far_plane,
     const float radius_clip
 );
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
 projection_2dgs_fused_bwd(
     // fwd inputs
     const at::Tensor means,    // [..., N, 3]
@@ -328,7 +329,8 @@ projection_2dgs_fused_bwd(
     const at::Tensor v_depths,         // [..., C, N]
     const at::Tensor v_normals,        // [..., C, N, 3]
     const at::Tensor v_ray_transforms, // [..., C, N, 3, 3]
-    const bool viewmats_requires_grad
+    const bool viewmats_requires_grad,
+    const bool Ks_requires_grad
 );
 
 std::tuple<
@@ -353,7 +355,7 @@ projection_2dgs_packed_fwd(
     const float far_plane,
     const float radius_clip
 );
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
 projection_2dgs_packed_bwd(
     // fwd inputs
     const at::Tensor means,    // [..., N, 3]
@@ -374,6 +376,7 @@ projection_2dgs_packed_bwd(
     const at::Tensor v_ray_transforms, // [nnz, 3, 3]
     const at::Tensor v_normals,        // [nnz, 3]
     const bool viewmats_requires_grad,
+    const bool Ks_requires_grad,
     const bool sparse_grad
 );
 

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -495,6 +495,64 @@ inline __device__ void ortho_proj_vjp(
     v_mean3d += vec3(fx * v_mean2d[0], fy * v_mean2d[1], 0.f);
 }
 
+// Overloaded version that also computes gradients w.r.t. intrinsics
+inline __device__ void ortho_proj_vjp(
+    // fwd inputs
+    const vec3 mean3d,
+    const mat3 cov3d,
+    const float fx,
+    const float fy,
+    const float cx,
+    const float cy,
+    const uint32_t width,
+    const uint32_t height,
+    // grad outputs
+    const mat2 v_cov2d,
+    const vec2 v_mean2d,
+    // grad inputs
+    vec3 &v_mean3d,
+    mat3 &v_cov3d,
+    float &v_fx,
+    float &v_fy,
+    float &v_cx,
+    float &v_cy
+) {
+    float x = mean3d[0], y = mean3d[1], z = mean3d[2];
+
+    // mat3x2 is 3 columns x 2 rows.
+    mat3x2 J = mat3x2(
+        fx,
+        0.f, // 1st column
+        0.f,
+        fy, // 2nd column
+        0.f,
+        0.f // 3rd column
+    );
+
+    // cov = J * V * Jt; G = df/dcov = v_cov
+    // -> df/dV = Jt * G * J
+    // -> df/dJ = G * J * Vt + Gt * J * V
+    v_cov3d += glm::transpose(J) * v_cov2d * J;
+
+    // Gradients w.r.t. mean
+    v_mean3d += vec3(fx * v_mean2d[0], fy * v_mean2d[1], 0.f);
+
+    // Gradients w.r.t. intrinsics from mean2d = [fx * x + cx, fy * y + cy]
+    v_fx += x * v_mean2d[0];  // d(mean2d.x)/dfx = x
+    v_fy += y * v_mean2d[1];  // d(mean2d.y)/dfy = y
+    v_cx += v_mean2d[0];      // d(mean2d.x)/dcx = 1
+    v_cy += v_mean2d[1];      // d(mean2d.y)/dcy = 1
+
+    // Gradients from covariance through Jacobian
+    mat3x2 v_J = v_cov2d * J * glm::transpose(cov3d) +
+                 glm::transpose(v_cov2d) * J * cov3d;
+
+    // Gradients w.r.t. intrinsics from Jacobian elements
+    // J = [fx, 0; 0, fy; 0, 0]
+    v_fx += v_J[0][0];
+    v_fy += v_J[1][1];
+}
+
 inline __device__ void persp_proj(
     // inputs
     const vec3 mean3d,
@@ -598,6 +656,100 @@ inline __device__ void persp_proj_vjp(
     float rz3 = rz2 * rz;
     mat3x2 v_J = v_cov2d * J * glm::transpose(cov3d) +
                  glm::transpose(v_cov2d) * J * cov3d;
+
+    // fov clipping
+    if (x * rz <= lim_x_pos && x * rz >= -lim_x_neg) {
+        v_mean3d.x += -fx * rz2 * v_J[2][0];
+    } else {
+        v_mean3d.z += -fx * rz3 * v_J[2][0] * tx;
+    }
+    if (y * rz <= lim_y_pos && y * rz >= -lim_y_neg) {
+        v_mean3d.y += -fy * rz2 * v_J[2][1];
+    } else {
+        v_mean3d.z += -fy * rz3 * v_J[2][1] * ty;
+    }
+    v_mean3d.z += -fx * rz2 * v_J[0][0] - fy * rz2 * v_J[1][1] +
+                  2.f * fx * tx * rz3 * v_J[2][0] +
+                  2.f * fy * ty * rz3 * v_J[2][1];
+}
+
+// Overloaded version that also computes gradients w.r.t. intrinsics
+inline __device__ void persp_proj_vjp(
+    // fwd inputs
+    const vec3 mean3d,
+    const mat3 cov3d,
+    const float fx,
+    const float fy,
+    const float cx,
+    const float cy,
+    const uint32_t width,
+    const uint32_t height,
+    // grad outputs
+    const mat2 v_cov2d,
+    const vec2 v_mean2d,
+    // grad inputs
+    vec3 &v_mean3d,
+    mat3 &v_cov3d,
+    float &v_fx,
+    float &v_fy,
+    float &v_cx,
+    float &v_cy
+) {
+    float x = mean3d[0], y = mean3d[1], z = mean3d[2];
+
+    float tan_fovx = 0.5f * width / fx;
+    float tan_fovy = 0.5f * height / fy;
+    float lim_x_pos = (width - cx) / fx + 0.3f * tan_fovx;
+    float lim_x_neg = cx / fx + 0.3f * tan_fovx;
+    float lim_y_pos = (height - cy) / fy + 0.3f * tan_fovy;
+    float lim_y_neg = cy / fy + 0.3f * tan_fovy;
+
+    float rz = 1.f / z;
+    float rz2 = rz * rz;
+    float tx = z * min(lim_x_pos, max(-lim_x_neg, x * rz));
+    float ty = z * min(lim_y_pos, max(-lim_y_neg, y * rz));
+
+    // mat3x2 is 3 columns x 2 rows.
+    mat3x2 J = mat3x2(
+        fx * rz,
+        0.f, // 1st column
+        0.f,
+        fy * rz, // 2nd column
+        -fx * tx * rz2,
+        -fy * ty * rz2 // 3rd column
+    );
+
+    // cov = J * V * Jt; G = df/dcov = v_cov
+    // -> df/dV = Jt * G * J
+    // -> df/dJ = G * J * Vt + Gt * J * V
+    v_cov3d += glm::transpose(J) * v_cov2d * J;
+
+    // Gradients w.r.t. mean
+    v_mean3d += vec3(
+        fx * rz * v_mean2d[0],
+        fy * rz * v_mean2d[1],
+        -(fx * x * v_mean2d[0] + fy * y * v_mean2d[1]) * rz2
+    );
+
+    // Gradients w.r.t. intrinsics from mean2d = [fx * x * rz + cx, fy * y * rz + cy]
+    v_fx += x * rz * v_mean2d[0];  // d(mean2d.x)/dfx = x * rz
+    v_fy += y * rz * v_mean2d[1];  // d(mean2d.y)/dfy = y * rz  
+    v_cx += v_mean2d[0];           // d(mean2d.x)/dcx = 1
+    v_cy += v_mean2d[1];           // d(mean2d.y)/dcy = 1
+
+    // Gradients from covariance through Jacobian
+    float rz3 = rz2 * rz;
+    mat3x2 v_J = v_cov2d * J * glm::transpose(cov3d) +
+                 glm::transpose(v_cov2d) * J * cov3d;
+
+    // Gradients w.r.t. intrinsics from Jacobian elements
+    // J = [fx*rz, 0; 0, fy*rz; -fx*tx*rz2, -fy*ty*rz2]
+    v_fx += rz * v_J[0][0] - tx * rz2 * v_J[2][0];
+    v_fy += rz * v_J[1][1] - ty * rz2 * v_J[2][1];
+
+    // Additional gradients from fov clipping limits
+    // The clipping limits depend on fx, fy, cx, cy but for simplicity
+    // we'll ignore these higher-order effects for now
 
     // fov clipping
     if (x * rz <= lim_x_pos && x * rz >= -lim_x_neg) {
@@ -754,6 +906,41 @@ inline __device__ void fisheye_proj_vjp(
     v_mean3d.x += dL_dtx_raw;
     v_mean3d.y += dL_dty_raw;
     v_mean3d.z += dL_dtz_raw;
+}
+
+// Overloaded version that also computes gradients w.r.t. intrinsics
+// Note: For fisheye projection, intrinsics gradients are complex and not implemented yet
+inline __device__ void fisheye_proj_vjp(
+    // fwd inputs
+    const vec3 mean3d,
+    const mat3 cov3d,
+    const float fx,
+    const float fy,
+    const float cx,
+    const float cy,
+    const uint32_t width,
+    const uint32_t height,
+    // grad outputs
+    const mat2 v_cov2d,
+    const vec2 v_mean2d,
+    // grad inputs
+    vec3 &v_mean3d,
+    mat3 &v_cov3d,
+    float &v_fx,
+    float &v_fy,
+    float &v_cx,
+    float &v_cy
+) {
+    // For now, call the original version and set intrinsics gradients to zero
+    fisheye_proj_vjp(mean3d, cov3d, fx, fy, cx, cy, width, height, v_cov2d, v_mean2d, v_mean3d, v_cov3d);
+    
+    // TODO: Implement proper fisheye intrinsics gradients
+    // For now, only handle the simple parts
+    v_cx += v_mean2d[0];  // d(mean2d.x)/dcx = 1
+    v_cy += v_mean2d[1];  // d(mean2d.y)/dcy = 1
+    // fx, fy gradients are more complex for fisheye - set to 0 for now
+    v_fx += 0.0f;
+    v_fy += 0.0f;
 }
 
 inline __device__ vec3 safe_normalize(vec3 v) {

--- a/test_intrinsics_optimization.py
+++ b/test_intrinsics_optimization.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+
+import torch
+import torch.nn.functional as F
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+import os
+
+# Import gsplat functions
+from gsplat import rasterization, rasterization_2dgs
+
+def create_random_scene(n_gaussians, device="cuda:0"):
+    """Create a random scene of 3D Gaussians."""
+    torch.manual_seed(41)  # For reproducibility
+    
+    # Random positions in a reasonable range
+    means = torch.randn(n_gaussians, 3, device=device) * 3.0
+    means[:, 2] += 8.0  # Push gaussians further away from camera (z > 5)
+    
+    # Random orientations (quaternions)
+    quats = F.normalize(torch.randn(n_gaussians, 4, device=device), dim=-1)
+    
+    # Smaller, more reasonable scales
+    scales = torch.exp(torch.randn(n_gaussians, 3, device=device) * 0.3 - 2.0)  # Much smaller scales
+    
+    # More varied colors (not all purple)
+    colors = torch.rand(n_gaussians, 3, device=device)
+    
+    # Random opacities (not too high)
+    opacities = torch.rand(n_gaussians, device=device) * 0.5 + 0.2  # Lower opacity range
+    
+    return {
+        'means': means,
+        'quats': quats, 
+        'scales': scales,
+        'colors': colors,
+        'opacities': opacities
+    }
+
+def create_camera_setup(device="cuda:0"):
+    """Create camera parameters."""
+    # Ground truth intrinsics
+    fx_true, fy_true = 800.0, 800.0
+    cx_true, cy_true = 320.0, 240.0
+    
+    Ks_true = torch.tensor([[[fx_true, 0.0, cx_true],
+                             [0.0, fy_true, cy_true], 
+                             [0.0, 0.0, 1.0]]], device=device)
+    
+    # Initial guess (smaller perturbation)
+    fx_init = fx_true + torch.randn(1).item() * 100   # ±100 pixel error
+    fy_init = fy_true + torch.randn(1).item() * 100
+    cx_init = cx_true + torch.randn(1).item() * 50   # ±50 pixel error  
+    cy_init = cy_true + torch.randn(1).item() * 50
+    
+    Ks_init = torch.tensor([[[fx_init, 0.0, cx_init],
+                             [0.0, fy_init, cy_init],
+                             [0.0, 0.0, 1.0]]], device=device, requires_grad=True)
+    
+    # Simple camera pose (identity)
+    viewmats = torch.eye(4, device=device).unsqueeze(0)
+    
+    # Image dimensions
+    width, height = 640, 480
+    
+    return {
+        'Ks_true': Ks_true,
+        'Ks_init': Ks_init,
+        'viewmats': viewmats,
+        'width': width,
+        'height': height
+    }
+
+def render_gaussians(scene, camera, Ks, use_2dgs):
+    """Render 3D Gaussians to 2D image."""
+    # Use the full rasterization pipeline
+    if use_2dgs:
+        render_colors = rasterization_2dgs(
+            means=scene['means'].unsqueeze(0),
+            quats=scene['quats'].unsqueeze(0),
+            scales=scene['scales'].unsqueeze(0),
+            opacities=scene['opacities'].unsqueeze(0),
+            colors=scene['colors'].unsqueeze(1).unsqueeze(0),
+            viewmats=camera['viewmats'].unsqueeze(0),
+            Ks=Ks.unsqueeze(0),
+            width=camera['width'],
+            height=camera['height'],
+            # near_plane=0.01,
+            # far_plane=100.0,
+            packed=False,  # Use non-packed version which has intrinsics gradients
+            backgrounds=torch.zeros(1, 1, 3, device=Ks.device),  # [1, 3] for single camera
+            sh_degree=0,
+            
+        )[0]
+        render_colors = render_colors[0]  # Remove batch dimension
+    else:
+        render_colors = rasterization(
+            means=scene['means'],
+            quats=scene['quats'],
+            scales=scene['scales'],
+            opacities=scene['opacities'],
+            colors=scene['colors'],
+            viewmats=camera['viewmats'],
+            Ks=Ks,
+            width=camera['width'],
+            height=camera['height'],
+            packed=False,  # Use non-packed version which has intrinsics gradients
+            backgrounds=torch.zeros(1, 3, device=Ks.device),  # [1, 3] for single camera
+            camera_model="pinhole"
+        )[0]
+    return render_colors
+
+def optimize_intrinsics(scene, camera, n_iterations=200, lr=100.0, use_2dgs=None):
+    """Optimize camera intrinsics to match ground truth rendering."""
+
+    assert use_2dgs is not None, "use_2dgs must be specified (True or False)"
+    
+    # Create output directory
+    output_dir = Path("intrinsics_optimization_results")
+    output_dir.mkdir(exist_ok=True)
+    
+    # Render ground truth image
+    with torch.no_grad():
+        gt_image = render_gaussians(scene, camera, camera['Ks_true'], use_2dgs=use_2dgs)
+        gt_image = gt_image.squeeze(0)  # Remove batch dimension
+    
+    # Save ground truth
+    plt.figure(figsize=(12, 4))
+    plt.subplot(1, 3, 1)
+    plt.imshow(gt_image.cpu().numpy())
+    plt.title("Ground Truth")
+    plt.axis('off')
+    plt.tight_layout()
+    plt.savefig(output_dir / "00_ground_truth.png", dpi=150, bbox_inches='tight')
+    plt.close()
+    
+    # Optimization setup
+    Ks_opt = camera['Ks_init'].clone().detach().requires_grad_(True)
+    optimizer = torch.optim.Adam([Ks_opt], lr=lr)
+    # optimizer = torch.optim.SGD([Ks_opt], lr=lr*10, momentum=0.9)
+    
+    losses = []
+    intrinsics_history = []
+    
+    print("Starting intrinsics optimization...")
+    print(f"Ground truth: fx={camera['Ks_true'][0,0,0]:.1f}, fy={camera['Ks_true'][0,1,1]:.1f}, "
+          f"cx={camera['Ks_true'][0,0,2]:.1f}, cy={camera['Ks_true'][0,1,2]:.1f}")
+    print(f"Initial guess: fx={Ks_opt[0,0,0]:.1f}, fy={Ks_opt[0,1,1]:.1f}, "
+          f"cx={Ks_opt[0,0,2]:.1f}, cy={Ks_opt[0,1,2]:.1f}")
+    print()
+    
+    for iteration in range(n_iterations):
+        optimizer.zero_grad()
+        
+        # Render with current intrinsics
+        pred_image = render_gaussians(scene, camera, Ks_opt, use_2dgs=use_2dgs)
+        pred_image = pred_image.squeeze(0)
+        
+        # Compute loss (MSE between images)
+        loss = F.mse_loss(pred_image, gt_image)
+        
+        # Backward pass
+        loss.backward()
+        
+        # Debug: Check if gradients are being computed
+        if iteration == 0:
+            print(f"Ks gradients at iteration 0: {Ks_opt.grad}")
+            if Ks_opt.grad is None:
+                print("WARNING: No gradients computed for Ks!")
+            else:
+                print(f"Gradient magnitudes: fx={Ks_opt.grad[0,0,0]:.6f}, fy={Ks_opt.grad[0,1,1]:.6f}, "
+                      f"cx={Ks_opt.grad[0,0,2]:.6f}, cy={Ks_opt.grad[0,1,2]:.6f}")
+        
+        optimizer.step()
+        
+        # Store metrics
+        losses.append(loss.item())
+        intrinsics_history.append([
+            Ks_opt[0,0,0].item(),  # fx
+            Ks_opt[0,1,1].item(),  # fy  
+            Ks_opt[0,0,2].item(),  # cx
+            Ks_opt[0,1,2].item()   # cy
+        ])
+        
+        # Print progress
+        if iteration % 20 == 0:
+            print(f"Iter {iteration:3d}: Loss={loss.item():.6f}, "
+                  f"fx={Ks_opt[0,0,0]:.1f}, fy={Ks_opt[0,1,1]:.1f}, "
+                  f"cx={Ks_opt[0,0,2]:.1f}, cy={Ks_opt[0,1,2]:.1f}")
+        
+        # Save intermediate results
+        if iteration % 40 == 0 or iteration == n_iterations - 1:
+            plt.figure(figsize=(15, 5))
+            
+            # Ground truth
+            plt.subplot(1, 3, 1)
+            plt.imshow(gt_image.cpu().numpy())
+            plt.title("Ground Truth")
+            plt.axis('off')
+            
+            # Current prediction
+            plt.subplot(1, 3, 2)
+            plt.imshow(pred_image.detach().cpu().numpy())
+            plt.title(f"Prediction (Iter {iteration})")
+            plt.axis('off')
+            
+            # Difference
+            plt.subplot(1, 3, 3)
+            diff = torch.abs(pred_image - gt_image).detach().cpu().numpy()
+            plt.imshow(diff)
+            plt.title(f"Abs Difference (Loss={loss.item():.4f})")
+            plt.axis('off')
+            
+            plt.tight_layout()
+            plt.savefig(output_dir / f"iter_{iteration:03d}.png", dpi=150, bbox_inches='tight')
+            plt.close()
+    
+    # Plot optimization curves
+    plt.figure(figsize=(15, 4))
+    
+    # Loss curve
+    plt.subplot(1, 3, 1)
+    plt.plot(losses)
+    plt.xlabel('Iteration')
+    plt.ylabel('MSE Loss')
+    plt.title('Optimization Progress')
+    plt.yscale('log')
+    plt.grid(True)
+    
+    # Intrinsics convergence
+    intrinsics_history = np.array(intrinsics_history)
+    gt_values = [camera['Ks_true'][0,0,0].item(), camera['Ks_true'][0,1,1].item(),
+                 camera['Ks_true'][0,0,2].item(), camera['Ks_true'][0,1,2].item()]
+    
+    plt.subplot(1, 3, 2)
+    labels = ['fx', 'fy', 'cx', 'cy']
+    for i, (label, gt_val) in enumerate(zip(labels, gt_values)):
+        plt.plot(intrinsics_history[:, i], label=f'{label} (pred)')
+        plt.axhline(y=gt_val, color=f'C{i}', linestyle='--', alpha=0.7, label=f'{label} (GT)')
+    plt.xlabel('Iteration')
+    plt.ylabel('Parameter Value')
+    plt.title('Intrinsics Convergence')
+    plt.legend()
+    plt.grid(True)
+    
+    # Final error
+    plt.subplot(1, 3, 3)
+    final_errors = np.abs(intrinsics_history[-1] - gt_values)
+    plt.bar(labels, final_errors)
+    plt.ylabel('Absolute Error')
+    plt.title('Final Parameter Errors')
+    plt.grid(True)
+    
+    plt.tight_layout()
+    plt.savefig(output_dir / "optimization_curves.png", dpi=150, bbox_inches='tight')
+    plt.close()
+    
+    # Final summary
+    print("\n" + "="*60)
+    print("OPTIMIZATION COMPLETE")
+    print("="*60)
+    print("Ground Truth:")
+    print(f"  fx={camera['Ks_true'][0,0,0]:.2f}, fy={camera['Ks_true'][0,1,1]:.2f}")
+    print(f"  cx={camera['Ks_true'][0,0,2]:.2f}, cy={camera['Ks_true'][0,1,2]:.2f}")
+    print("\nFinal Prediction:")
+    print(f"  fx={Ks_opt[0,0,0]:.2f}, fy={Ks_opt[0,1,1]:.2f}")
+    print(f"  cx={Ks_opt[0,0,2]:.2f}, cy={Ks_opt[0,1,2]:.2f}")
+    print("\nAbsolute Errors:")
+    print(f"  fx: {abs(Ks_opt[0,0,0] - camera['Ks_true'][0,0,0]):.2f}")
+    print(f"  fy: {abs(Ks_opt[0,1,1] - camera['Ks_true'][0,1,1]):.2f}")
+    print(f"  cx: {abs(Ks_opt[0,0,2] - camera['Ks_true'][0,0,2]):.2f}")
+    print(f"  cy: {abs(Ks_opt[0,1,2] - camera['Ks_true'][0,1,2]):.2f}")
+    print(f"\nFinal Loss: {losses[-1]:.8f}")
+    print(f"\nResults saved to: {output_dir.absolute()}")
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Optimize camera intrinsics using 3D Gaussian splatting.")
+    parser.add_argument('--use_2dgs', action='store_true', help="Use 2DGS rasterization (default is standard rasterization).")
+    parser.add_argument('--use_3dgs', action='store_false', dest='use_2dgs', help="Use standard 3D rasterization.")
+    args = parser.parse_args()
+    use_2dgs = args.use_2dgs
+    print(f"Using {'2DGS' if use_2dgs else '3DGS'} rasterization for optimization.")
+    """Main function to run the intrinsics optimization test."""
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+    
+    # Create scene and camera
+    scene = create_random_scene(n_gaussians=1000, device=device)
+    camera = create_camera_setup(device=device)
+    
+    # Print scene statistics
+    print(f"\nScene Statistics:")
+    print(f"  Number of Gaussians: {len(scene['means'])}")
+    print(f"  Mean positions: {scene['means'].mean(0).cpu().numpy()}")
+    print(f"  Position std: {scene['means'].std(0).cpu().numpy()}")
+    print(f"  Z range: {scene['means'][:, 2].min().item():.2f} to {scene['means'][:, 2].max().item():.2f}")
+    print(f"  Scale range: {scene['scales'].min().item():.4f} to {scene['scales'].max().item():.4f}")
+    print(f"  Opacity range: {scene['opacities'].min().item():.3f} to {scene['opacities'].max().item():.3f}")
+    
+    # Run optimization
+    optimize_intrinsics(scene, camera, n_iterations=200, lr=1.0, use_2dgs=use_2dgs)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR modifies FullyFusedProjection and FullyFusedProjection2DGS such that the intrinsics (`Ks`) receive gradients.
Am currently working on adding it to PackedProjection as well

Inspiration and derivation of gradients to K for 3DGS came from [this paper](https://arxiv.org/abs/2502.19800v1).

2DGS gradients were derived by hand.

A simple test is added for now. It confirms that an "incorrect" K converges to the correct K from RGB gradients alone.

```
python test_intrinsics_optimization.py --use_3dgs
python test_intrinsics_optimization.py --use_2dgs
```

The results will look something like this:
<img width="2233" height="581" alt="image" src="https://github.com/user-attachments/assets/f4b630f1-92a2-41ec-8bf7-e37a798a1dd3" />


However, while I am fairly confident, I am not 100% sure on the math of the gradients. Would be great if someone can double-check!

Not too sure on the design choice of overloading the `persp_proj_vjp` function for 3DGS to support with/without Ks grads. Maybe we can change that.