### PR TITLE
fix: relax backgrounds shape assertion when packed=True

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -881,7 +881,14 @@ def rasterize_to_pixels(
         assert colors.shape == image_dims + (N, channels), colors.shape
         assert opacities.shape == image_dims + (N,), opacities.shape
     if backgrounds is not None:
-        assert backgrounds.shape == image_dims + (channels,), backgrounds.shape
+        if packed:
+            # When packed, image_dims is empty but backgrounds should still
+            # be (C, channels) where C is the number of cameras.
+            assert backgrounds.shape[-1] == channels, (
+                f"backgrounds last dim {backgrounds.shape[-1]} != channels {channels}"
+            )
+        else:
+            assert backgrounds.shape == image_dims + (channels,), backgrounds.shape
         backgrounds = backgrounds.contiguous()
     if masks is not None:
         assert masks.shape == isect_offsets.shape, masks.shape


### PR DESCRIPTION
## What

When `packed=True`, `means2d.shape` is `(nnz, 2)` so `image_dims = means2d.shape[:-2]` is `()`. The assertion `backgrounds.shape == () + (channels,)` then requires backgrounds to be `(channels,)`, but it should be `(C, channels)` where `C` is the number of cameras (each image can have a different background).

## Fix

When packed, only check that the last dimension of backgrounds matches `channels`. The batch dimensions vary depending on the number of cameras.

Fixes #826.