### PR TITLE
fix(docs): bump Python to 3.10 in docs CI to fix empty API pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,7 +21,7 @@ jobs:
           
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       
       - name: Install dependencies
         run: |


### PR DESCRIPTION
 Root cause: The docs CI uses Python 3.9, which caps torch at ~2.6. These older torch versions are incompatible with modern setuptools>=82 (which removed pkg_resources), causing import torch.utils.cpp_extension to fail. Since   _backend.py is imported at module level via _make_lazy_cuda_cls() in _wrapper.py, this crashes the entire import gsplat chain. Sphinx catches the error silently and deploys empty pages.