### PR TITLE
Move scipy dependency to be only in gsplat[lidar]

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -133,6 +133,8 @@ jobs:
           ls -lah
           pip install *.whl
           python -c "import gsplat; print('gsplat:', gsplat.__version__)"
+          pip install "$(ls *.whl)[lidar]"
+          python -c "import gsplat; print('gsplat:', gsplat.__version__); from scipy.spatial import cKDTree; print('scipy OK')"
           cd ..
         shell: bash
 

--- a/gsplat/cuda/_lidar.py
+++ b/gsplat/cuda/_lidar.py
@@ -23,7 +23,6 @@ from typing import Optional
 
 import numpy as np
 import torch
-from scipy import spatial as scipy_spatial
 from typing_extensions import override
 
 
@@ -679,6 +678,8 @@ def compute_angles_to_columns_map(
     # TODO: this is quite slow and should be moved to CUDA.
     #       We can get away with it for now because we're caching the results,
     #       and usually this function would be called only once per lidar model needed.
+    from scipy import spatial as scipy_spatial  # requires pip install gsplat[lidar]
+
     kdtree = scipy_spatial.cKDTree(
         sensor_rays.sensor_rays.contiguous().cpu().numpy()
     )  # ty:ignore[unresolved-attribute]

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,14 @@ setup(
         "numpy",
         "jaxtyping",
         "rich>=12",
-        "scipy",
         "torch",
         "typing_extensions; python_version<'3.8'",
     ],
     extras_require={
+        # lidar dependencies. Install them by `pip install gsplat[lidar]`
+        "lidar": [
+            "scipy",
+        ],
         # dev dependencies. Install them by `pip install gsplat[dev]`
         "dev": [
             "black[jupyter]==22.3.0",


### PR DESCRIPTION
Move scipy from install_requires to extras_require[lidar]

scipy is only needed for the lidar KD-tree NN lookup. Users who don't
use lidar features no longer need to install it. Install with:

    pip install gsplat[lidar]

The wheel build CI test step now also installs with [lidar] to verify
scipy is available when testing the built wheel.