### PR TITLE
Enable Windows CUDA 13 build

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -48,11 +48,6 @@ jobs:
           # the MSVC STL requires CUDA 12.8+
           - os: windows-2022
             cuda-version: 'cu126'
-          # CUDA 13.0 does not ship a complete Windows installer,
-          # it does not have NVIDIA driver and crt/cudart.
-          # TODO: Fix Windows build to include CUDA 13.0 for Windows
-          - os: windows-2022
-            cuda-version: 'cu130'
 
     steps:
       - name: Checkout repository
@@ -115,7 +110,7 @@ jobs:
       - name: Build wheel
         env:
           # Step-level env so Windows Python sees CUDA_HOME (bash export does not propagate to python.exe)
-          CUDA_HOME: ${{ runner.os == 'Windows' && (matrix.cuda-version == 'cu129' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9' || matrix.cuda-version == 'cu128' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8' || 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6') || '' }}
+          CUDA_HOME: ${{ runner.os == 'Windows' && (matrix.cuda-version == 'cu130' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0' || matrix.cuda-version == 'cu129' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9' || matrix.cuda-version == 'cu128' && 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8' || 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6') || '' }}
         run: |
           pip install wheel rich
           if [ "$RUNNER_OS" = "Windows" ]; then

--- a/.github/workflows/cuda/Windows.sh
+++ b/.github/workflows/cuda/Windows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Install NVIDIA drivers, see:
-# https://github.com/pytorch/vision/blob/master/packaging/windows/internal/cuda_install.bat#L99-L102
+# Install NVIDIA driver stub DLLs (needed for linking, not for runtime).
+# CUDA 13+ no longer bundles the driver, but we still need the stubs for building.
 curl -k -L "https://drive.google.com/u/0/uc?id=1injUyo3lnarMgWyRcXqKg4UGnN0ysmuq&export=download" --output "/tmp/gpu_driver_dlls.zip"
 7z x "/tmp/gpu_driver_dlls.zip" -o"/c/Windows/System32"
 
@@ -9,7 +9,8 @@ case ${1} in
   cu130)
     CUDA_SHORT=13.0
     CUDA_URL=https://developer.download.nvidia.com/compute/cuda/${CUDA_SHORT}.0/local_installers
-    CUDA_FILE=cuda_${CUDA_SHORT}.0_581.28_windows.exe
+    # CUDA 13+ no longer bundles the driver, so the filename has no driver version.
+    CUDA_FILE=cuda_${CUDA_SHORT}.0_windows.exe
     ;;
   cu129)
     CUDA_SHORT=12.9
@@ -40,7 +41,22 @@ esac
 curl -k -L "${CUDA_URL}/${CUDA_FILE}" --output "${CUDA_FILE}"
 echo ""
 echo "Installing from ${CUDA_FILE}..."
-PowerShell -Command "Start-Process -FilePath \"${CUDA_FILE}\" -ArgumentList \"-s nvcc_${CUDA_SHORT} cuobjdump_${CUDA_SHORT} nvprune_${CUDA_SHORT} cupti_${CUDA_SHORT} cublas_dev_${CUDA_SHORT} cudart_${CUDA_SHORT} cufft_dev_${CUDA_SHORT} curand_dev_${CUDA_SHORT} cusolver_dev_${CUDA_SHORT} cusparse_dev_${CUDA_SHORT} thrust_${CUDA_SHORT} npp_dev_${CUDA_SHORT} nvrtc_dev_${CUDA_SHORT} nvml_dev_${CUDA_SHORT}\" -Wait -NoNewWindow"
+
+# Base components needed for building CUDA extensions.
+CUDA_COMPONENTS="nvcc_${CUDA_SHORT} cuobjdump_${CUDA_SHORT} nvprune_${CUDA_SHORT} cupti_${CUDA_SHORT} cublas_dev_${CUDA_SHORT} cudart_${CUDA_SHORT} cufft_dev_${CUDA_SHORT} curand_dev_${CUDA_SHORT} cusolver_dev_${CUDA_SHORT} cusparse_dev_${CUDA_SHORT} thrust_${CUDA_SHORT} npp_dev_${CUDA_SHORT} nvrtc_dev_${CUDA_SHORT} nvml_dev_${CUDA_SHORT}"
+
+# CUDA 13+ split several components out of nvcc into their own subpackages:
+#   crt       - compiler headers (crt/host_config.h)
+#   nvvm      - CUDA IR compiler (cicc)
+#   nvfatbin  - fatbinary combiner
+#   nvptxcompiler - PTX compiler
+#   visual_studio_integration - MSVC integration for --use-local-env
+CUDA_MAJOR=${CUDA_SHORT%%.*}
+if [ "${CUDA_MAJOR}" -ge 13 ]; then
+    CUDA_COMPONENTS="${CUDA_COMPONENTS} crt_${CUDA_SHORT} nvvm_${CUDA_SHORT} nvfatbin_${CUDA_SHORT} nvptxcompiler_${CUDA_SHORT} visual_studio_integration_${CUDA_SHORT}"
+fi
+
+PowerShell -Command "Start-Process -FilePath \"${CUDA_FILE}\" -ArgumentList \"-s ${CUDA_COMPONENTS}\" -Wait -NoNewWindow"
 echo "Done!"
 rm -f "${CUDA_FILE}"
 


### PR DESCRIPTION
Enable Windows CUDA 13 build: add crt component and CUDA_HOME mapping

CUDA 13.0 split the CRT (compiler headers including crt/host_config.h) out of the nvcc component into its own subpackage. The Windows silent installer now requires `crt_13.0` to be explicitly listed.

Changes:
- Windows.sh: add `crt_${CUDA_SHORT}` for CUDA >= 13
- building.yml: add cu130 to the Windows CUDA_HOME mapping
