### PR TITLE
[NV] Compute max external dist coeffs from constant cache

### DIFF
--- a/gsplat/cuda/_torch_external_distortion.py
+++ b/gsplat/cuda/_torch_external_distortion.py
@@ -83,21 +83,36 @@ def num_coeffs_for_order(order: int) -> int:
 
 
 def make_identity_horizontal_poly(order: int = 1) -> list:
-    """Order-1 identity polynomial that maps (phi, theta) -> phi.
+    """Identity polynomial that maps (phi, theta) -> phi for any order 0-5.
 
-    For order 1: f(phi, theta) = c0 + c1*phi + c2*theta = phi  =>  [0, 1, 0]
+    The bivariate polynomial coefficient layout groups by descending inner order:
+      block 0: inner_order=N  (N+1 coeffs, polynomial in x) → outer_coeffs[0]
+      block 1: inner_order=N-1 (N coeffs) → outer_coeffs[1]
+      ...
+    Result = outer_coeffs[0] + outer_coeffs[1]*y + ...
+
+    For f(x,y) = x: we need outer_coeffs[0] = x, so coeffs[1] = 1.0 (x^1 term
+    in the first block), everything else zero.
     """
-    assert order == 1, "Only order-1 identity is implemented"
-    return [0.0, 1.0, 0.0]
+    n = num_coeffs_for_order(order)
+    coeffs = [0.0] * n
+    if order >= 1:
+        coeffs[1] = 1.0
+    return coeffs
 
 
 def make_identity_vertical_poly(order: int = 1) -> list:
-    """Order-1 identity polynomial that maps (phi, theta) -> theta.
+    """Identity polynomial that maps (phi, theta) -> theta for any order 0-5.
 
-    For order 1: f(phi, theta) = c0 + c1*phi + c2*theta = theta  =>  [0, 0, 1]
+    For f(x,y) = y: we need outer_coeffs[1] = 1 (constant in x), so the first
+    coefficient of the second block must be 1.0. The second block starts at
+    index (order + 1).
     """
-    assert order == 1, "Only order-1 identity is implemented"
-    return [0.0, 0.0, 1.0]
+    n = num_coeffs_for_order(order)
+    coeffs = [0.0] * n
+    if order >= 1:
+        coeffs[order + 1] = 1.0
+    return coeffs
 
 
 def make_zero_poly(order: int = 1) -> list:

--- a/gsplat/cuda/csrc/CameraWrappers.cu
+++ b/gsplat/cuda/csrc/CameraWrappers.cu
@@ -268,26 +268,17 @@ template <typename CameraModel>
 void PyBaseCameraModel<CameraModel>::init_external_distortion(
     const gsplat::extdist::BivariateWindshieldModelParameters& params)
 {
-    // Store the params to keep tensors alive (they own the GPU data)
-    m_ext_dist_params_storage = params;
-    auto& stored = *m_ext_dist_params_storage;
-
-    // Ensure tensors are contiguous and on CUDA
-    stored.horizontal_poly = stored.horizontal_poly.contiguous().cuda();
-    stored.vertical_poly = stored.vertical_poly.contiguous().cuda();
-    stored.horizontal_poly_inverse = stored.horizontal_poly_inverse.contiguous().cuda();
-    stored.vertical_poly_inverse = stored.vertical_poly_inverse.contiguous().cuda();
-
-    // Build the host-side device params (contains raw pointers into the tensor data)
-    gsplat::extdist::BivariateWindshieldModelDeviceParams host_params(stored);
-
-    // Allocate device memory and copy
-    gsplat::extdist::BivariateWindshieldModelDeviceParams* d_params;
-    CUDA_CHECK(cudaMalloc(&d_params, sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams)));
-    CUDA_CHECK(cudaMemcpy(d_params, &host_params,
-                          sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams),
+    // Construct host-side device params — copies tensor data into std::array members
+    // via pad_tensor_coefficients later.
+    m_ext_dist_device_params = gsplat::extdist::BivariateWindshieldModelDeviceParams(params);
+    // Allocate persistent device copy for CameraWrapper camera objects that outlive kernel execution.
+    gsplat::extdist::BivariateWindshieldModelDeviceParams* d_params = nullptr;
+    C10_CUDA_CHECK(cudaMalloc(&d_params, sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams)));
+    C10_CUDA_CHECK(cudaMemcpy(d_params, &m_ext_dist_device_params,
+                          sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams), 
                           cudaMemcpyHostToDevice));
-    m_dev_ext_dist_params.reset(d_params);
+    m_dev_ext_dist.reset(d_params);
+    m_has_ext_dist = true;
 }
 
 /**

--- a/gsplat/cuda/csrc/ExternalDistortionWrappers.cu
+++ b/gsplat/cuda/csrc/ExternalDistortionWrappers.cu
@@ -39,15 +39,14 @@ namespace gsplat::extdist {
 __global__ void eval_bivariate_poly_kernel(
     const float* __restrict__ x,
     const float* __restrict__ y,
-    const float* __restrict__ poly_coeffs,
-    int32_t order,
+    std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> poly_coeffs,
     float* __restrict__ result,
     int64_t N)
 {
     int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= N) return;
 
-    result[idx] = gsplat::extdist::eval_bivariate_poly(poly_coeffs, order, x[idx], y[idx]);
+    result[idx] = gsplat::extdist::eval_bivariate_poly(poly_coeffs.data(), x[idx], y[idx]);
 }
 
 torch::Tensor eval_bivariate_poly_wrapper(
@@ -58,19 +57,20 @@ torch::Tensor eval_bivariate_poly_wrapper(
 {
     TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
     TORCH_CHECK(y.is_cuda(), "y must be a CUDA tensor");
-    TORCH_CHECK(poly_coeffs.is_cuda(), "poly_coeffs must be a CUDA tensor");
     TORCH_CHECK(x.dtype() == torch::kFloat32, "x must be float32");
     TORCH_CHECK(y.dtype() == torch::kFloat32, "y must be float32");
     TORCH_CHECK(poly_coeffs.dtype() == torch::kFloat32, "poly_coeffs must be float32");
     TORCH_CHECK(x.numel() == y.numel(), "x and y must have same number of elements");
     TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
     TORCH_CHECK(y.is_contiguous(), "y must be contiguous");
-    TORCH_CHECK(poly_coeffs.is_contiguous(), "poly_coeffs must be contiguous");
 
     int64_t N = x.numel();
     auto result = torch::empty_like(x);
 
     if (N == 0) return result;
+
+    // Pad coefficients to MAX_ORDER layout and pass by value as kernel arg (constant memory)
+    auto padded = pad_tensor_coefficients(poly_coeffs);
 
     cudaStream_t stream = at::cuda::getCurrentCUDAStream(x.device().index());
 
@@ -80,8 +80,7 @@ torch::Tensor eval_bivariate_poly_wrapper(
     eval_bivariate_poly_kernel<<<blocks, threads, 0, stream>>>(
         x.data_ptr<float>(),
         y.data_ptr<float>(),
-        poly_coeffs.data_ptr<float>(),
-        order,
+        padded,
         result.data_ptr<float>(),
         N);
 
@@ -98,11 +97,9 @@ torch::Tensor eval_bivariate_poly_wrapper(
 
 __global__ void distort_camera_rays_kernel(
     const float* __restrict__ rays,        // [N, 3]
-    const float* __restrict__ h_poly,
-    const float* __restrict__ v_poly,
-    int32_t h_order,
-    int32_t v_order,
+    BivariateWindshieldModelDeviceParams params,
     float* __restrict__ result,            // [N, 3]
+    bool inverse,
     int64_t N)
 {
     int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -110,8 +107,11 @@ __global__ void distort_camera_rays_kernel(
 
     glm::fvec3 ray(rays[idx * 3 + 0], rays[idx * 3 + 1], rays[idx * 3 + 2]);
 
-    glm::fvec3 distorted = BivariateWindshieldModel::distort_camera_ray(
-        ray, h_poly, v_poly, h_order, v_order);
+    glm::fvec3 distorted = inverse
+        ? BivariateWindshieldModel::undistort_camera_ray(
+            ray, params.horizontal_poly_inverse.data(), params.vertical_poly_inverse.data())
+        : BivariateWindshieldModel::distort_camera_ray(
+            ray, params.horizontal_poly.data(), params.vertical_poly.data());
 
     result[idx * 3 + 0] = distorted.x;
     result[idx * 3 + 1] = distorted.y;
@@ -134,18 +134,8 @@ torch::Tensor distort_camera_rays(
 
     if (N == 0) return result;
 
-    // Select forward or inverse polynomials
-    const torch::Tensor& h_poly = inverse ? params.horizontal_poly_inverse : params.horizontal_poly;
-    const torch::Tensor& v_poly = inverse ? params.vertical_poly_inverse : params.vertical_poly;
-
-    TORCH_CHECK(h_poly.is_cuda(), "horizontal polynomial must be a CUDA tensor");
-    TORCH_CHECK(v_poly.is_cuda(), "vertical polynomial must be a CUDA tensor");
-
-    auto h_poly_contig = h_poly.contiguous();
-    auto v_poly_contig = v_poly.contiguous();
-
-    int32_t h_order = compute_order(h_poly_contig.size(-1));
-    int32_t v_order = compute_order(v_poly_contig.size(-1));
+    // Construct device params — pads and copies tensor data into std::array members
+    BivariateWindshieldModelDeviceParams device_params(params);
 
     cudaStream_t stream = at::cuda::getCurrentCUDAStream(rays.device().index());
 
@@ -154,11 +144,9 @@ torch::Tensor distort_camera_rays(
 
     distort_camera_rays_kernel<<<blocks, threads, 0, stream>>>(
         rays_contig.data_ptr<float>(),
-        h_poly_contig.data_ptr<float>(),
-        v_poly_contig.data_ptr<float>(),
-        h_order,
-        v_order,
+        device_params,
         result.data_ptr<float>(),
+        inverse,
         N);
 
     cudaError_t err = cudaGetLastError();

--- a/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
+++ b/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
@@ -67,7 +67,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
     const scalar_t *__restrict__ thin_prism_coeffs, // [B, C, 4] optional
     const FThetaCameraDistortionDeviceParams ftheta_device_coeffs, // shared parameters for all cameras
     const cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_coeffs,
-    const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params, // external distortion parameters
+    __grid_constant__ const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
     // outputs
     int32_t *__restrict__ radii,         // [B, C, N, 2]
     scalar_t *__restrict__ means2d,      // [B, C, N, 2]
@@ -147,7 +147,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
             cm_params.shutter_type = rs_type;
             cm_params.principal_point = { principal_point.x, principal_point.y };
             cm_params.focal_length = { focal_length.x, focal_length.y };
-            cm_params.external_distortion_params = external_distortion_device_params.has_value() ? 
+            cm_params.external_distortion_params = external_distortion_device_params.has_value() ?
                 &external_distortion_device_params.value() : nullptr;
             PerfectPinholeCameraModel camera_model(cm_params);
             image_gaussian_return =
@@ -168,7 +168,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
             if (thin_prism_coeffs != nullptr) {
                 cm_params.thin_prism_coeffs = make_array<float, 4>(thin_prism_coeffs + bid * C * 4 + cid * 4);
             }
-            cm_params.external_distortion_params = external_distortion_device_params.has_value() ? 
+            cm_params.external_distortion_params = external_distortion_device_params.has_value() ?
                 &external_distortion_device_params.value() : nullptr;
             OpenCVPinholeCameraModel camera_model(cm_params);
             image_gaussian_return =
@@ -184,7 +184,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
         if (radial_coeffs != nullptr) {
             cm_params.radial_coeffs = make_array<float, 4>(radial_coeffs + bid * C * 4 + cid * 4);
         }
-        cm_params.external_distortion_params = external_distortion_device_params.has_value() ? 
+        cm_params.external_distortion_params = external_distortion_device_params.has_value() ?
             &external_distortion_device_params.value() : nullptr;
         OpenCVFisheyeCameraModel camera_model(cm_params);
         image_gaussian_return =

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
@@ -73,7 +73,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
     const scalar_t *__restrict__ thin_prism_coeffs, // [B, C, 4] optional
     const FThetaCameraDistortionDeviceParams ftheta_device_coeffs, // shared parameters for all cameras
     const cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_device_coeffs,
-    const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
+    __grid_constant__ const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
     // intersections
     const int32_t *__restrict__ tile_offsets, // [B, C, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
@@ -75,7 +75,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_fwd_kernel(
     const scalar_t *__restrict__ thin_prism_coeffs, // [B, C, 4] optional
     const FThetaCameraDistortionDeviceParams ftheta_device_coeffs, // shared parameters for all cameras
     const cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_device_coeffs,
-    const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
+    __grid_constant__ const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
     // intersections
     const int32_t *__restrict__ tile_offsets, // [B, C, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]

--- a/gsplat/cuda/include/CameraWrappers.h
+++ b/gsplat/cuda/include/CameraWrappers.h
@@ -212,20 +212,33 @@ protected:
     void init_external_distortion(const extdist::BivariateWindshieldModelParameters& params);
 
     /**
-     * @brief Get pointer to device-side external distortion params (or nullptr).
+     * @brief Whether external distortion is enabled.
+     */
+    bool has_ext_dist() const { return m_has_ext_dist; }
+
+    /**
+     * @brief Get host-side external distortion device params (by-value, for kernel arg passing).
+     */
+    const extdist::BivariateWindshieldModelDeviceParams& ext_dist_device_params() const {
+        return m_ext_dist_device_params;
+    }
+
+    /**
+     * @brief Get persistent device pointer to external distortion params (for camera construction kernels).
      */
     const extdist::BivariateWindshieldModelDeviceParams* dev_ext_dist_params() const {
-        return m_dev_ext_dist_params.get();
+        return m_dev_ext_dist.get();
     }
 
 private:
     std::unique_ptr<CameraModel, CudaDeleter> m_dev_cameras;
-    std::unique_ptr<extdist::BivariateWindshieldModelDeviceParams, CudaDeleter> m_dev_ext_dist_params;
 
     torch::Tensor m_focal_lengths;
     torch::Tensor m_principal_points;
-    // Keep external distortion tensors alive (they own the data pointed to by device params)
-    std::optional<extdist::BivariateWindshieldModelParameters> m_ext_dist_params_storage;
+
+    extdist::BivariateWindshieldModelDeviceParams m_ext_dist_device_params;
+    std::unique_ptr<extdist::BivariateWindshieldModelDeviceParams, CudaDeleter> m_dev_ext_dist;
+    bool m_has_ext_dist = false;
 };
 
 /**

--- a/gsplat/cuda/include/Cameras.cuh
+++ b/gsplat/cuda/include/Cameras.cuh
@@ -354,12 +354,7 @@ template <class DerivedCameraModel> struct BaseCameraModel {
 
         if (external_distortion_params != nullptr) {
             distorted_ray = gsplat::extdist::BivariateWindshieldModel::distort_camera_ray(
-                cam_ray,
-                external_distortion_params->horizontal_poly_ptr,
-                external_distortion_params->vertical_poly_ptr,
-                external_distortion_params->horizontal_poly_order,
-                external_distortion_params->vertical_poly_order
-            );
+                cam_ray, external_distortion_params->horizontal_poly.data(), external_distortion_params->vertical_poly.data());
         }
         
         return derived->camera_ray_to_image_point_impl(distorted_ray, margin_factor);
@@ -371,13 +366,8 @@ template <class DerivedCameraModel> struct BaseCameraModel {
         auto cam_ray = derived->image_point_to_camera_ray_impl(image_point);
         
         if (cam_ray.valid_flag && external_distortion_params != nullptr) {
-            cam_ray.ray_dir = gsplat::extdist::BivariateWindshieldModel::distort_camera_ray(
-                cam_ray.ray_dir,
-                external_distortion_params->horizontal_poly_inverse_ptr,
-                external_distortion_params->vertical_poly_inverse_ptr,
-                external_distortion_params->horizontal_poly_inverse_order,
-                external_distortion_params->vertical_poly_inverse_order
-            );
+            cam_ray.ray_dir = gsplat::extdist::BivariateWindshieldModel::undistort_camera_ray(
+                cam_ray.ray_dir, external_distortion_params->horizontal_poly_inverse.data(), external_distortion_params->vertical_poly_inverse.data());
         }
         
         return cam_ray;
@@ -546,6 +536,7 @@ struct PerfectPinholeCameraModel : BaseCameraModel<PerfectPinholeCameraModel> {
 
     __device__ PerfectPinholeCameraModel(Parameters const &parameters)
         : Base(parameters.external_distortion_params),
+
           parameters(parameters) {}
 
     Parameters parameters;
@@ -619,6 +610,7 @@ struct OpenCVPinholeCameraModel
         float stop_undistortion_square_error_px2 = 1e-12
     )
         : Base(parameters.external_distortion_params),
+
           parameters(parameters),
           undistortion_stop_square_error_px2(stop_undistortion_square_error_px2
           ) {}
@@ -977,7 +969,8 @@ struct OpenCVFisheyeCameraModel
     __host__ __device__ OpenCVFisheyeCameraModel(
         Parameters const &parameters, float min_2d_norm = 1e-6f
     )
-        : Base(parameters.external_distortion_params), parameters(parameters), min_2d_norm(min_2d_norm) {
+        : Base(parameters.external_distortion_params),
+ parameters(parameters), min_2d_norm(min_2d_norm) {
         // initialize ninth-degree odd-only forward polynomial (mapping angles
         // to normalized distances) theta + k1*theta^3 + k2*theta^5 + k3*theta^7
         // + k4*theta^9
@@ -1193,7 +1186,8 @@ public:
     __host__ __device__ FThetaCameraModel(
         Parameters const& parameters, float min_2d_norm = 1e-6f
     )
-        : Base(parameters.external_distortion_params), parameters(parameters), min_2d_norm(min_2d_norm), dreference_poly{} {
+        : Base(parameters.external_distortion_params),
+ parameters(parameters), min_2d_norm(min_2d_norm), dreference_poly{} {
 
         auto const dist = parameters.dist;
 

--- a/gsplat/cuda/include/ExternalDistortion.cuh
+++ b/gsplat/cuda/include/ExternalDistortion.cuh
@@ -18,82 +18,125 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 
 #include "ExternalDistortion.h"
 #include "Common.h"
 
 // ---------------------------------------------------------------------------------------------
 
-namespace gsplat::extdist
-{
-
-struct BivariateWindshieldModelDeviceParams;
-
 // NOTE: Some of the device functions herein are marked GSPLAT_NOINLINE to prevent compilation
 // combinatorial explosion. e.g. eval_bivariate_poly and distort_camera_ray in ProjectionUT3DGSFused.cu:
 // - 7 sigma points (unrolled loop - inside world_gaussian_to_image_gaussian_unscented_transform_shutter_pose)
 // - 5 camera models
 // - N CUDA architectures/compute capability targets (e.g. 80, 86, 89, 90, 100, 120)
-// - Inlining into all contexts creates O(n³) register allocation complexity
+// - Inlining into every context creates O(n³) register allocation complexity
 
-inline __host__ __device__ int32_t compute_order(int32_t num_coeffs) {
-    // For bivariate polynomial: num_coeffs = (order + 1) * (order + 2) / 2
-    // Solve: order^2 + 3*order + 2 - 2*num_coeffs = 0
-    // Using quadratic formula: order = (-3 + sqrt(1 + 8*num_coeffs)) / 2
-    int32_t sqrt_discriminant = static_cast<int32_t>(std::sqrt(1 + 8 * num_coeffs));
-    return (-3 + sqrt_discriminant) / 2;
+namespace gsplat::extdist
+{
+
+constexpr int32_t compute_order(int32_t num_coeffs) {
+    // MAX_ORDER is so small we can just avoid math and use
+    // (order+1)*(order+2)/2 = num_coeffs to inverse check equivalence.
+    if (num_coeffs == 1) return 0;
+    if (num_coeffs == 3) return 1;
+    if (num_coeffs == 6) return 2;
+    if (num_coeffs == 10) return 3;
+    if (num_coeffs == 15) return 4;
+    if (num_coeffs == 21) return BivariateWindshieldModelParameters::MAX_ORDER;
+    return -1;
 }
 
-// Evaluate 2D bivariate polynomial at (x, y)
+// Device-side polynomial evaluation — always iterates over MAX_ORDER.
+// Coefficients are expected in MAX_ORDER triangular layout (21 elements, zero-padded).
 inline __device__ GSPLAT_NOINLINE float eval_bivariate_poly(
     const float* poly_coeffs,
-    int32_t order,
     float x,
     float y
 ) {
-    auto const horner_range = [](const float* poly, float x, int32_t idx_start, int32_t idx_end) {
-        float result = 0.f;
-        for (int32_t idx = idx_end - 1; idx >= idx_start; idx--) {
-            result = result * x + poly[idx];
-        }
-        return result;
-    };
+    constexpr int32_t MAX_ORDER = BivariateWindshieldModelParameters::MAX_ORDER;
 
-    float outer_coeffs[BivariateWindshieldModelParameters::MAX_ORDER + 1]; // 6 outter coeffs with MAX_ORDER=5
-    int start_idx = 0;
-    for (int32_t inner_order = order; inner_order >= 0; inner_order--) {
-        outer_coeffs[order - inner_order] = horner_range(poly_coeffs, x, start_idx, start_idx + inner_order + 1);
+    float outer_coeffs[MAX_ORDER + 1];
+    int32_t start_idx = 0;
+
+    #pragma unroll
+    for (int32_t inner_order = MAX_ORDER; inner_order >= 0; inner_order--) {
+        float result = 0.f;
+        #pragma unroll
+        for (int32_t idx = start_idx + inner_order; idx >= start_idx; idx--) {
+            result = result * x + poly_coeffs[idx];
+        }
+        outer_coeffs[MAX_ORDER - inner_order] = result;
         start_idx += inner_order + 1;
     }
-    return horner_range(outer_coeffs, y, 0, order + 1);
+
+    float result = 0.f;
+    #pragma unroll
+    for (int32_t idx = MAX_ORDER; idx >= 0; idx--) {
+        result = result * y + outer_coeffs[idx];
+    }
+    return result;
 }
 
+// Host-side coefficient padding matching the layout for Horner bivariate polynomial evaluation.
+//   Group 0 (y^0 term): (order+1) x-coefficients
+//   Group 1 (y^1 term): (order)   x-coefficients
+//   ...
+//   Group k (y^k term): (order-k+1) x-coefficients
+//
+// For MAX_ORDER layout, each group k has (MAX_ORDER-k+1) elements.
+// Original coefficients are placed at the start of each group, zero-padded.
+// Groups beyond the original order are all zeros.
+inline std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> pad_coefficients_to_max_order(
+    const float* src,
+    int32_t src_order
+) {
+    constexpr int32_t MAX_ORDER = BivariateWindshieldModelParameters::MAX_ORDER;
+    constexpr int32_t MAX_COEFFS = BivariateWindshieldModelParameters::MAX_COEFFS;
+
+    std::array<float, MAX_COEFFS> dst{};
+
+    int32_t src_offset = 0;
+    int32_t dst_offset = 0;
+    for (int32_t k = 0; k <= MAX_ORDER; k++) {
+        int32_t dst_group_size = MAX_ORDER - k + 1;
+        int32_t src_group_size = (k <= src_order) ? (src_order - k + 1) : 0;
+        std::copy_n(src + src_offset, src_group_size, dst.data() + dst_offset);
+        src_offset += src_group_size;
+        dst_offset += dst_group_size;
+    }
+    return dst;
+}
+
+// Get a padded MAX_COEFFS coefficient array from a tensor.
+inline std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> pad_tensor_coefficients(
+    const at::Tensor& tensor
+) {
+    auto tensor_contig = tensor.contiguous().cpu();
+    const float* src = tensor_contig.data_ptr<float>();
+    int32_t src_order = compute_order(static_cast<int32_t>(tensor_contig.numel()));
+    TORCH_CHECK(src_order >= 0,
+        "Invalid number of bivariate polynomial coefficients: ", tensor_contig.numel(),
+        ". Expected triangular number: 1, 3, 6, 10, 15, or 21.");
+    return pad_coefficients_to_max_order(src, src_order);
+}
+
+// Device-side parameters for the bivariate windshield distortion model.
+// Stores polynomial coefficients as fixed-size arrays (zero-padded to MAX_ORDER layout).
 struct BivariateWindshieldModelDeviceParams {
+    inline __host__ __device__ BivariateWindshieldModelDeviceParams() {}
 
     inline __host__ BivariateWindshieldModelDeviceParams(const BivariateWindshieldModelParameters& params)
-    : reference_poly(params.reference_poly)
-    , horizontal_poly_order(extdist::compute_order(params.horizontal_poly.size(-1)))
-    , vertical_poly_order(extdist::compute_order(params.vertical_poly.size(-1)))
-    , horizontal_poly_inverse_order(extdist::compute_order(params.horizontal_poly_inverse.size(-1)))
-    , vertical_poly_inverse_order(extdist::compute_order(params.vertical_poly_inverse.size(-1)))
-    {
-        horizontal_poly_ptr = static_cast<const float*>(params.horizontal_poly.data_ptr());
-        vertical_poly_ptr = static_cast<const float*>(params.vertical_poly.data_ptr());
-        horizontal_poly_inverse_ptr = static_cast<const float*>(params.horizontal_poly_inverse.data_ptr());
-        vertical_poly_inverse_ptr = static_cast<const float*>(params.vertical_poly_inverse.data_ptr());
-    }
+    : horizontal_poly(pad_tensor_coefficients(params.horizontal_poly))
+    , vertical_poly(pad_tensor_coefficients(params.vertical_poly))
+    , horizontal_poly_inverse(pad_tensor_coefficients(params.horizontal_poly_inverse))
+    , vertical_poly_inverse(pad_tensor_coefficients(params.vertical_poly_inverse))
+    {}
 
-    ReferencePolynomialType reference_poly = ReferencePolynomialType::FORWARD;
-
-    const float *horizontal_poly_ptr = nullptr;
-    const float *vertical_poly_ptr = nullptr;
-    const float *horizontal_poly_inverse_ptr = nullptr;
-    const float *vertical_poly_inverse_ptr = nullptr;
-
-    int32_t horizontal_poly_order = 0;
-    int32_t vertical_poly_order = 0;
-    int32_t horizontal_poly_inverse_order = 0;
-    int32_t vertical_poly_inverse_order = 0;
+    std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> horizontal_poly = {};
+    std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> vertical_poly = {};
+    std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> horizontal_poly_inverse = {};
+    std::array<float, BivariateWindshieldModelParameters::MAX_COEFFS> vertical_poly_inverse = {};
 };
 
 // ---------------------------------------------------------------------------------------------
@@ -101,19 +144,12 @@ struct BivariateWindshieldModelDeviceParams {
 // External Distortion Models
 
 struct BivariateWindshieldModel {
-    gsplat::extdist::BivariateWindshieldModelDeviceParams params;
 
-    __device__ BivariateWindshieldModel(const gsplat::extdist::BivariateWindshieldModelDeviceParams& device_params)
-        : params(device_params)
-    {
-    }
-
+    // Distort a camera ray using forward polynomials.
     static __device__ GSPLAT_NOINLINE glm::fvec3 distort_camera_ray(
         const glm::fvec3& ray,
         const float* horizontal_poly,
-        const float* vertical_poly,
-        int32_t horizontal_order,
-        int32_t vertical_order)
+        const float* vertical_poly)
     {
         const float ray_length = glm::length(ray);
         if (ray_length < 1e-6f) return ray;
@@ -124,31 +160,30 @@ struct BivariateWindshieldModel {
         const float phi = std::asin(std::clamp(ray.x / ray_length, -1.f, 1.f));
         const float theta = std::asin(std::clamp(ray.y / ray_length, -1.f, 1.f));
 
-        const float x = std::sin(eval_bivariate_poly(horizontal_poly, horizontal_order, phi, theta));
-        const float y = std::sin(eval_bivariate_poly(vertical_poly, vertical_order, phi, theta));
+        const float x = std::sin(eval_bivariate_poly(horizontal_poly, phi, theta));
+        const float y = std::sin(eval_bivariate_poly(vertical_poly, phi, theta));
         const float z = std::sqrt(1.f - std::min(x * x + y * y, 1.f)) * (ray.z < 0.f ? -1.f : 1.f);
 
         return glm::fvec3(x, y, z);
     }
 
-    __device__ glm::fvec3 distort_camera_ray(glm::fvec3 ray) const {
-        return distort_camera_ray(
-            ray,
-            params.horizontal_poly_ptr,
-            params.vertical_poly_ptr,
-            params.horizontal_poly_order,
-            params.vertical_poly_order
-        );
-    }
+    // Undistort a camera ray using inverse polynomials.
+    static __device__ GSPLAT_NOINLINE glm::fvec3 undistort_camera_ray(
+        const glm::fvec3& ray,
+        const float* horizontal_poly_inverse,
+        const float* vertical_poly_inverse)
+    {
+        const float ray_length = glm::length(ray);
+        if (ray_length < 1e-6f) return ray;
 
-    __device__ glm::fvec3 undistort_camera_ray(glm::fvec3 ray) const {
-        return distort_camera_ray(
-            ray,
-            params.horizontal_poly_inverse_ptr,
-            params.vertical_poly_inverse_ptr,
-            params.horizontal_poly_inverse_order,
-            params.vertical_poly_inverse_order
-        );
+        const float phi = std::asin(std::clamp(ray.x / ray_length, -1.f, 1.f));
+        const float theta = std::asin(std::clamp(ray.y / ray_length, -1.f, 1.f));
+
+        const float x = std::sin(eval_bivariate_poly(horizontal_poly_inverse, phi, theta));
+        const float y = std::sin(eval_bivariate_poly(vertical_poly_inverse, phi, theta));
+        const float z = std::sqrt(1.f - std::min(x * x + y * y, 1.f)) * (ray.z < 0.f ? -1.f : 1.f);
+
+        return glm::fvec3(x, y, z);
     }
 };
 

--- a/tests/test_external_distortion.py
+++ b/tests/test_external_distortion.py
@@ -298,10 +298,49 @@ class TestBivariatePolyEvaluationCUDA:
             result = self._eval_cuda(coeffs, order, [0.0], [0.0])
             assert result[0].item() == pytest.approx(coeffs[0], abs=1e-5)
 
+    def test_cubic_poly(self):
+        """Order 3: f(x,y) = x^3 (cubic monomial)."""
+        # Order 3 layout: block0 has 4 coeffs (inner_order=3, x^0..x^3)
+        # x^3 → coeffs[3] = 1.0, rest zero → f = x^3 * y^0 = x^3
+        coeffs = [0.0] * num_coeffs_for_order(3)  # 10 coeffs
+        coeffs[3] = 1.0  # x^3 in first block
+        result = self._eval_cuda(coeffs, 3, [2.0, -1.0, 0.5], [0.0, 0.0, 0.0])
+        assert result[0].item() == pytest.approx(8.0, abs=1e-4)
+        assert result[1].item() == pytest.approx(-1.0, abs=1e-4)
+        assert result[2].item() == pytest.approx(0.125, abs=1e-4)
+
+    def test_cubic_mixed(self):
+        """Order 3: f(x,y) = x^2*y."""
+        # block0 (inner_order=3): x^0..x^3 → outer_coeffs[0], multiplied by y^0
+        # block1 (inner_order=2): x^0..x^2 → outer_coeffs[1], multiplied by y^1
+        # For x^2*y: need outer_coeffs[1] = x^2, so block1's x^2 coeff = 1.0
+        # block1 starts at index 4, x^2 is at offset 2 → coeffs[6] = 1.0
+        coeffs = [0.0] * num_coeffs_for_order(3)
+        coeffs[6] = 1.0
+        result = self._eval_cuda(coeffs, 3, [3.0], [2.0])
+        assert result[0].item() == pytest.approx(18.0, abs=1e-3)
+
+    def test_quartic_poly(self):
+        """Order 4: f(x,y) = x^4."""
+        coeffs = [0.0] * num_coeffs_for_order(4)  # 15 coeffs
+        coeffs[4] = 1.0  # x^4 in first block
+        result = self._eval_cuda(coeffs, 4, [2.0, -1.0], [0.0, 0.0])
+        assert result[0].item() == pytest.approx(16.0, abs=1e-3)
+        assert result[1].item() == pytest.approx(1.0, abs=1e-4)
+
+    def test_quintic_poly(self):
+        """Order 5 (MAX_ORDER): f(x,y) = x^5."""
+        coeffs = [0.0] * num_coeffs_for_order(5)  # 21 coeffs
+        coeffs[5] = 1.0  # x^5 in first block
+        result = self._eval_cuda(coeffs, 5, [2.0, -1.0, 0.5], [0.0, 0.0, 0.0])
+        assert result[0].item() == pytest.approx(32.0, abs=1e-2)
+        assert result[1].item() == pytest.approx(-1.0, abs=1e-4)
+        assert result[2].item() == pytest.approx(0.03125, abs=1e-4)
+
     def test_cross_validate_against_python_reference(self):
-        """Compare CUDA results to Python reference for many random inputs."""
+        """Compare CUDA results to Python reference for many random inputs (orders 0-5)."""
         torch.manual_seed(42)
-        for order in range(5):
+        for order in range(6):  # 0 through 5 (MAX_ORDER)
             n = num_coeffs_for_order(order)
             coeffs = torch.randn(n).tolist()
             x_vals = (torch.rand(50) * 2 - 1).tolist()  # [-1, 1]
@@ -312,6 +351,26 @@ class TestBivariatePolyEvaluationCUDA:
                 assert cuda_result[i].item() == pytest.approx(
                     ref, abs=1e-4
                 ), f"Mismatch at order={order}, i={i}: CUDA={cuda_result[i].item()}, ref={ref}"
+
+    def test_precision_padded_vs_reference(self):
+        """Zero-padded CUDA evaluation should match exact-order Python reference.
+
+        This validates that padding lower-order polynomials to MAX_ORDER=5 (21 coeffs)
+        doesn't degrade precision — the core invariant of the zero-padding approach.
+        """
+        torch.manual_seed(99)
+        for order in range(6):
+            n = num_coeffs_for_order(order)
+            coeffs = torch.randn(n).tolist()
+            x_vals = (torch.rand(30) * 2 - 1).tolist()
+            y_vals = (torch.rand(30) * 2 - 1).tolist()
+            cuda_result = self._eval_cuda(coeffs, order, x_vals, y_vals)
+            for i in range(len(x_vals)):
+                ref = ref_eval_bivariate_poly(coeffs, order, x_vals[i], y_vals[i])
+                assert cuda_result[i].item() == pytest.approx(ref, abs=1e-5), (
+                    f"Precision loss at order={order}, i={i}: "
+                    f"CUDA={cuda_result[i].item()}, ref={ref}"
+                )
 
 
 # ===========================================================================
@@ -486,6 +545,58 @@ class TestDistortCameraRaysCUDA:
                 assert result[i, j].item() == pytest.approx(
                     ref[j], abs=1e-5
                 ), f"Mismatch at ray {i}, component {j}"
+
+    @pytest.mark.parametrize("order", [2, 3, 4, 5])
+    def test_cross_validate_higher_orders(self, order):
+        """Cross-validate CUDA vs Python for random higher-order polynomials."""
+        torch.manual_seed(42 + order)
+        n = num_coeffs_for_order(order)
+        # Small random perturbation around identity to keep rays well-behaved
+        h = make_identity_horizontal_poly(order)
+        v = make_identity_vertical_poly(order)
+        # Add small random higher-order terms
+        for i in range(n):
+            h[i] += torch.randn(1).item() * 0.01
+            v[i] += torch.randn(1).item() * 0.01
+
+        rays_list = []
+        for _ in range(20):
+            r = torch.randn(3)
+            r[2] = abs(r[2]) + 0.5
+            rays_list.append(r.tolist())
+
+        h_order = ref_compute_order(len(h))
+        v_order = ref_compute_order(len(v))
+        result = self._distort_cuda(rays_list, h, v, h_inv=h, v_inv=v)
+        for i, ray in enumerate(rays_list):
+            ref = ref_distort_camera_ray(tuple(ray), h, v, h_order, v_order)
+            for j in range(3):
+                assert result[i, j].item() == pytest.approx(ref[j], abs=1e-4), (
+                    f"Mismatch at order={order}, ray {i}, component {j}: "
+                    f"CUDA={result[i, j].item()}, ref={ref[j]}"
+                )
+
+    @pytest.mark.parametrize("order", [2, 3, 4, 5])
+    def test_identity_higher_orders(self, order):
+        """Identity polynomials at higher orders should preserve ray direction."""
+        h = make_identity_horizontal_poly(order)
+        v = make_identity_vertical_poly(order)
+        rays = [
+            [0.3, 0.4, 0.8],
+            [0.1, 0.0, 1.0],
+            [0.0, 0.2, 0.9],
+            [-0.3, 0.2, 0.7],
+            [0.5, -0.3, 0.6],
+        ]
+        result = self._distort_cuda(rays, h, v, h_inv=h, v_inv=v)
+        for i, ray in enumerate(rays):
+            length = math.sqrt(sum(c**2 for c in ray))
+            expected = [c / length for c in ray]
+            for j in range(3):
+                assert result[i, j].item() == pytest.approx(expected[j], abs=1e-5), (
+                    f"Order {order}: component {j} mismatch for ray {ray}: "
+                    f"got {result[i, j].item()}, expected {expected[j]}"
+                )
 
     def test_cross_validate_nonidentity_poly(self):
         """Cross-validate CUDA vs Python for non-identity polynomials."""
@@ -776,6 +887,30 @@ class TestCameraWithExternalDistortion:
         assert valid.all()
         assert not torch.isnan(img_pts).any()
 
+    @pytest.mark.parametrize("order", [3, 4, 5])
+    def test_higher_order_roundtrip(self, order):
+        """Identity polynomial at orders 3-5: project -> unproject should recover direction."""
+        h = make_identity_horizontal_poly(order)
+        v = make_identity_vertical_poly(order)
+        params = make_params(h_poly=h, v_poly=v, h_inv=h, v_inv=v)
+        cam = self._create_pinhole_camera(external_distortion_coeffs=params)
+
+        rays = torch.tensor(
+            [[[0.05, 0.03, 1.0], [0.0, 0.0, 1.0], [-0.05, 0.05, 1.0]]],
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+        img_pts, valid_proj = cam.camera_ray_to_image_point(rays)
+        assert valid_proj.all(), f"Projection failed at order {order}"
+
+        rays_back, valid_unproj = cam.image_point_to_camera_ray(img_pts)
+        assert valid_unproj.all(), f"Unprojection failed at order {order}"
+
+        rays_norm = rays / rays.norm(dim=-1, keepdim=True)
+        rays_back_norm = rays_back / rays_back.norm(dim=-1, keepdim=True)
+        torch.testing.assert_close(rays_norm, rays_back_norm, atol=1e-4, rtol=1e-4)
+
 
 # ===========================================================================
 # 6. Integration tests through the full rendering pipeline (3DGUT)
@@ -853,7 +988,7 @@ class TestRenderingWithExternalDistortion:
             linear_cde=(9.9968284e-01, 1.8735906e-05, 1.7659619e-05),
         )
 
-        renders, alphas, meta = rasterization(
+        renders, alphas, _meta = rasterization(
             means=test_data["means"],
             quats=test_data["quats"],
             scales=test_data["scales"],
@@ -875,7 +1010,7 @@ class TestRenderingWithExternalDistortion:
 
     def test_no_external_distortion(self, test_data):
         """Rendering with external_distortion_coeffs=None should succeed."""
-        renders, alphas = self._render(test_data, external_distortion_coeffs=None)
+        renders, _alphas = self._render(test_data, external_distortion_coeffs=None)
         C = test_data["Ks"].shape[0]
         assert renders.shape == (C, test_data["height"], test_data["width"], 3)
         assert not torch.isnan(renders).any()
@@ -927,7 +1062,7 @@ class TestRenderingWithExternalDistortion:
             h_inv=make_zero_poly(1),
             v_inv=make_zero_poly(1),
         )
-        renders, alphas = self._render(
+        renders, _alphas = self._render(
             test_data, external_distortion_coeffs=zero_params
         )
         assert not torch.isnan(renders).any()
@@ -939,7 +1074,7 @@ class TestRenderingWithExternalDistortion:
         v = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
 
         params = make_params(h_poly=h, v_poly=v, h_inv=h, v_inv=v)
-        renders, alphas = self._render(test_data, external_distortion_coeffs=params)
+        renders, _alphas = self._render(test_data, external_distortion_coeffs=params)
         assert renders.shape == (
             test_data["Ks"].shape[0],
             test_data["height"],
@@ -948,6 +1083,21 @@ class TestRenderingWithExternalDistortion:
         )
         assert not torch.isnan(renders).any()
 
+    def test_order5_rendering(self, test_data):
+        """Order-5 (MAX_ORDER) identity polynomial through full rendering pipeline."""
+        h = make_identity_horizontal_poly(5)
+        v = make_identity_vertical_poly(5)
+        params = make_params(h_poly=h, v_poly=v, h_inv=h, v_inv=v)
+        renders, _alphas = self._render(test_data, external_distortion_coeffs=params)
+        assert renders.shape == (
+            test_data["Ks"].shape[0],
+            test_data["height"],
+            test_data["width"],
+            3,
+        )
+        assert not torch.isnan(renders).any()
+        assert not torch.isinf(renders).any()
+
     def test_backward_reference_poly(self, test_data):
         """Rendering with BACKWARD reference polynomial should succeed."""
         params = make_params(
@@ -955,5 +1105,5 @@ class TestRenderingWithExternalDistortion:
             v_poly=make_identity_vertical_poly(),
             ref_poly=ExternalDistortionReferencePolynomial.BACKWARD,
         )
-        renders, alphas = self._render(test_data, external_distortion_coeffs=params)
+        renders, _alphas = self._render(test_data, external_distortion_coeffs=params)
         assert not torch.isnan(renders).any()


### PR DESCRIPTION
# !! Putting as draft since some deps are missing and necessary before integrating this one !!

- Store std::array in struct, have the pointer point to the array.
- Reduces the number of registers just enough so we gain a CTA for projection.
- Noinline prevents compiler from generating any LDC instructions. Force it with `__grid_constant__`.

## Projection Kernel

| Metric | Baseline | Current | Delta |
|--------|----------|---------|-------|
| Duration | 61.1 ms | 32.2 ms | **-47.3%** |
| Regs/thread | 129 | 127 | -2 (below 128 cliff) |
| Occupancy | 12.5% | 25.0% | **2x** |
| SM throughput | 23.8% | 45.4% | +91% |
| FMA pipe | 12.7% | 24.6% | +93% |
| Uniform pipe (LDC) | 0.073% | 0.123% | +69% |
| Memory throughput | 7.1% | 12.5% | +77% |