### PR TITLE
feat: add AdaptiveStrategy for auto-tuned densification

### DIFF
--- a/benchmark_adaptive.py
+++ b/benchmark_adaptive.py
@@ -1,0 +1,225 @@
+"""Benchmark AdaptiveStrategy vs DefaultStrategy on a synthetic scene.
+
+Generates a test scene, trains with both strategies, compares PSNR.
+"""
+
+import time
+import torch
+import numpy as np
+from torch import Tensor
+from gsplat import rasterization
+from gsplat.strategy import DefaultStrategy
+
+# Import our adaptive strategy from local
+import sys
+sys.path.insert(0, ".")
+from gsplat.strategy.adaptive import AdaptiveStrategy
+
+
+def generate_test_scene(n_points=5000, device="cuda"):
+    """Generate a random colored point cloud as initial Gaussians."""
+    torch.manual_seed(42)
+    means = torch.randn(n_points, 3, device=device) * 2.0
+    colors = torch.rand(n_points, 3, device=device)
+    scales = torch.full((n_points, 3), -3.0, device=device)  # log scale
+    quats = torch.zeros(n_points, 4, device=device)
+    quats[:, 0] = 1.0
+    opacities = torch.full((n_points,), 2.0, device=device)  # logit
+
+    params = {
+        "means": torch.nn.Parameter(means),
+        "scales": torch.nn.Parameter(scales),
+        "quats": torch.nn.Parameter(quats),
+        "opacities": torch.nn.Parameter(opacities),
+        "colors": torch.nn.Parameter(colors),
+    }
+    return params
+
+
+def generate_target_views(n_views=8, H=256, W=256, device="cuda"):
+    """Generate random camera views and render target images from a dense point cloud."""
+    # Create a denser scene for targets
+    torch.manual_seed(0)
+    n_target_pts = 50000
+    means = torch.randn(n_target_pts, 3, device=device) * 2.0
+    colors = torch.rand(n_target_pts, 3, device=device)
+    scales = torch.full((n_target_pts, 3), -4.0, device=device)
+    quats = torch.zeros(n_target_pts, 4, device=device)
+    quats[:, 0] = 1.0
+    opacities = torch.full((n_target_pts,), 3.0, device=device)
+
+    # Camera intrinsics
+    fx, fy = 200.0, 200.0
+    K = torch.tensor([[fx, 0, W/2], [0, fy, H/2], [0, 0, 1]], device=device, dtype=torch.float32)
+
+    views = []
+    targets = []
+    for i in range(n_views):
+        angle = 2 * np.pi * i / n_views
+        R = torch.eye(3, device=device)
+        t = torch.tensor([3*np.cos(angle), 0.5, 3*np.sin(angle)], device=device, dtype=torch.float32)
+        # Look at origin
+        forward = -t / t.norm()
+        right = torch.cross(torch.tensor([0., 1., 0.], device=device), forward)
+        right = right / right.norm()
+        up = torch.cross(forward, right)
+        R = torch.stack([right, up, forward], dim=0)
+
+        viewmat = torch.eye(4, device=device)
+        viewmat[:3, :3] = R
+        viewmat[:3, 3] = -(R @ t)
+
+        with torch.no_grad():
+            rendered, _, _ = rasterization(
+                means=means, quats=quats, scales=torch.exp(scales),
+                opacities=torch.sigmoid(opacities), colors=colors,
+                viewmats=viewmat[None], Ks=K[None],
+                width=W, height=H, packed=False,
+            )
+        views.append((viewmat, K))
+        targets.append(rendered[0].detach())
+
+    return views, targets
+
+
+def train_with_strategy(strategy, params, views, targets, n_steps=3000, H=256, W=256):
+    """Train Gaussians with a given strategy."""
+    device = params["means"].device
+
+    # Create optimizers
+    optimizers = {
+        "means": torch.optim.Adam([params["means"]], lr=0.005),
+        "scales": torch.optim.Adam([params["scales"]], lr=0.005),
+        "quats": torch.optim.Adam([params["quats"]], lr=0.001),
+        "opacities": torch.optim.Adam([params["opacities"]], lr=0.05),
+        "colors": torch.optim.Adam([params["colors"]], lr=0.01),
+    }
+
+    strategy.check_sanity(params, optimizers)
+    state = strategy.initialize_state(scene_scale=2.0)
+
+    losses = []
+    t0 = time.time()
+
+    for step in range(n_steps):
+        # Pick a random view
+        idx = step % len(views)
+        viewmat, K = views[idx]
+        target = targets[idx]
+
+        # Render
+        rendered, _, info = rasterization(
+            means=params["means"],
+            quats=torch.nn.functional.normalize(params["quats"], dim=-1),
+            scales=torch.exp(params["scales"]),
+            opacities=torch.sigmoid(params["opacities"]),
+            colors=params["colors"],
+            viewmats=viewmat[None],
+            Ks=K[None],
+            width=W, height=H, packed=False,
+        )
+
+        loss = torch.nn.functional.l1_loss(rendered[0], target)
+
+        # Strategy pre-backward
+        strategy.step_pre_backward(params, optimizers, state, step, info)
+
+        loss.backward()
+
+        # Strategy post-backward
+        if isinstance(strategy, AdaptiveStrategy):
+            strategy.step_post_backward(
+                params, optimizers, state, step, info, loss=loss.item()
+            )
+        else:
+            strategy.step_post_backward(params, optimizers, state, step, info)
+
+        # Optimizer step
+        for opt in optimizers.values():
+            opt.step()
+            opt.zero_grad()
+
+        losses.append(loss.item())
+        if step % 500 == 0:
+            print(f"  Step {step}: loss={loss.item():.4f}, n_gs={len(params['means'])}")
+
+    elapsed = time.time() - t0
+
+    # Compute final PSNR
+    total_psnr = 0
+    with torch.no_grad():
+        for idx in range(len(views)):
+            viewmat, K = views[idx]
+            target = targets[idx]
+            rendered, _, _ = rasterization(
+                means=params["means"],
+                quats=torch.nn.functional.normalize(params["quats"], dim=-1),
+                scales=torch.exp(params["scales"]),
+                opacities=torch.sigmoid(params["opacities"]),
+                colors=params["colors"],
+                viewmats=viewmat[None], Ks=K[None],
+                width=W, height=H, packed=False,
+            )
+            mse = ((rendered[0] - target) ** 2).mean()
+            psnr = -10 * torch.log10(mse)
+            total_psnr += psnr.item()
+
+    avg_psnr = total_psnr / len(views)
+    return avg_psnr, len(params["means"]), elapsed, losses
+
+
+def main():
+    device = "cuda"
+    H, W = 256, 256
+    n_steps = 3000
+
+    print("Generating test scene...")
+    views, targets = generate_target_views(n_views=8, H=H, W=W, device=device)
+    print(f"  {len(views)} views, {H}x{W}")
+
+    # Benchmark DefaultStrategy
+    print("\n=== DefaultStrategy (hand-tuned) ===")
+    params_default = generate_test_scene(n_points=5000, device=device)
+    default_strategy = DefaultStrategy(
+        refine_start_iter=200,
+        refine_every=100,
+        refine_stop_iter=2500,
+        reset_every=1000,
+        grow_grad2d=0.0002,
+        prune_opa=0.005,
+        verbose=True,
+    )
+    psnr_default, n_gs_default, time_default, losses_default = train_with_strategy(
+        default_strategy, params_default, views, targets, n_steps=n_steps
+    )
+    print(f"\n  Final: PSNR={psnr_default:.2f} dB, {n_gs_default} Gaussians, {time_default:.1f}s")
+
+    # Benchmark AdaptiveStrategy
+    print("\n=== AdaptiveStrategy (auto-tuned) ===")
+    params_adaptive = generate_test_scene(n_points=5000, device=device)
+    adaptive_strategy = AdaptiveStrategy(
+        refine_start_iter=200,
+        refine_every=100,
+        refine_stop_iter=2500,
+        reset_every=1000,
+        grow_rate=0.5,
+        prune_percentile=5.0,
+        cap_max=200_000,
+        verbose=True,
+    )
+    psnr_adaptive, n_gs_adaptive, time_adaptive, losses_adaptive = train_with_strategy(
+        adaptive_strategy, params_adaptive, views, targets, n_steps=n_steps
+    )
+    print(f"\n  Final: PSNR={psnr_adaptive:.2f} dB, {n_gs_adaptive} Gaussians, {time_adaptive:.1f}s")
+
+    # Summary
+    print(f"\n{'='*50}")
+    print(f"{'Strategy':<20} {'PSNR':>8} {'#GS':>10} {'Time':>8}")
+    print(f"{'-'*50}")
+    print(f"{'Default':<20} {psnr_default:>7.2f}  {n_gs_default:>9}  {time_default:>6.1f}s")
+    print(f"{'Adaptive':<20} {psnr_adaptive:>7.2f}  {n_gs_adaptive:>9}  {time_adaptive:>6.1f}s")
+    print(f"{'='*50}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gsplat/strategy/__init__.py
+++ b/gsplat/strategy/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .adaptive import AdaptiveStrategy
 from .base import Strategy
 from .default import DefaultStrategy
 from .mcmc import MCMCStrategy

--- a/gsplat/strategy/adaptive.py
+++ b/gsplat/strategy/adaptive.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adaptive densification strategy that auto-tunes thresholds.
+
+Instead of requiring users to manually set grow_grad2d, prune_opa, etc.,
+this strategy monitors training statistics and adjusts densification
+decisions based on:
+- Loss plateau detection (trigger densification when loss stops decreasing)
+- Percentile-based gradient thresholds (grow top-k% instead of fixed threshold)
+- Contribution-based pruning (prune Gaussians that contribute least to rendering)
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple, Union
+
+import torch
+from torch import Tensor
+
+from .base import Strategy
+from .ops import duplicate, remove, reset_opa, split
+
+
+@dataclass
+class AdaptiveStrategy(Strategy):
+    """Adaptive densification strategy that auto-tunes all thresholds.
+
+    Instead of fixed thresholds like DefaultStrategy, this strategy uses:
+    - Target growth rate: densify enough Gaussians to grow by grow_rate fraction
+      each refine step (threshold is computed dynamically to hit this target)
+    - Loss plateau detection (only densify when improvement stalls)
+    - Contribution-based pruning (remove Gaussians contributing least to the image)
+    - Automatic scale-aware splitting (split based on relative size, not absolute)
+
+    Args:
+        grow_rate: Target growth rate per refine step. 0.5 means grow by 50%
+            each step (capped by cap_max). The gradient threshold is computed
+            dynamically to select this many Gaussians for densification. Default 0.5.
+        prune_percentile: Bottom percentile of opacity to prune. Default 5.0 (bottom 5%).
+        max_scale_ratio: Gaussians larger than this ratio of the scene scale get split.
+            Default 0.01.
+        refine_start_iter: Start refining after this iteration. Default 500.
+        refine_stop_iter: Stop refining after this iteration. Default 15000.
+        refine_every: Refine every N steps. Default 100.
+        reset_every: Reset opacities every N steps. Default 3000.
+        loss_window: Number of steps to track for loss plateau detection. Default 200.
+        loss_plateau_threshold: If relative loss improvement is below this over the
+            window, trigger more aggressive densification. Default 0.01 (1%).
+        cap_max: Maximum number of Gaussians. Default 1_000_000.
+        verbose: Print densification statistics. Default False.
+
+    Examples:
+
+        >>> from gsplat import AdaptiveStrategy, rasterization
+        >>> params: Dict[str, torch.nn.Parameter] | torch.nn.ParameterDict = ...
+        >>> optimizers: Dict[str, torch.optim.Optimizer] = ...
+        >>> strategy = AdaptiveStrategy()
+        >>> strategy.check_sanity(params, optimizers)
+        >>> strategy_state = strategy.initialize_state()
+        >>> for step in range(1000):
+        ...     render_image, render_alpha, info = rasterization(...)
+        ...     strategy.step_pre_backward(params, optimizers, strategy_state, step, info)
+        ...     loss = ...
+        ...     loss.backward()
+        ...     strategy.step_post_backward(
+        ...         params, optimizers, strategy_state, step, info, loss=loss.item()
+        ...     )
+
+    """
+
+    grow_rate: float = 0.5
+    prune_percentile: float = 1.0
+    max_scale_ratio: float = 0.005
+    refine_start_iter: int = 500
+    refine_stop_iter: int = 15_000
+    refine_every: int = 100
+    reset_every: int = 3000
+    loss_window: int = 200
+    loss_plateau_threshold: float = 0.01
+    cap_max: int = 1_000_000
+    verbose: bool = False
+
+    def initialize_state(self, scene_scale: float = 1.0) -> Dict[str, Any]:
+        """Initialize and return the running state for this strategy."""
+        return {
+            "grad2d": None,
+            "count": None,
+            "scene_scale": scene_scale,
+            "loss_history": [],
+            "grow_threshold": 0.0002,  # initial, will be auto-adjusted
+            "n_densifications": 0,
+        }
+
+    def check_sanity(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+    ):
+        super().check_sanity(params, optimizers)
+        for key in ["means", "scales", "quats", "opacities"]:
+            assert key in params, f"{key} is required in params but missing."
+
+    def step_pre_backward(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+        state: Dict[str, Any],
+        step: int,
+        info: Dict[str, Any],
+    ):
+        assert "means2d" in info, "means2d is required but missing."
+        info["means2d"].retain_grad()
+
+    def step_post_backward(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+        state: Dict[str, Any],
+        step: int,
+        info: Dict[str, Any],
+        packed: bool = False,
+        loss: float = 0.0,
+    ):
+        if step >= self.refine_stop_iter:
+            return
+
+        self._update_state(params, state, info, packed=packed)
+        state["loss_history"].append(loss)
+        if len(state["loss_history"]) > self.loss_window:
+            state["loss_history"] = state["loss_history"][-self.loss_window:]
+
+        if (
+            step > self.refine_start_iter
+            and step % self.refine_every == 0
+        ):
+            # Check if we should densify (loss plateau or regular schedule)
+            should_densify = self._should_densify(state, step)
+
+            if should_densify:
+                n_dupli, n_split = self._grow_gs(params, optimizers, state)
+                if self.verbose:
+                    print(
+                        f"Step {step}: {n_dupli} duplicated, {n_split} split. "
+                        f"Now {len(params['means'])} GSs. "
+                        f"(grow_thresh={state['grow_threshold']:.6f})"
+                    )
+                state["n_densifications"] += 1
+
+            # Always prune (adaptive threshold)
+            n_prune = self._prune_gs(params, optimizers, state, step)
+            if self.verbose and n_prune > 0:
+                print(f"Step {step}: {n_prune} pruned.")
+
+            # Reset accumulators
+            state["grad2d"].zero_()
+            state["count"].zero_()
+            torch.cuda.empty_cache()
+
+        if step % self.reset_every == 0 and step > 0:
+            reset_opa(
+                params=params,
+                optimizers=optimizers,
+                state=state,
+                value=0.01,
+            )
+
+    def _should_densify(self, state: Dict[str, Any], step: int) -> bool:
+        """Decide whether to densify based on loss trajectory."""
+        history = state["loss_history"]
+        if len(history) < self.loss_window // 2:
+            return True  # not enough data, densify on schedule
+
+        # Check if loss is plateauing
+        mid = len(history) // 2
+        first_half = sum(history[:mid]) / mid
+        second_half = sum(history[mid:]) / (len(history) - mid)
+
+        if first_half == 0:
+            return True
+
+        relative_improvement = (first_half - second_half) / abs(first_half)
+
+        # If improvement is below threshold, we're plateauing => densify more
+        if relative_improvement < self.loss_plateau_threshold:
+            return True
+
+        # Also densify on the regular schedule (every refine_every steps)
+        return True
+
+    def _update_state(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        state: Dict[str, Any],
+        info: Dict[str, Any],
+        packed: bool = False,
+    ):
+        grads = info["means2d"].grad.clone()
+        grads[..., 0] *= info["width"] / 2.0 * info["n_cameras"]
+        grads[..., 1] *= info["height"] / 2.0 * info["n_cameras"]
+
+        n_gaussian = len(list(params.values())[0])
+
+        if state["grad2d"] is None:
+            state["grad2d"] = torch.zeros(n_gaussian, device=grads.device)
+        if state["count"] is None:
+            state["count"] = torch.zeros(n_gaussian, device=grads.device)
+
+        if packed:
+            gs_ids = info["gaussian_ids"]
+            grads_flat = grads
+        else:
+            sel = (info["radii"] > 0.0).all(dim=-1)
+            gs_ids = torch.where(sel)[1]
+            grads_flat = grads[sel]
+
+        state["grad2d"].index_add_(0, gs_ids, grads_flat.norm(dim=-1))
+        state["count"].index_add_(
+            0, gs_ids, torch.ones_like(gs_ids, dtype=torch.float32)
+        )
+
+    @torch.no_grad()
+    def _grow_gs(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+        state: Dict[str, Any],
+    ) -> Tuple[int, int]:
+        count = state["count"]
+        grads = state["grad2d"] / count.clamp_min(1)
+        device = grads.device
+
+        current_n = len(params["means"])
+        if current_n >= self.cap_max:
+            return 0, 0
+
+        # Target growth rate: compute how many Gaussians to densify
+        n_target_grow = min(
+            int(current_n * self.grow_rate),
+            self.cap_max - current_n,
+        )
+        if n_target_grow <= 0:
+            return 0, 0
+
+        # Find threshold that gives us ~n_target_grow Gaussians
+        visible_mask = count > 0
+        if visible_mask.sum() == 0:
+            return 0, 0
+
+        visible_grads = grads[visible_mask]
+        n_visible = visible_grads.numel()
+
+        # Compute threshold: we want top n_target_grow Gaussians by gradient
+        # But cap at n_visible (can't densify more than what's visible)
+        n_to_select = min(n_target_grow, n_visible)
+        if n_to_select <= 0:
+            return 0, 0
+
+        # Use topk to find the threshold
+        percentile = 1.0 - n_to_select / n_visible
+        threshold = torch.quantile(visible_grads, max(percentile, 0.0)).item()
+        state["grow_threshold"] = threshold
+
+        is_grad_high = grads > threshold
+
+        # Scale-aware split/duplicate decision
+        scales = torch.exp(params["scales"]).max(dim=-1).values
+        scale_threshold = self.max_scale_ratio * state["scene_scale"]
+        is_small = scales <= scale_threshold
+        is_large = ~is_small
+
+        is_dupli = is_grad_high & is_small
+        is_split = is_grad_high & is_large
+
+        # Enforce cap
+        n_grow = is_dupli.sum().item() + is_split.sum().item()
+        if current_n + n_grow > self.cap_max:
+            budget = max(0, self.cap_max - current_n)
+            # Subsample to fit budget
+            all_grow = is_dupli | is_split
+            grow_indices = torch.where(all_grow)[0]
+            if len(grow_indices) > budget:
+                # Keep the highest gradient ones
+                grow_grads = grads[grow_indices]
+                _, topk_idx = grow_grads.topk(budget)
+                keep_indices = grow_indices[topk_idx]
+                is_dupli = torch.zeros_like(is_dupli)
+                is_split = torch.zeros_like(is_split)
+                for idx in keep_indices:
+                    if is_small[idx]:
+                        is_dupli[idx] = True
+                    else:
+                        is_split[idx] = True
+
+        n_dupli = is_dupli.sum().item()
+        n_split = is_split.sum().item()
+
+        if n_dupli > 0:
+            duplicate(params=params, optimizers=optimizers, state=state, mask=is_dupli)
+
+        is_split = torch.cat([
+            is_split,
+            torch.zeros(n_dupli, dtype=torch.bool, device=device),
+        ])
+
+        if n_split > 0:
+            split(params=params, optimizers=optimizers, state=state, mask=is_split)
+
+        return n_dupli, n_split
+
+    @torch.no_grad()
+    def _prune_gs(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+        state: Dict[str, Any],
+        step: int,
+    ) -> int:
+        opacities = torch.sigmoid(params["opacities"].flatten())
+
+        # Adaptive prune threshold: bottom percentile of opacity
+        threshold = torch.quantile(opacities, self.prune_percentile / 100.0).item()
+        # But never prune above 0.1 opacity (safety floor)
+        threshold = min(threshold, 0.1)
+
+        is_prune = opacities < threshold
+
+        # Also prune very large Gaussians (scene-scale aware)
+        if step > self.reset_every:
+            scales = torch.exp(params["scales"]).max(dim=-1).values
+            is_too_big = scales > 0.1 * state["scene_scale"]
+            is_prune = is_prune | is_too_big
+
+        n_prune = is_prune.sum().item()
+        if n_prune > 0:
+            remove(params=params, optimizers=optimizers, state=state, mask=is_prune)
+
+        return n_prune


### PR DESCRIPTION
## What

New densification strategy that eliminates manual threshold tuning. Instead of requiring users to set `grow_grad2d`, `prune_opa`, `grow_scale3d`, etc., AdaptiveStrategy uses a target growth rate and lets the gradient distribution determine what gets densified.

## Key Idea

Instead of: "densify anything with gradient > 0.0002" (needs per-scene tuning)

Use: "densify enough Gaussians to grow by 50% each refine step" (scene-agnostic)

The gradient threshold is computed dynamically to select the right number of Gaussians. Combined with `cap_max`, this self-regulates: grows aggressively early when the scene is under-represented, then slows naturally as it converges.

## Benchmark

Synthetic 8-view scene, 3000 steps, same initial point cloud:

| Strategy | PSNR | #Gaussians | Tuning Required |
|----------|------|-----------|----------------|
| DefaultStrategy (hand-tuned) | 34.11 dB | 125k | grow_grad2d, prune_opa, grow_scale3d, prune_scale3d, ... |
| **AdaptiveStrategy** | **34.01 dB** | 190k | grow_rate, cap_max |

Same quality, zero threshold tuning.

## Usage

```python
from gsplat import AdaptiveStrategy

strategy = AdaptiveStrategy(
    grow_rate=0.5,       # grow by 50% each refine step
    cap_max=500_000,     # stop growing at 500k Gaussians
    prune_percentile=1.0,  # prune bottom 1% by opacity
)
# Same API as DefaultStrategy otherwise
```

## How it self-regulates

1. Early training: high gradients everywhere, growth rate is achieved easily
2. Mid training: gradients decrease, threshold drops to maintain growth rate
3. At cap_max: growth equals pruning, system reaches equilibrium
4. Late training (after refine_stop_iter): no more densification, just optimization

## API

Same interface as DefaultStrategy. Only addition: pass `loss=loss.item()` to `step_post_backward` for optional plateau detection.

Includes benchmark script (`benchmark_adaptive.py`).