### PR TITLE
unpin torch in docs CI to fix empty API pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
-          pip install torch==2.0.0 --index-url https://download.pytorch.org/whl/cpu
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
           BUILD_NO_CUDA=1 pip install .
       
       # Get version (read from source to avoid importing gsplat; BUILD_NO_CUDA=1

--- a/docs/source/tests/eval.rst
+++ b/docs/source/tests/eval.rst
@@ -141,7 +141,7 @@ within the gsplat repo (commit 6acdce4).
 
 The evaluation of `inria-X` can be 
 reproduced with our forked wersion of the official implementation at 
-`here <https://github.com/liruilong940607/gaussian-splatting/tree/benchmark>`_, 
+`here <https://github.com/liruilong940607/gaussian-splatting/tree/benchmark>`__, 
 with the command :code:`python full_eval_m360.py` (commit 36546ce).
 
 2DGS
@@ -152,13 +152,13 @@ No Regularization
 
 .. table:: Performance on `Mip-NeRF 360 Captures <https://jonbarron.info/mipnerf360/>`_ (Averaged Over 7 Scenes)
 
-+---------------------+-------+-------+-------+------------------+------------+
-|                     | PSNR  | SSIM  | LPIPS | Train Mem        | Train Time |
-+=====================+=======+=======+=======+==================+============+
-| inria-30k           | 28.73 | 0.860 | 0.148 | 3.73 GB          | 22m16s     |
-+---------------------+-------+-------+-------+------------------+------------+
-| gsplat-30k          | 28.76 | 0.867 | 0.145 | **3.70 GB**      | **15m44s** |
-+---------------------+-------+-------+-------+------------------+------------+
+    +---------------------+-------+-------+-------+------------------+------------+
+    |                     | PSNR  | SSIM  | LPIPS | Train Mem        | Train Time |
+    +=====================+=======+=======+=======+==================+============+
+    | inria-30k           | 28.73 | 0.860 | 0.148 | 3.73 GB          | 22m16s     |
+    +---------------------+-------+-------+-------+------------------+------------+
+    | gsplat-30k          | 28.76 | 0.867 | 0.145 | **3.70 GB**      | **15m44s** |
+    +---------------------+-------+-------+-------+------------------+------------+
 
 With Normal Consistency and Distortion Regularization
 ------------------------------------------------------
@@ -237,6 +237,6 @@ within the gsplat repo (commit 48abf70).
 
 The evaluation of `inria-X` can be 
 reproduced with our forked wersion of the official implementation at 
-`here <https://github.com/hbb1/diff-surfel-rasterization>`_;
+`here <https://github.com/hbb1/diff-surfel-rasterization>`__;
 you need to change the :code:`--model_type 2dgs` to :code:`--model_type 2dgs-inria` in
 :code:`benchmars/basic_2dgs` and run command :code:`cd examples; bash benchmarks/basic_2dgs.sh` (commit 28c928a).

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -508,7 +508,7 @@ def fully_fused_projection(
         an indicator, in which zero radii means the corresponding elements are invalid in
         the output tensors and will be ignored in the next rasterization process. If `packed=True`,
         the output tensors will be packed into a flattened tensor, in which all elements are valid.
-        In this case, a ``batch_ids` tensor and `camera_ids` tensor will be returned to indicate the
+        In this case, a `batch_ids` tensor and `camera_ids` tensor will be returned to indicate the
         batch, camera and gaussian indices of the packed flattened tensor, which is essentially following the
         COO sparse tensor format.
 


### PR DESCRIPTION
  Fix empty API pages on docs.gsplat.studio/main

  The API documentation pages (utils, rasterization, compression, strategy) have been empty since the LiDAR PR (#890)
  was merged. The pages render with section headers but no function or class documentation.

  Root cause: The docs CI pins torch==2.0.0, which is incompatible with modern setuptools>=82 (removed pkg_resources).
  When Sphinx tries to import gsplat, the import chain reaches _backend.py which does import torch.utils.cpp_extension
  at module level — this fails, and Sphinx silently skips all autofunction/autoclass directives, deploying empty pages.

  Fix: Unpin torch so the CI installs a version compatible with the current setuptools.

  Also fixes three pre-existing Sphinx warnings in the docs:
  - Mismatched backticks in fully_fused_projection docstring
  - Unindented table body under a .. table:: directive in eval.rst
  - Duplicate here link targets in eval.rst (use anonymous refs)

  Tested locally — all API pages now render correctly (utils: 16, rasterization: 2, compression: 3, strategy: 9
  documented symbols).