### PR TITLE
Fix fused-bilagrid build error with MSVC

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -20,5 +20,5 @@ tensorly
 pyyaml
 matplotlib
 git+https://github.com/rahul-goel/fused-ssim@328dc9836f513d00c4b5bc38fe30478b4435cbb5
-git+https://github.com/harry7557558/fused-bilagrid@90f9788e57d3545e3a033c1038bb9986549632fe
+git+https://github.com/harry7557558/fused-bilagrid@49f0ef06c9f81810fb9b5dd9027cf1844950cc16
 splines


### PR DESCRIPTION
In example requirements, fused-bilagrid references an old commit that gives build error with MSVC (common on Windows). This PR updates it to a newer commit that fixes the error.

See harry7557558/fused-bilagrid#4 for details.

Relevant issues: #811 #812 #730
