### PR TITLE
Fix wheel builds and align PyTorch/CUDA matrix with pytorch.org

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           name: pypi_packages
           path: dist/*.tar.gz
- 
+
   build_wheels:
     runs-on: ${{ matrix.os }}
     environment: production
@@ -30,62 +30,31 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2022]
         python-version: ['3.10']
-        torch-version: ['2.0.0', '2.1.0', '2.2.0', '2.3.0', '2.4.0']
-        cuda-version: ['cu118', 'cu121', 'cu124']
+        # Last 3 minor PyTorch versions aligned with pytorch.org
+        torch-version: ['2.8.0', '2.9.1', '2.10.0']
+        # CUDA versions aligned with PyTorch build matrix
+        cuda-version: ['cu126', 'cu128', 'cu129', 'cu130']
         exclude:
-          - python-version: 3.12
-            torch-version: 2.0.0
-          - python-version: 3.12
-            torch-version: 2.1.0
-          - torch-version: 2.0.0
-            cuda-version: 'cu113'
-          - torch-version: 2.0.0
-            cuda-version: 'cu116'
-          - torch-version: 2.0.0
-            cuda-version: 'cu121'
-          - torch-version: 2.0.0
-            cuda-version: 'cu124'
-          - torch-version: 2.1.0
-            cuda-version: 'cu113'
-          - torch-version: 2.1.0
-            cuda-version: 'cu116'
-          - torch-version: 2.1.0
-            cuda-version: 'cu117'
-          - torch-version: 2.1.0
-            cuda-version: 'cu124'
-          - torch-version: 2.2.0
-            cuda-version: 'cu113'
-          - torch-version: 2.2.0
-            cuda-version: 'cu116'
-          - torch-version: 2.2.0
-            cuda-version: 'cu117'
-          - torch-version: 2.2.0
-            cuda-version: 'cu124'
-          - torch-version: 2.3.0
-            cuda-version: 'cu113'
-          - torch-version: 2.3.0
-            cuda-version: 'cu116'
-          - torch-version: 2.3.0
-            cuda-version: 'cu117'
-          - torch-version: 2.3.0
-            cuda-version: 'cu124'
-          - torch-version: 2.4.0
-            cuda-version: 'cu113'
-          - torch-version: 2.4.0
-            cuda-version: 'cu116'
-          - torch-version: 2.4.0
-            cuda-version: 'cu117'
+          # PyTorch 2.8.0 does not ship cu130 wheels
+          - torch-version: '2.8.0'
+            cuda-version: 'cu130'
+          # PyTorch 2.9.1 does not ship cu129 wheels
+          - torch-version: '2.9.1'
+            cuda-version: 'cu129'
+          # PyTorch 2.10.0 does not ship cu129 wheels
+          - torch-version: '2.10.0'
+            cuda-version: 'cu129'
+          # CUDA 12.6 is incompatible with MSVC >= 14.44 (VS 2022);
+          # the MSVC STL requires CUDA 12.8+
           - os: windows-2022
-            cuda-version: 'cu121'
-          - os: windows-2022
-            cuda-version: 'cu118'
+            cuda-version: 'cu126'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-  
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -115,14 +84,6 @@ jobs:
           python -c "import torch; print('CUDA Available:', torch.cuda.is_available())"
         shell: bash
 
-      - name: Patch PyTorch static constexpr on Windows
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          Torch_DIR=`python -c 'import os; import torch; print(os.path.dirname(torch.__file__))'`
-          sed -i '31,38c\
-          TORCH_API void lazy_init_num_threads();' ${Torch_DIR}/include/ATen/Parallel.h
-        shell: bash
-
       - name: Set version
         if: ${{ runner.os != 'macOS' }}
         run: |
@@ -135,7 +96,8 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --upgrade setuptools
+          # https://github.com/pypa/setuptools/issues/5174, pkg_resources is removed in setuptools 82 but we need it for older torch versions
+          pip install --upgrade "setuptools<82"
           pip install ninja
         shell: bash
 
@@ -146,9 +108,17 @@ jobs:
         shell: bash
 
       - name: Build wheel
+        env:
+          # Step-level env so Windows Python sees CUDA_HOME (bash export does not propagate to python.exe)
+          CUDA_HOME: ${{ runner.os == 'Windows' && (matrix.cuda-version == 'cu130' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0' || matrix.cuda-version == 'cu129' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9' || matrix.cuda-version == 'cu128' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8' || 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6') || '' }}
         run: |
-          pip install wheel
-          source .github/workflows/cuda/${{ runner.os }}-env.sh ${{ matrix.cuda-version }}
+          pip install wheel rich
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            export PATH="${CUDA_HOME}/bin:${PATH}"
+            export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
+          else
+            source .github/workflows/cuda/${{ runner.os }}-env.sh ${{ matrix.cuda-version }}
+          fi
           MAX_JOBS=2 python setup.py bdist_wheel --dist-dir=dist
         shell: bash
 

--- a/.github/workflows/cuda/Linux-env.sh
+++ b/.github/workflows/cuda/Linux-env.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
 
-# Took from https://github.com/pyg-team/pyg-lib/
-
 case ${1} in
+  cu130)
+    export CUDA_HOME=/usr/local/cuda-13.0
+    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+    export PATH=${CUDA_HOME}/bin:${PATH}
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;9.0a"
+    ;;
+  cu129)
+    export CUDA_HOME=/usr/local/cuda-12.9
+    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+    export PATH=${CUDA_HOME}/bin:${PATH}
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;9.0a"
+    ;;
+  cu128)
+    export CUDA_HOME=/usr/local/cuda-12.8
+    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+    export PATH=${CUDA_HOME}/bin:${PATH}
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;9.0a"
+    ;;
+  cu126)
+    export CUDA_HOME=/usr/local/cuda-12.6
+    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+    export PATH=${CUDA_HOME}/bin:${PATH}
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
+    ;;
   cu124)
     export CUDA_HOME=/usr/local/cuda-12.4
     export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
@@ -14,42 +36,6 @@ case ${1} in
     export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
     export PATH=${CUDA_HOME}/bin:${PATH}
     export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
-    ;;
-  cu118)
-    export CUDA_HOME=/usr/local/cuda-11.8
-    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
-    export PATH=${CUDA_HOME}/bin:${PATH}
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
-    ;;
-  cu117)
-    export CUDA_HOME=/usr/local/cuda-11.7
-    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
-    export PATH=${CUDA_HOME}/bin:${PATH}
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu116)
-    export CUDA_HOME=/usr/local/cuda-11.6
-    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
-    export PATH=${CUDA_HOME}/bin:${PATH}
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu115)
-    export CUDA_HOME=/usr/local/cuda-11.5
-    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
-    export PATH=${CUDA_HOME}/bin:${PATH}
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu113)
-    export CUDA_HOME=/usr/local/cuda-11.3
-    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
-    export PATH=${CUDA_HOME}/bin:${PATH}
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu102)
-    export CUDA_HOME=/usr/local/cuda-10.2
-    export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
-    export PATH=${CUDA_HOME}/bin:${PATH}
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5"
     ;;
   *)
     ;;

--- a/.github/workflows/cuda/Linux.sh
+++ b/.github/workflows/cuda/Linux.sh
@@ -1,57 +1,31 @@
 #!/bin/bash
 
-# Took from https://github.com/pyg-team/pyg-lib/
+# Install CUDA toolkit components via the NVIDIA network repository.
+# This approach is more maintainable than downloading local .deb installers
+# because it does not require tracking exact driver-version filenames.
 
-OS=ubuntu2004
+set -euo pipefail
+
+OS=ubuntu2204
 
 case ${1} in
+  cu130)
+    CUDA_MAJOR_MINOR=13.0
+    ;;
+  cu129)
+    CUDA_MAJOR_MINOR=12.9
+    ;;
+  cu128)
+    CUDA_MAJOR_MINOR=12.8
+    ;;
+  cu126)
+    CUDA_MAJOR_MINOR=12.6
+    ;;
   cu124)
-    CUDA=12.4
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.1-550.54.15-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.1/local_installers
+    CUDA_MAJOR_MINOR=12.4
     ;;
   cu121)
-    CUDA=12.1
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.1-530.30.02-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.1/local_installers
-    ;;
-  cu118)
-    CUDA=11.8
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.0-520.61.05-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.0/local_installers
-    ;;
-  cu117)
-    CUDA=11.7
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.1-515.65.01-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.1/local_installers
-    ;;
-  cu116)
-    CUDA=11.6
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.2-510.47.03-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.2/local_installers
-    ;;
-  cu115)
-    CUDA=11.5
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.2-495.29.05-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.2/local_installers
-    ;;
-  cu113)
-    CUDA=11.3
-    APT_KEY=${OS}-${CUDA/./-}-local
-    FILENAME=cuda-repo-${APT_KEY}_${CUDA}.0-465.19.01-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}.0/local_installers
-    ;;
-  cu102)
-    CUDA=10.2
-    APT_KEY=${CUDA/./-}-local-${CUDA}.89-440.33.01
-    FILENAME=cuda-repo-${OS}-${APT_KEY}_1.0-1_amd64.deb
-    URL=https://developer.download.nvidia.com/compute/cuda/${CUDA}/Prod/local_installers
+    CUDA_MAJOR_MINOR=12.1
     ;;
   *)
     echo "Unrecognized CUDA_VERSION=${1}"
@@ -59,19 +33,16 @@ case ${1} in
     ;;
 esac
 
-wget -nv https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/cuda-${OS}.pin
-sudo mv cuda-${OS}.pin /etc/apt/preferences.d/cuda-repository-pin-600
-wget -nv ${URL}/${FILENAME}
-sudo dpkg -i ${FILENAME}
+CUDA_DASHED=${CUDA_MAJOR_MINOR/./-}
 
-if [ "${1}" = "cu117" ] || [ "${1}" = "cu118" ] || [ "${1}" = "cu121" ] || [ "${1}" = "cu124" ]; then
-  sudo cp /var/cuda-repo-${APT_KEY}/cuda-*-keyring.gpg /usr/share/keyrings/
-else
-  sudo apt-key add /var/cuda-repo-${APT_KEY}/7fa2af80.pub
-fi
+# Install the CUDA keyring for repository authentication
+wget -nv "https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/cuda-keyring_1.1-1_all.deb"
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+rm -f cuda-keyring_1.1-1_all.deb
 
 sudo apt-get -qq update
-sudo apt install cuda-nvcc-${CUDA/./-} cuda-libraries-dev-${CUDA/./-} cuda-command-line-tools-${CUDA/./-}
-sudo apt clean
-
-rm -f ${FILENAME}
+sudo apt-get -qq install -y \
+  cuda-nvcc-${CUDA_DASHED} \
+  cuda-libraries-dev-${CUDA_DASHED} \
+  cuda-command-line-tools-${CUDA_DASHED}
+sudo apt-get clean

--- a/.github/workflows/cuda/Windows-env.sh
+++ b/.github/workflows/cuda/Windows-env.sh
@@ -1,49 +1,30 @@
 #!/bin/bash
 
-# Took from https://github.com/pyg-team/pyg-lib/
-
 case ${1} in
+  cu130)
+    export CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v13.0
+    export PATH=${CUDA_HOME}/bin:/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;9.0a"
+    ;;
+  cu129)
+    export CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v12.9
+    export PATH=${CUDA_HOME}/bin:/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;9.0a"
+    ;;
+  cu128)
+    export CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v12.8
+    export PATH=${CUDA_HOME}/bin:/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0;9.0a"
+    ;;
+  cu126)
+    export CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v12.6
+    export PATH=${CUDA_HOME}/bin:/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
+    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
+    ;;
   cu124)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v12.4
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
+    export CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v12.4
+    export PATH=${CUDA_HOME}/bin:/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
     export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
-    ;;
-  cu121)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v12.1
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
-    ;;
-  cu118)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v11.8
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0"
-    ;;
-  cu117)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v11.7
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu116)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v11.6
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu115)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v11.5
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
-    ;;
-  cu113)
-    CUDA_HOME=/c/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA/v11.3
-    PATH=${CUDA_HOME}/bin:$PATH
-    PATH=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/BuildTools/MSBuild/15.0/Bin:$PATH
-    export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"
     ;;
   *)
     ;;

--- a/.github/workflows/cuda/Windows.sh
+++ b/.github/workflows/cuda/Windows.sh
@@ -1,47 +1,35 @@
 #!/bin/bash
 
-# Took from https://github.com/pyg-team/pyg-lib/
-
 # Install NVIDIA drivers, see:
 # https://github.com/pytorch/vision/blob/master/packaging/windows/internal/cuda_install.bat#L99-L102
 curl -k -L "https://drive.google.com/u/0/uc?id=1injUyo3lnarMgWyRcXqKg4UGnN0ysmuq&export=download" --output "/tmp/gpu_driver_dlls.zip"
 7z x "/tmp/gpu_driver_dlls.zip" -o"/c/Windows/System32"
 
 case ${1} in
+  cu130)
+    CUDA_SHORT=13.0
+    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
+    CUDA_FILE=cuda_${CUDA_SHORT}.0_581.28_windows.exe
+    ;;
+  cu129)
+    CUDA_SHORT=12.9
+    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
+    CUDA_FILE=cuda_${CUDA_SHORT}.0_576.02_windows.exe
+    ;;
+  cu128)
+    CUDA_SHORT=12.8
+    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.1/local_installers
+    CUDA_FILE=cuda_${CUDA_SHORT}.1_572.61_windows.exe
+    ;;
+  cu126)
+    CUDA_SHORT=12.6
+    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.3/local_installers
+    CUDA_FILE=cuda_${CUDA_SHORT}.3_561.17_windows.exe
+    ;;
   cu124)
     CUDA_SHORT=12.4
     CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.1/local_installers
     CUDA_FILE=cuda_${CUDA_SHORT}.1_551.78_windows.exe
-    ;;
-  cu121)
-    CUDA_SHORT=12.1
-    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.1/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.1_531.14_windows.exe
-    ;;
-  cu118)
-    CUDA_SHORT=11.8
-    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.0_522.06_windows.exe
-    ;;
-  cu117)
-    CUDA_SHORT=11.7
-    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.1/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.1_516.94_windows.exe
-    ;;
-  cu116)
-    CUDA_SHORT=11.3
-    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.0_465.89_win10.exe
-    ;;
-  cu115)
-    CUDA_SHORT=11.3
-    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.0_465.89_win10.exe
-    ;;
-  cu113)
-    CUDA_SHORT=11.3
-    CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.0_465.89_win10.exe
     ;;
   *)
     echo "Unrecognized CUDA_VERSION=${1}"

--- a/gsplat/cuda/build.py
+++ b/gsplat/cuda/build.py
@@ -69,8 +69,12 @@ def get_build_parameters():
     extra_ldflags = []
 
     if sys.platform == "win32":
-        extra_cflags += ["/std=c++20", "-DWIN32_LEAN_AND_MEAN"]
-        extra_cuda_cflags += ["-allow-unsupported-compiler"]
+        extra_cflags += ["/std:c++20", "-DWIN32_LEAN_AND_MEAN"]
+        extra_cuda_cflags += [
+            "-std=c++20",
+            "-allow-unsupported-compiler",
+            "-DWIN32_LEAN_AND_MEAN",
+        ]
     else:
         extra_cflags = ["-std=c++20"]
 
@@ -82,36 +86,56 @@ def get_build_parameters():
     extra_cuda_cflags += ["--forward-unknown-opts"]
 
     # Debug/Release mode
-    extra_cflags += ["-g", "-O0"] if DEBUG else ["-O3", "-DNDEBUG"]
+    # MSVC (cl) does not support -O3/-O0; use -O2/-Od (torch converts - to /)
+    if sys.platform == "win32":
+        if DEBUG:
+            extra_cflags += ["/Zi", "/Od"]
+            extra_cuda_cflags += ["-Od"]
+        else:
+            extra_cflags += ["/O2", "-DNDEBUG"]
+            extra_cuda_cflags += ["-O2", "-DNDEBUG"]
+    else:
+        extra_cflags += ["-g", "-O0"] if DEBUG else ["-O3", "-DNDEBUG"]
+
     extra_cuda_cflags += ["-use_fast_math"] if FAST_MATH else []
 
     extra_cuda_cflags += ["-lineinfo"] if DEBUG else []
 
     # Silencing of warnings
-    extra_cflags += ["-Wno-attributes"]
     # GLM/Torch has spammy and very annoyingly verbose warnings that this suppresses
     extra_cuda_cflags += ["-diag-suppress", "20012,186"]
     if not os.name == "nt":
-        extra_cflags += ["-Wno-sign-compare"]
+        extra_cflags += ["-Wno-sign-compare", "-Wno-attributes"]
 
     if BUILD_2DGS is not None:
         extra_cflags += [f"-DGSPLAT_BUILD_2DGS={BUILD_2DGS}"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += [f"-DGSPLAT_BUILD_2DGS={BUILD_2DGS}"]
     if BUILD_3DGS is not None:
         extra_cflags += [f"-DGSPLAT_BUILD_3DGS={BUILD_3DGS}"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += [f"-DGSPLAT_BUILD_3DGS={BUILD_3DGS}"]
     if BUILD_3DGUT is not None:
         extra_cflags += [f"-DGSPLAT_BUILD_3DGUT={BUILD_3DGUT}"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += [f"-DGSPLAT_BUILD_3DGUT={BUILD_3DGUT}"]
     if BUILD_ADAM is not None:
         extra_cflags += [f"-DGSPLAT_BUILD_ADAM={BUILD_ADAM}"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += [f"-DGSPLAT_BUILD_ADAM={BUILD_ADAM}"]
     if BUILD_RELOC is not None:
         extra_cflags += [f"-DGSPLAT_BUILD_RELOC={BUILD_RELOC}"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += [f"-DGSPLAT_BUILD_RELOC={BUILD_RELOC}"]
     if BUILD_CAMERA_WRAPPERS:
-        extra_cuda_cflags += ["-DBUILD_CAMERA_WRAPPERS=1"]
         extra_cflags += ["-DBUILD_CAMERA_WRAPPERS=1"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += ["-DBUILD_CAMERA_WRAPPERS=1"]
     else:
         # Remove 'csrc/CameraWrappers.cu' from the sources list if it exists
         sources = [s for s in sources if not s.endswith("csrc/CameraWrappers.cu")]
 
-    extra_ldflags += [] if WITH_SYMBOLS else ["-s"]
+    extra_ldflags += [] if WITH_SYMBOLS or sys.platform == "win32" else ["-s"]
 
     if torch.version.hip:
         # USE_ROCM was added to later versions of PyTorch.
@@ -127,11 +151,18 @@ def get_build_parameters():
         and sys.platform != "darwin"
     ):
         extra_cflags += ["-DAT_PARALLEL_OPENMP"]
-        extra_cflags += ["/openmp"] if sys.platform == "win32" else ["-fopenmp"]
+        if sys.platform == "win32":
+            extra_cflags += ["/openmp"]
+            extra_cuda_cflags += ["-Xcompiler", "/openmp"]
+        else:
+            extra_cflags += ["-fopenmp"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += ["-DAT_PARALLEL_OPENMP"]
     else:
         print("Compiling without OpenMP...")
 
-    extra_cuda_cflags += extra_cflags
+    if sys.platform != "win32":
+        extra_cuda_cflags += extra_cflags
 
     if NUM_CHANNELS is not None:
         # nvcc has a bug where you need to escape the commas in macro values defined with -D.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ requires = [
     "wheel",
     "ninja",
     "torch",
+    "numpy",
+    "rich",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,27 @@ def get_ext():
 
 def get_extensions():
     from torch.utils.cpp_extension import CUDAExtension
-    from gsplat.cuda.build import get_build_parameters
 
-    params = get_build_parameters()
+    # Use the same build parameters as the JIT build. However, directly
+    # importing the gsplat.cuda.build module would trigger a circular
+    # dependency where gsplat is imported before it is built. To avoid
+    # this, we sidestep the traditional Python import mechanism and construct
+    # the module directly from build.py.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "gsplat_cuda_build", os.path.join("gsplat", "cuda", "build.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    params = module.get_build_parameters()
+
+    setup_dir = os.path.dirname(os.path.abspath(__file__))
+    sources = [os.path.relpath(s, setup_dir) for s in params.sources]
 
     extension = CUDAExtension(
         "gsplat.csrc",
-        sources=params.sources,
+        sources=sources,
         include_dirs=params.extra_include_paths,
         extra_compile_args={
             "cxx": params.extra_cflags,


### PR DESCRIPTION
This commit supersedes the previous nv/fix_build_wheels branch, consolidating all wheel build fixes into a single commit based on the latest main and updating the PyTorch/CUDA version matrix to match the current pytorch.org support (March 2026).

Build system fixes (gsplat/cuda/build.py):
- Fix MSVC C++ standard flag: /std=c++20 -> /std:c++20
- Add -std=c++20, -allow-unsupported-compiler, -DWIN32_LEAN_AND_MEAN to nvcc flags on Windows
- Platform-branch debug/release flags: MSVC gets /Zi /Od or /O2 instead of GCC -g -O0 or -O3
- Guard -Wno-attributes and -Wno-sign-compare behind os.name \!= "nt"
- Forward BUILD_* and BUILD_CAMERA_WRAPPERS macros to nvcc on Windows
- Guard -s linker flag off Windows (not supported by MSVC)
- Add -Xcompiler /openmp and -DAT_PARALLEL_OPENMP for nvcc on Windows
- Gate extra_cuda_cflags += extra_cflags behind sys.platform \!= "win32" to prevent GCC flags from being passed to nvcc on Windows

Wheel packaging fixes (setup.py, pyproject.toml):
- Fix circular import: replace `from gsplat.cuda.build import` with importlib.util.module_from_spec to avoid importing gsplat before it is built
- Convert absolute source paths to relative for bdist_wheel compat
- Add numpy and rich to pyproject.toml [build-system] requires

GitHub Actions workflow (building.yml):
- Update PyTorch matrix to last 3 minor versions: 2.8.0, 2.9.1, 2.10.0
- Update CUDA matrix to: cu126, cu128, cu129, cu130
- Add exclusions for unavailable PyTorch+CUDA combinations and MSVC+CUDA 12.6 incompatibility on Windows (VS 2022)
- Pin setuptools<82 to avoid pkg_resources removal
- Add Windows CUDA_HOME step-level env variable
- Add rich to wheel build dependencies
- Remove stale ATen/Parallel.h patch (not needed for PyTorch 2.8+)

CUDA installation scripts:
- Linux: switch from local .deb installers to NVIDIA network repository (cuda-keyring) for easier maintenance
- Add cu126, cu128, cu129, cu130 entries to all four scripts
- Remove obsolete cu102-cu118 entries
- Add 9.0a to TORCH_CUDA_ARCH_LIST for cu128+ (Blackwell support)
- Export CUDA_HOME and PATH in Windows-env.sh