### PR TITLE
[NV] Remove `NRend` References in the Comments

### DIFF
--- a/gsplat/cuda/_torch_impl_eval3d.py
+++ b/gsplat/cuda/_torch_impl_eval3d.py
@@ -351,7 +351,7 @@ def accumulate_eval3d(
     gauss_colors = colors[image_ids, gaussian_ids]
 
     # 6b. Compute normals if requested
-    # Normal computation follows nRend: canonical normal (0,0,1) transformed by rotation
+    # Normal computation uses the normal (0,0,1) transformed by rotation
     gauss_normals = None
     if return_normals:
         quats_per_gauss = quats_flat[batch_ids, gaussian_ids]  # [M, 4]
@@ -362,7 +362,6 @@ def accumulate_eval3d(
         gauss_normals = R[:, :, 2]  # [M, 3]
 
         # Direction resolution: flip if facing away from ray
-        # (same as nRend: if dot(normal, ray_direction) > 0, flip)
         ray_d_normalized = _safe_normalize(ray_d)  # [M, 3]
         dot_product = torch.sum(
             gauss_normals * ray_d_normalized, dim=-1, keepdim=True

--- a/gsplat/cuda/_torch_lidars.py
+++ b/gsplat/cuda/_torch_lidars.py
@@ -66,8 +66,11 @@ class _StructuredLidarModel(_LidarModel, _BaseCameraModel):
         # TODO: passing shutter type because the base expects it, but Lidar doesn't use it.
         # This is a clear sign of design smell, the camera/sensor class hierarchy needs a revamp
         # to properly support lidar sensors.
-        # TODO: we're transposing rows and columns like nrend does.
-        # This needs to be reverted once we validate that gsplat is a drop-in replacement for nrend.
+        # TODO: we're transposing rows and columns by mapping n_rows->width and
+        # n_columns->height because the current pipeline uses image_point =
+        # [x, y] = [row, column] = [elevation, azimuth]. This needs to be
+        # reverted once the pipeline switches to the standard
+        # [x, y] = [column, row] = [azimuth, elevation].
         _BaseCameraModel.__init__(self, width=params.n_rows, height=params.n_columns)
 
 
@@ -240,7 +243,9 @@ class _RowOffsetStructuredSpinningLidarModel(_StructuredSpinningLidarModel):
         row = angles.elevation * self.ANGLE_TO_PIXEL_SCALING_FACTOR
 
         # NOTE: here the image point is (elevation, azimuth)
-        # TODO: this is following nrend/vren, but it should be the other way around.
+        # TODO: the current pipeline has image_point following [x, y] = [row,
+        # column] = [elevation, azimuth], but it should be [x, y] = [column,
+        # row] = [azimuth, elevation].
         image_point = torch.stack([row, column], dim=-1)
 
         # Validation: compute relative angles for FOV checking
@@ -275,7 +280,8 @@ class _RowOffsetStructuredSpinningLidarModel(_StructuredSpinningLidarModel):
         row = image_point[..., 0]
         column = image_point[..., 1]
 
-        # Convert from scaled angle space to angles (NREND approach)
+        # Convert from scaled angle space to angles
+        # NOTE: the current pipeline uses image_point = [x, y] = [row, column] = [elevation, azimuth].
         kToAngle = 1.0 / self.ANGLE_TO_PIXEL_SCALING_FACTOR
         angles = SphericalUnitCoord(elevation=row * kToAngle, azimuth=column * kToAngle)
 

--- a/gsplat/cuda/csrc/CameraWrappers.cu
+++ b/gsplat/cuda/csrc/CameraWrappers.cu
@@ -961,8 +961,10 @@ __global__ void construct_lidar_cameras_kernel(
 }
 
 PyRowOffsetStructuredSpinningLidarModel::PyRowOffsetStructuredSpinningLidarModel(RowOffsetStructuredSpinningLidarModelParametersExt params)
-    // TODO: We're mapping n_rows->width and n_columns->height to conform with nrend, but this should be reverted
-    // once we validate that gsplat is 1:1 replacement of nrend.
+    // TODO: We're mapping n_rows->width and n_columns->height because the
+    // current pipeline uses image_point = [x, y] = [row, column] = [elevation,
+    // azimuth]. This should be reverted once the pipeline switches to the
+    // standard [x, y] = [column, row] = [azimuth, elevation].
     : PyBaseCameraModel(1, params.n_rows(), params.n_columns(),
                       // Spinning lidars always have rolling shutter; the actual per-sigma-point
                       // timing is handled by shutter_relative_frame_time() in the lidar model.

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
@@ -411,7 +411,6 @@ __global__ void rasterize_to_pixels_from_world_3dgs_fwd_kernel(
                 const vec3 unnormalized_normal = normal_batch[t];
                 
                 // Direction resolution: flip if facing away from ray
-                // (same as nRend: if dot(normal, ray_direction) > 0, flip)
                 const bool flipped = glm::dot(unnormalized_normal, ray_d) > 0.0f;
                 const vec3 unnormalized_flipped = flipped ? -unnormalized_normal : unnormalized_normal;
                 

--- a/gsplat/cuda/include/Lidars.cuh
+++ b/gsplat/cuda/include/Lidars.cuh
@@ -76,7 +76,11 @@ struct RowOffsetStructuredSpinningLidarModel : BaseCameraModel<RowOffsetStructur
     {
         __device__
         explicit Parameters(RowOffsetStructuredSpinningLidarModelParametersExtDevice lidar_params)
-            // TODO: We're mapping n_rows->width and n_columns->height to conform with nrend, but this should be reverted
+            // TODO: We're mapping n_rows->width and n_columns->height because
+            // the current pipeline uses image_point = [x, y] = [row, column]
+            // = [elevation, azimuth]. This should be reverted once the pipeline
+            // switches to the standard [x, y] = [column, row] = [azimuth,
+            // elevation].
             : Base::Parameters{
                 {static_cast<unsigned int>(lidar_params.n_rows), static_cast<unsigned int>(lidar_params.n_columns)},
                 ShutterType::ROLLING_LEFT_TO_RIGHT
@@ -116,7 +120,9 @@ public:
         assert(lidar.angles_to_columns_map != nullptr);
 
         // Convert image point (in scaled pixel space) back to angles
-        // TODO: transposing here to make it compatible with nrend/vren, this needs to be reverted later.
+        // TODO: transposing here because the current pipeline uses image_point =
+        // [x, y] = [elevation, azimuth], this needs to be reverted
+        // once the pipeline switches to the standard [x, y] = [azimuth, elevation].
         constexpr float kToAngle = 1.f / lidar.ANGLE_TO_PIXEL_SCALING_FACTOR;
         const float elevation = image_point.x * kToAngle;
         const float azimuth = image_point.y * kToAngle;
@@ -166,7 +172,9 @@ public:
         const float azimuth = std::atan2(ray_normalized.y, ray_normalized.x);
 
         // Image point: [row, column] (in scaled angle space)
-        // TODO: Must undo this swap once the current code is confirmed to be 1:1 with nrend.
+        // TODO: the current pipeline uses image_point = [x, y] = [row, column]
+        // = [elevation, azimuth]. Must undo this swap once the pipeline switches
+        // to the standard [x, y] = [column, row] = [azimuth, elevation].
         const float row = elevation * lidar.ANGLE_TO_PIXEL_SCALING_FACTOR;
         const float column = azimuth * lidar.ANGLE_TO_PIXEL_SCALING_FACTOR;
         const glm::fvec2 image_point = glm::fvec2{row, column};
@@ -192,7 +200,10 @@ public:
     {
         const RowOffsetStructuredSpinningLidarModelParametersExtDevice &lidar = parameters.lidar;
 
-        // TODO: transposing to be compatible with nrend, but this must be reverted later.
+        // TODO: transposing because the current pipeline uses image_point =
+        // [x, y] = [row, column] = [elevation, azimuth], but this must be reverted
+        // once the pipeline switches to the standard [x, y] = [column, row] =
+        // [azimuth, elevation].
         const float row = image_point.x;
         const float col = image_point.y;
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2071,7 +2071,7 @@ def _expected_hit_distance_canonical_ray_distance(
     quats: torch.Tensor,
     scales: torch.Tensor,
 ) -> float:
-    """Expected hit distance using nrend canonicalRayDistance: length(scale * grd * hit_t)."""
+    """Expected hit distance using the formula: length(scale * grd * hit_t)."""
     from gsplat.cuda._math import _quat_scale_to_preci_half
     from gsplat.cuda._torch_impl_eval3d import _safe_normalize
 
@@ -2159,7 +2159,7 @@ def _pixel_ray_dir_pinhole(
 def test_rasterize_to_pixels_hit_distance_principal_axis(
     means_list, quats_choice, scales_list, pixel_dx, pixel_dy
 ):
-    """Check that hit distance (accumulated/alpha) matches nrend KBuffer canonicalRayDistance:
+    """Check that hit distance (accumulated/alpha) matches the hit-distance formula:
     length(scale * grd * hit_t) with hit_t = dot(grd, -gro). Includes center and off-center
     pixels. Failures indicate the rasterization hit-distance code should be analyzed and fixed.
     """


### PR DESCRIPTION
## Summary

This PR removes the remaining `NRend` references from comments and test docstrings, and replaces them with direct descriptions of the current gsplat behavior.