### PR TITLE
[NV] Add AccuTile Conservative Ellipse Intersection for 3DGS

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -645,8 +645,17 @@ def isect_tiles(
     n_images: Optional[int] = None,
     image_ids: Optional[Tensor] = None,
     gaussian_ids: Optional[Tensor] = None,
+    conics: Optional[
+        Tensor
+    ] = None,  # [..., N, 3] or [nnz, 3], enables AccuTile when provided
+    opacities: Optional[
+        Tensor
+    ] = None,  # [..., N] or [nnz], enables AccuTile when provided
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Maps projected Gaussians to intersecting tiles.
+
+    When `conics` and `opacities` are provided the kernel uses conservative ellipse intersection (AccuTile/SNUGBOX),
+    skipping tiles that the opacity-thresholded ellipse does not touch. When either is `None` the kernel falls back to the original axis-aligned bounding box.
 
     Args:
         means2d: Projected Gaussian means. [..., N, 2] if packed is False, [nnz, 2] if packed is True.
@@ -661,6 +670,8 @@ def isect_tiles(
         n_images: Number of images. Required if packed is True.
         image_ids: The image indices of the projected Gaussians. Required if packed is True.
         gaussian_ids: The column indices of the projected Gaussians. Required if packed is True.
+        conics: Inverse of projected covariances (upper triangle). [..., N, 3] if packed is False, [nnz, 3] if packed is True. Enables AccuTile when provided together with opacities.
+        opacities: Gaussian opacities. [..., N] if packed is False, [nnz] if packed is True. Enables AccuTile when provided together with conics.
 
     Returns:
         A tuple:
@@ -678,6 +689,10 @@ def isect_tiles(
         assert means2d.shape == (nnz, 2), means2d.shape
         assert radii.shape == (nnz, 2), radii.shape
         assert depths.shape == (nnz,), depths.shape
+        if conics is not None:
+            assert conics.shape == (nnz, 3), conics.shape
+        if opacities is not None:
+            assert opacities.shape == (nnz,), opacities.shape
         assert image_ids is not None, "image_ids is required if packed is True"
         assert gaussian_ids is not None, "gaussian_ids is required if packed is True"
         assert n_images is not None, "n_images is required if packed is True"
@@ -692,11 +707,17 @@ def isect_tiles(
         assert means2d.shape == image_dims + (N, 2), means2d.shape
         assert radii.shape == image_dims + (N, 2), radii.shape
         assert depths.shape == image_dims + (N,), depths.shape
+        if conics is not None:
+            assert conics.shape == image_dims + (N, 3), conics.shape
+        if opacities is not None:
+            assert opacities.shape == image_dims + (N,), opacities.shape
 
     tiles_per_gauss, isect_ids, flatten_ids = _make_lazy_cuda_func("intersect_tile")(
         means2d.contiguous(),
         radii.contiguous(),
         depths.contiguous(),
+        conics.contiguous() if conics is not None else None,
+        opacities.contiguous() if opacities is not None else None,
         image_ids,
         gaussian_ids,
         I,

--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -31,11 +31,13 @@
 namespace gsplat {
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
-    const at::Tensor &means2d,                    // [..., N, 2] or [nnz, 2]
-    const at::Tensor &radii,                      // [..., N, 2] or [nnz, 2]
-    const at::Tensor &depths,                     // [..., N] or [nnz]
-    const at::optional<at::Tensor> &image_ids,    // [nnz]
-    const at::optional<at::Tensor> &gaussian_ids, // [nnz]
+    const at::Tensor &means2d,                           // [..., N, 2] or [nnz, 2]
+    const at::Tensor &radii,                             // [..., N, 2] or [nnz, 2]
+    const at::Tensor &depths,                            // [..., N] or [nnz]
+    const at::optional<at::Tensor> &conics,              // [..., N, 3] or [nnz, 3] 
+    const at::optional<at::Tensor> &opacities,           // [..., N] or [nnz]        
+    const at::optional<at::Tensor> &image_ids,           // [nnz]
+    const at::optional<at::Tensor> &gaussian_ids,        // [nnz]
     int64_t I,
     int64_t tile_size,
     int64_t tile_width,
@@ -47,6 +49,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
     CHECK_INPUT(means2d);
     CHECK_INPUT(radii);
     CHECK_INPUT(depths);
+    if (conics.has_value()) { CHECK_INPUT(conics.value()); }
+    if (opacities.has_value()) { CHECK_INPUT(opacities.value()); }
 
     auto opt = depths.options();
     uint32_t n_elements = means2d.numel() / 2;
@@ -83,6 +87,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
             means2d,
             radii,
             depths,
+            conics, // at::optional, AccuTile when provided, AABB fallback otherwise
+            opacities, // at::optional
             packed ? image_ids : c10::nullopt,
             packed ? gaussian_ids : c10::nullopt,
             I,
@@ -120,6 +126,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
             means2d,
             radii,
             depths,
+            conics, // at::optional, AccuTile when provided, AABB fallback otherwise
+            opacities, // at::optional
             packed ? image_ids : c10::nullopt,
             packed ? gaussian_ids : c10::nullopt,
             I,

--- a/gsplat/cuda/csrc/Intersect.h
+++ b/gsplat/cuda/csrc/Intersect.h
@@ -29,11 +29,13 @@ namespace gsplat {
 
 void launch_intersect_tile_kernel(
     // inputs
-    const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
-    const at::Tensor radii,                      // [..., N, 2] or [nnz, 2]
-    const at::Tensor depths,                     // [..., N] or [nnz]
-    const at::optional<at::Tensor> image_ids,    // [nnz]
-    const at::optional<at::Tensor> gaussian_ids, // [nnz]
+    const at::Tensor means2d,                           // [..., N, 2] or [nnz, 2]
+    const at::Tensor radii,                             // [..., N, 2] or [nnz, 2]
+    const at::Tensor depths,                            // [..., N] or [nnz]
+    const at::optional<at::Tensor> conics,              // [..., N, 3] or [nnz, 3]
+    const at::optional<at::Tensor> opacities,           // [..., N] or [nnz]      
+    const at::optional<at::Tensor> image_ids,           // [nnz]
+    const at::optional<at::Tensor> gaussian_ids,        // [nnz]
     const uint32_t I,
     const uint32_t tile_size,
     const uint32_t tile_width,

--- a/gsplat/cuda/csrc/IntersectTile.cu
+++ b/gsplat/cuda/csrc/IntersectTile.cu
@@ -32,10 +32,102 @@ namespace gsplat {
 
 namespace cg = cooperative_groups;
 
-// Evaluate spherical harmonics bases at unit direction for high orders using
-// approach described by Efficient Spherical Harmonic Evaluation, Peter-Pike
-// Sloan, JCGT 2013 See https://jcgt.org/published/0002/02/06/ for reference
-// implementation
+// ============================================================
+// SNUGBOX + AccuTile helper functions
+// (ported from test_viewer/src/cuda/Intersect.cu)
+// ============================================================
+
+__device__ inline float2 accutile_ellipse_intersection(
+    float A, float B, float C, float disc, float t, float2 p,
+    bool isY, float coord
+) {
+    float p_u   = isY ? p.y : p.x;
+    float p_v   = isY ? p.x : p.y;
+    float coeff = isY ? A : C;
+
+    float h         = coord - p_u;
+    float sqrt_term = sqrtf(disc * h * h + t * coeff);
+
+    return {(-B * h - sqrt_term) / coeff + p_v, (-B * h + sqrt_term) / coeff + p_v};
+}
+
+__device__ inline uint32_t accutile_process_tiles(
+    float A, float B, float C, float disc, float t, float2 p,
+    float2 bbox_min, float2 bbox_max, float2 bbox_argmin, float2 bbox_argmax,
+    int2 rect_min, int2 rect_max,
+    uint32_t tile_size, uint32_t tile_width, bool isY,
+    int64_t iid_enc, uint32_t tile_n_bits, int64_t depth_id_enc,
+    uint32_t flatten_idx, int64_t *isect_ids, int32_t *flatten_ids,
+    int64_t *cur_idx
+) {
+    float BLOCK = (float)tile_size;
+
+    if (isY) {
+        rect_min    = {rect_min.y, rect_min.x};
+        rect_max    = {rect_max.y, rect_max.x};
+        bbox_min    = {bbox_min.y, bbox_min.x};
+        bbox_max    = {bbox_max.y, bbox_max.x};
+        bbox_argmin = {bbox_argmin.y, bbox_argmin.x};
+        bbox_argmax = {bbox_argmax.y, bbox_argmax.x};
+    }
+
+    uint32_t tiles_count = 0;
+    float2 intersect_min_line, intersect_max_line;
+    float ellipse_min, ellipse_max;
+    float min_line, max_line;
+
+    intersect_max_line = {bbox_max.y, bbox_min.y};
+
+    min_line = rect_min.x * BLOCK;
+    if (bbox_min.x <= min_line) {
+        intersect_min_line = accutile_ellipse_intersection(A, B, C, disc, t, p, isY, min_line);
+    } else {
+        intersect_min_line = intersect_max_line;
+    }
+
+#pragma unroll 1
+    for (int u = rect_min.x; u < rect_max.x; ++u) {
+        max_line = min_line + BLOCK;
+        if (max_line <= bbox_max.x) {
+            intersect_max_line = accutile_ellipse_intersection(A, B, C, disc, t, p, isY, max_line);
+        }
+
+        if (min_line <= bbox_argmin.y && bbox_argmin.y < max_line) {
+            ellipse_min = bbox_min.y;
+        } else {
+            ellipse_min = min(intersect_min_line.x, intersect_max_line.x);
+        }
+
+        if (min_line <= bbox_argmax.y && bbox_argmax.y < max_line) {
+            ellipse_max = bbox_max.y;
+        } else {
+            ellipse_max = max(intersect_min_line.y, intersect_max_line.y);
+        }
+
+        int min_tile_v = max(rect_min.y, min(rect_max.y, (int)(ellipse_min / BLOCK)));
+        int max_tile_v = min(rect_max.y, max(rect_min.y, (int)(ellipse_max / BLOCK + 1)));
+
+        tiles_count += max_tile_v - min_tile_v;
+
+        if (isect_ids != nullptr) {
+#pragma unroll 1
+            for (int v = min_tile_v; v < max_tile_v; v++) {
+                int64_t tile_id       = isY ? (int64_t)(u * tile_width + v) : (int64_t)(v * tile_width + u);
+                isect_ids[*cur_idx]   = iid_enc | (tile_id << 32) | depth_id_enc;
+                flatten_ids[*cur_idx] = static_cast<int32_t>(flatten_idx);
+                ++(*cur_idx);
+            }
+        }
+
+        intersect_min_line = intersect_max_line;
+        min_line           = max_line;
+    }
+    return tiles_count;
+}
+
+// ============================================================
+// Main intersection kernel
+// ============================================================
 
 template <typename scalar_t>
 __global__ void intersect_tile_kernel(
@@ -52,6 +144,8 @@ __global__ void intersect_tile_kernel(
     const scalar_t *__restrict__ means2d,            // [..., N, 2] or [nnz, 2]
     const int32_t *__restrict__ radii,               // [..., N, 2] or [nnz, 2]
     const scalar_t *__restrict__ depths,             // [..., N] or [nnz]
+    const float *__restrict__ conics,                // [..., N, 3] or [nnz, 3]  (Sigma^{-1} upper tri)
+    const float *__restrict__ opacities,             // [..., N] or [nnz]
     const int64_t *__restrict__ cum_tiles_per_gauss, // [..., N] or [nnz]
     const uint32_t tile_size,
     const uint32_t tile_width,
@@ -78,65 +172,130 @@ __global__ void intersect_tile_kernel(
         return;
     }
 
-    vec2 mean2d = glm::make_vec2(means2d + 2 * idx);
+    float2 mean2d = {(float)means2d[2 * idx], (float)means2d[2 * idx + 1]};
 
-    float tile_radius_x = radius_x / static_cast<float>(tile_size);
-    float tile_radius_y = radius_y / static_cast<float>(tile_size);
-    float tile_x = mean2d.x / static_cast<float>(tile_size);
-    float tile_y = mean2d.y / static_cast<float>(tile_size);
+    int64_t iid_enc      = 0;
+    int64_t depth_id_enc = 0;
+    if (!first_pass) {
+        int64_t iid;
+        if (packed) {
+            // parallelize over nnz
+            iid = image_ids[idx];
+        } else {
+            // parallelize over I * N
+            iid = idx / N;
+        }
+        iid_enc = iid << (32 + tile_n_bits);
 
-    // tile_min is inclusive, tile_max is exclusive
-    uint2 tile_min, tile_max;
-    tile_min.x = min(max(0, (uint32_t)floor(tile_x - tile_radius_x)), tile_width);
-    tile_min.y =
-        min(max(0, (uint32_t)floor(tile_y - tile_radius_y)), tile_height);
-    tile_max.x = min(max(0, (uint32_t)ceil(tile_x + tile_radius_x)), tile_width);
-    tile_max.y = min(max(0, (uint32_t)ceil(tile_y + tile_radius_y)), tile_height);
+        // tolerance for negative depth
+        int32_t depth_i32 = *(int32_t *)&(depths[idx]);  // Bit-level reinterpret
+        depth_id_enc = static_cast<uint32_t>(depth_i32);  // Zero-extend to 64-bit
+    }
 
-    if (first_pass) {
-        // first pass only writes out tiles_per_gauss
-        tiles_per_gauss[idx] = static_cast<int32_t>(
-            (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
+    if (conics != nullptr && opacities != nullptr) {
+        // AccuTile: conservative ellipse intersection using the full 2x2 inverse covariance.
+        // conic = (a, b, c) = upper triangle of Sigma^{-1}
+        // Quadratic form: a*dx^2 + 2*b*dx*dy + c*dy^2
+        const float A = conics[idx * 3];
+        const float B = conics[idx * 3 + 1];
+        const float C = conics[idx * 3 + 2];
+
+        // disc = B^2 - A*C = -(det Sigma^{-1})
+        float disc = B * B - A * C;
+
+        // Opacity-aware isocontour level: alpha = opacity * exp(-0.5 * q) >= ALPHA_THRESHOLD
+        // => q <= 2 * ln(opacity / ALPHA_THRESHOLD). Cap at GAUSSIAN_EXTEND^2 (same as the gsplat radius budget).
+        const float opacity = opacities[idx];
+        float t = fminf(GAUSSIAN_EXTEND * GAUSSIAN_EXTEND, 2.0f * __logf(opacity / ALPHA_THRESHOLD));
+
+        // SNUGBOX: tight axis-aligned bounding box of the ellipse
+        float neg_t_over_disc = -t / disc;
+        float x_extent = sqrtf(neg_t_over_disc * C);
+        float y_extent = sqrtf(neg_t_over_disc * A);
+
+        float2 bbox_min = {mean2d.x - x_extent, mean2d.y - y_extent};
+        float2 bbox_max = {mean2d.x + x_extent, mean2d.y + y_extent};
+
+        float Bx_over_C    = B * x_extent / C;
+        float By_over_A    = B * y_extent / A;
+        float2 bbox_argmin = {mean2d.y + Bx_over_C, mean2d.x + By_over_A};
+        float2 bbox_argmax = {mean2d.y - Bx_over_C, mean2d.x - By_over_A};
+
+        float tile_size_f = (float)tile_size;
+        int2 rect_min = {max(0, min((int)tile_width,  (int)(bbox_min.x / tile_size_f))),
+                         max(0, min((int)tile_height, (int)(bbox_min.y / tile_size_f)))};
+        int2 rect_max = {max(0, min((int)tile_width,  (int)(bbox_max.x / tile_size_f + 1.f))),
+                         max(0, min((int)tile_height, (int)(bbox_max.y / tile_size_f + 1.f)))};
+
+        int y_span = rect_max.y - rect_min.y;
+        int x_span = rect_max.x - rect_min.x;
+        if (y_span * x_span == 0) {
+            if (first_pass) tiles_per_gauss[idx] = 0;
+            return;
+        }
+
+        bool isY = y_span < x_span;
+        int64_t cur_idx = first_pass ? 0 : ((idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1]);
+
+        uint32_t count = accutile_process_tiles(
+            A, B, C, disc, t, mean2d,
+            bbox_min, bbox_max, bbox_argmin, bbox_argmax,
+            rect_min, rect_max,
+            tile_size, tile_width, isY,
+            iid_enc, tile_n_bits, depth_id_enc, idx,
+            first_pass ? nullptr : isect_ids,
+            first_pass ? nullptr : flatten_ids,
+            &cur_idx
         );
-        return;
-    }
 
-    int64_t iid; // image id
-    if (packed) {
-        // parallelize over nnz
-        iid = image_ids[idx];
+        if (first_pass) {
+            tiles_per_gauss[idx] = static_cast<int32_t>(count);
+        }
     } else {
-        // parallelize over I * N
-        iid = idx / N;
-    }
-    const int64_t iid_enc = iid << (32 + tile_n_bits);
+        // AABB fallback: used when conics/opacities are not available (e.g. 2DGS).
+        float tile_radius_x = radius_x / static_cast<float>(tile_size);
+        float tile_radius_y = radius_y / static_cast<float>(tile_size);
+        float tile_x = mean2d.x / static_cast<float>(tile_size);
+        float tile_y = mean2d.y / static_cast<float>(tile_size);
 
-    // tolerance for negative depth
-    int32_t depth_i32 = *(int32_t *)&(depths[idx]);  // Bit-level reinterpret
-    int64_t depth_id_enc = static_cast<uint32_t>(depth_i32);  // Zero-extend to 64-bit
-    // int64_t depth_id_enc = (int64_t) * (int32_t *)&(depths[idx]);
-    
-    int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
-    for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
-        for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
-            int64_t tile_id = i * tile_width + j;
-            // e.g. tile_n_bits = 22:
-            // image id (10 bits) | tile id (22 bits) | depth (32 bits)
-            isect_ids[cur_idx] = iid_enc | (tile_id << 32) | depth_id_enc;
-            // the flatten index in [I * N] or [nnz]
-            flatten_ids[cur_idx] = static_cast<int32_t>(idx);
-            ++cur_idx;
+        // tile_min is inclusive, tile_max is exclusive
+        int2 tile_min, tile_max;
+        tile_min.x = min(max(0, (int32_t)floor(tile_x - tile_radius_x)), tile_width);
+        tile_min.y = min(max(0, (int32_t)floor(tile_y - tile_radius_y)), tile_height);
+        tile_max.x = min(max(0, (int32_t)ceil(tile_x + tile_radius_x)), tile_width);
+        tile_max.y = min(max(0, (int32_t)ceil(tile_y + tile_radius_y)), tile_height);
+
+        if (first_pass) {
+            tiles_per_gauss[idx] = static_cast<int32_t>(
+                (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
+            );
+            return;
+        }
+
+        int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
+        for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
+            for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
+                int64_t tile_id = i * tile_width + j;
+                // e.g. tile_n_bits = 22:
+                // image id (10 bits) | tile id (22 bits) | depth (32 bits)
+                isect_ids[cur_idx] = iid_enc | (tile_id << 32) | depth_id_enc;
+                // the flatten index in [I * N] or [nnz]
+                flatten_ids[cur_idx] = static_cast<int32_t>(idx);
+                ++cur_idx;
+            }
         }
     }
 }
 
 void launch_intersect_tile_kernel(
     // inputs
-    const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
-    const at::Tensor radii,                      // [..., N, 2] or [nnz, 2]
-    const at::Tensor depths,                     // [..., N] or [nnz]
-    const at::optional<at::Tensor> image_ids,    // [nnz]
-    const at::optional<at::Tensor> gaussian_ids, // [nnz]
+    const at::Tensor means2d,                           // [..., N, 2] or [nnz, 2]
+    const at::Tensor radii,                             // [..., N, 2] or [nnz, 2]
+    const at::Tensor depths,                            // [..., N] or [nnz]
+    const at::optional<at::Tensor> conics,              // [..., N, 3] or [nnz, 3] 
+    const at::optional<at::Tensor> opacities,           // [..., N] or [nnz]
+    const at::optional<at::Tensor> image_ids,           // [nnz]
+    const at::optional<at::Tensor> gaussian_ids,        // [nnz]
     const uint32_t I,
     const uint32_t tile_size,
     const uint32_t tile_width,
@@ -201,6 +360,12 @@ void launch_intersect_tile_kernel(
                     means2d.data_ptr<scalar_t>(),
                     radii.data_ptr<int32_t>(),
                     depths.data_ptr<scalar_t>(),
+                    conics.has_value()
+                        ? conics.value().data_ptr<float>()
+                        : nullptr,
+                    opacities.has_value()
+                        ? opacities.value().data_ptr<float>()
+                        : nullptr,
                     cum_tiles_per_gauss.has_value()
                         ? cum_tiles_per_gauss.value().data_ptr<int64_t>()
                         : nullptr,

--- a/gsplat/cuda/csrc/Projection2DGSFused.cu
+++ b/gsplat/cuda/csrc/Projection2DGSFused.cu
@@ -238,8 +238,8 @@ __global__ void projection_2dgs_fused_fwd_kernel(
     const vec2 half_extend = mean2d * mean2d - temp;
 
     // ==============================================
-    const float radius_x = ceil(3.33f * sqrt(max(1e-4, half_extend.x)));
-    const float radius_y = ceil(3.33f * sqrt(max(1e-4, half_extend.y)));
+    const float radius_x = ceil(GAUSSIAN_EXTEND * sqrt(max(1e-4, half_extend.x)));
+    const float radius_y = ceil(GAUSSIAN_EXTEND * sqrt(max(1e-4, half_extend.y)));
 
     if (radius_x <= radius_clip && radius_y <= radius_clip) {
         radii[idx * 2] = 0;

--- a/gsplat/cuda/csrc/Projection2DGSPacked.cu
+++ b/gsplat/cuda/csrc/Projection2DGSPacked.cu
@@ -142,8 +142,8 @@ __global__ void projection_2dgs_packed_fwd_kernel(
 
         const vec2 temp = {sum(f * M0 * M0), sum(f * M1 * M1)};
         const vec2 half_extend = mean2d * mean2d - temp;
-        radius_x = ceil(3.33f * sqrt(max(1e-4, half_extend.x)));
-        radius_y = ceil(3.33f * sqrt(max(1e-4, half_extend.y)));
+        radius_x = ceil(GAUSSIAN_EXTEND * sqrt(max(1e-4, half_extend.x)));
+        radius_y = ceil(GAUSSIAN_EXTEND * sqrt(max(1e-4, half_extend.y)));
 
         if (radius_x <= radius_clip && radius_y <= radius_clip) {
             valid = false;

--- a/gsplat/cuda/csrc/ProjectionEWA3DGSFused.cu
+++ b/gsplat/cuda/csrc/ProjectionEWA3DGSFused.cu
@@ -183,7 +183,7 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
     // compute the inverse of the 2d covariance
     mat2 covar2d_inv = glm::inverse(covar2d);
 
-    float extend = 3.33f;
+    float extend = GAUSSIAN_EXTEND;
     if (opacities != nullptr) {
         float opacity = opacities[bid * N + gid];
         if (compensations != nullptr) {
@@ -197,7 +197,7 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
         }
         // Compute opacity-aware bounding box.
         // https://arxiv.org/pdf/2402.00525 Section B.2
-        extend = min(extend, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
+        extend = min(GAUSSIAN_EXTEND, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
     }
 
     // compute tight rectangular bounding box (non differentiable)

--- a/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
+++ b/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
@@ -200,19 +200,19 @@ __global__ void projection_ewa_3dgs_packed_fwd_kernel(
     // check if the points are in the image region
     float radius_x, radius_y;
     if (valid) {
-        float extend = 3.33f;
+        float extend = GAUSSIAN_EXTEND;
         if (opacities != nullptr) {
             float opacity = opacities[bid * N + gid];
             if (compensations != nullptr) {
                 // we assume compensation term will be applied later on.
                 opacity *= compensation;
-            }    
+            }
             if (opacity < ALPHA_THRESHOLD) {
                 valid = false;
             }
             // Compute opacity-aware bounding box.
             // https://arxiv.org/pdf/2402.00525 Section B.2
-            extend = min(extend, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
+            extend = min(GAUSSIAN_EXTEND, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
         }
         
         // compute tight rectangular bounding box (non differentiable)

--- a/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
+++ b/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
@@ -245,7 +245,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
     // compute the inverse of the 2d covariance
     mat2 covar2d_inv = glm::inverse(covar2d);
 
-    float extend = 3.33f;
+    float extend = GAUSSIAN_EXTEND;
     // Note: the optimizations from StopThePop (https://arxiv.org/pdf/2402.00525) give identical
     // results when the Gaussian's contribution is evaluated in 2D from the projected 2D Gaussian.
     // However, with UT, the Gaussian's contribution is evaluated in 3D by intersecting the ray
@@ -264,7 +264,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
         }
         // Compute opacity-aware bounding box.
         // https://arxiv.org/pdf/2402.00525 Section B.2
-        extend = min(extend, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
+        extend = min(GAUSSIAN_EXTEND, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
     }
 
     // compute tight rectangular bounding box (non differentiable)

--- a/gsplat/cuda/ext.cpp
+++ b/gsplat/cuda/ext.cpp
@@ -716,7 +716,7 @@ TORCH_LIBRARY(gsplat, m) {
     m.def("spherical_harmonics_fwd(int degrees_to_use, Tensor dirs, Tensor coeffs, Tensor? masks) -> Tensor");
     m.def("spherical_harmonics_bwd(int degrees_to_use, Tensor dirs, Tensor coeffs, Tensor? masks, Tensor v_colors, bool compute_v_dirs) -> (Tensor, Tensor)");
 
-    m.def("intersect_tile(Tensor means2d, Tensor radii, Tensor depths, Tensor? image_ids, Tensor? gaussian_ids, int I, int tile_size, int tile_width, int tile_height, bool sort, bool segmented) -> (Tensor, Tensor, Tensor)");
+    m.def("intersect_tile(Tensor means2d, Tensor radii, Tensor depths, Tensor? conics, Tensor? opacities, Tensor? image_ids, Tensor? gaussian_ids, int I, int tile_size, int tile_width, int tile_height, bool sort, bool segmented) -> (Tensor, Tensor, Tensor)");
     m.def("intersect_offset(Tensor isect_ids, int I, int tile_width, int tile_height) -> Tensor");
 #if GSPLAT_BUILD_3DGUT
     m.def("intersect_tile_lidar(__torch__.torch.classes.gsplat.RowOffsetStructuredSpinningLidarModelParametersExt lidar, Tensor means2d, Tensor radii, Tensor depths, Tensor? image_ids, Tensor? gaussian_ids, int I, bool sort, bool segmented) -> (Tensor, Tensor, Tensor)");

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -72,6 +72,8 @@ enum CameraModelType {
 
 #define N_THREADS_PACKED 256
 #define ALPHA_THRESHOLD (1.f / 255.f)
+// GAUSSIAN_EXTEND determines where the gaussian is truncated in standard deviations."
+#define GAUSSIAN_EXTEND 3.33f
 // MAX_ALPHA and TRANSMITTANCE_THRESHOLD are chosen so that the equivalent of
 // a maximal opacity Gaussian has to be rasterized twice to reach the threshold,
 // without getting the transmittance too small for numerical stability of

--- a/gsplat/cuda/include/Ops.h
+++ b/gsplat/cuda/include/Ops.h
@@ -274,11 +274,13 @@ void adam(
 
 // GS Tile Intersection
 std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
-    const at::Tensor &means2d,                    // [..., C, N, 2] or [nnz, 2]
-    const at::Tensor &radii,                      // [..., C, N, 2] or [nnz, 2]
-    const at::Tensor &depths,                     // [..., C, N] or [nnz]
-    const at::optional<at::Tensor> &image_ids,    // [nnz]
-    const at::optional<at::Tensor> &gaussian_ids, // [nnz]
+    const at::Tensor &means2d,                           // [..., N, 2] or [nnz, 2]
+    const at::Tensor &radii,                             // [..., N, 2] or [nnz, 2]
+    const at::Tensor &depths,                            // [..., N] or [nnz]
+    const at::optional<at::Tensor> &conics,              // [..., N, 3] or [nnz, 3] 
+    const at::optional<at::Tensor> &opacities,           // [..., N] or [nnz]        
+    const at::optional<at::Tensor> &image_ids,           // [nnz]
+    const at::optional<at::Tensor> &gaussian_ids,        // [nnz]
     int64_t I,
     int64_t tile_size,
     int64_t tile_width,

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -1084,6 +1084,8 @@ def rasterization(
             n_images=I,
             image_ids=image_ids,
             gaussian_ids=gaussian_ids,
+            conics=None if with_ut else conics,
+            opacities=None if with_ut else opacities,
         )
 
     # print("rank", world_rank, "Before isect_offset_encode")
@@ -1490,6 +1492,8 @@ def _rasterization(
             n_images=I,
             image_ids=image_ids,
             gaussian_ids=gaussian_ids,
+            conics=None if with_ut else conics,
+            opacities=None if with_ut else opacities,
         )
     isect_offsets = isect_offset_encode(isect_ids, I, tile_width, tile_height)
     isect_offsets = isect_offsets.reshape(batch_dims + (C, tile_height, tile_width))


### PR DESCRIPTION
Introduces the AccuTile optimization for tighter tile-Gaussian intersection testing in the 3DGS rendering path.

**Background**

Standard tile intersection uses axis-aligned bounding boxes (AABB), which can over-count tiles and include Gaussians that don't meaningfully contribute to a tile. AccuTile uses the projected ellipse's conic parameters to perform a tighter conservative intersection test (SNUGBOX), reducing unnecessary rasterization work.

**Changes**
- Added accutile_ellipse_intersection() and accutile_process_tiles() device helpers to IntersectTile.cu
- Updated intersect_tile_kernel() to accept optional conics and opacities parameters. When provided, the AccuTile+SNUGBOX path is used for tighter per-tile intersection tests. When either is nullptr, it falls back to the standard AABB test
- Updated API declarations and pybind bindings in Intersect.cpp, Intersect.h, and _wrapper.py
- Enabled AccuTile for 3DGS rendering paths in rendering.py by passing conics and opacities

**Scope**
This optimization applies only to 3DGS. It is intentionally not applied to:
- 3DGUT: The projected Gaussian is an approximation, so exact ellipse intersection against it increases the risk of incorrectly culling valid Gaussians
- 2DGS: Does not produce conics, so the fallback AABB path is used automatically