### PR TITLE
[NV] Allow ext dist coeffs tensors to live on CPU

### DIFF
--- a/gsplat/cuda/csrc/Projection.cpp
+++ b/gsplat/cuda/csrc/Projection.cpp
@@ -989,10 +989,8 @@ projection_ut_3dgs_fused_impl(
     }
 
     if (external_distortion_params.has_value()) {
-        CHECK_INPUT(external_distortion_params.value()->horizontal_poly);
-        CHECK_INPUT(external_distortion_params.value()->vertical_poly);
-        CHECK_INPUT(external_distortion_params.value()->horizontal_poly_inverse); // Could be omitted for projection
-        CHECK_INPUT(external_distortion_params.value()->vertical_poly_inverse); // Could be omitted for projection
+        CHECK_CONTIGUOUS(external_distortion_params.value()->horizontal_poly);
+        CHECK_CONTIGUOUS(external_distortion_params.value()->vertical_poly);
     }
 
     at::DimVector batch_dims(means.sizes().slice(0, means.dim() - 2));

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -704,10 +704,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> rasterize_to_pixels_from_world_3d
     if (external_distortion_params.has_value()) {
         const auto& params = external_distortion_params.value();
         TORCH_CHECK(params, "external_distortion_params intrusive_ptr is null");
-        CHECK_INPUT(params->horizontal_poly);
-        CHECK_INPUT(params->vertical_poly);
-        CHECK_INPUT(params->horizontal_poly_inverse);
-        CHECK_INPUT(params->vertical_poly_inverse);
+        CHECK_CONTIGUOUS(params->horizontal_poly);
+        CHECK_CONTIGUOUS(params->vertical_poly);
+        CHECK_CONTIGUOUS(params->horizontal_poly_inverse);
+        CHECK_CONTIGUOUS(params->vertical_poly_inverse);
     }
 
     if (sample_counts.has_value()) {
@@ -918,10 +918,10 @@ rasterize_to_pixels_from_world_3dgs_bwd_impl(
     if (external_distortion_params.has_value()) {
         const auto& params = external_distortion_params.value();
         TORCH_CHECK(params, "external_distortion_params intrusive_ptr is null");
-        CHECK_INPUT(params->horizontal_poly);
-        CHECK_INPUT(params->vertical_poly);
-        CHECK_INPUT(params->horizontal_poly_inverse);
-        CHECK_INPUT(params->vertical_poly_inverse);
+        CHECK_CONTIGUOUS(params->horizontal_poly);
+        CHECK_CONTIGUOUS(params->vertical_poly);
+        CHECK_CONTIGUOUS(params->horizontal_poly_inverse);
+        CHECK_CONTIGUOUS(params->vertical_poly_inverse);
     }
 
     uint32_t channels = colors.size(-1);


### PR DESCRIPTION
# !! KEEPING AS DRAFT UNTIL PREREQUISITES CHANGES ARE MERGED !!

# Allows external distortion coefficients tensors to live on the CPU and avoid potential CPU-GPU sync(s).

| Metric | Baseline | Fix | Delta |
|--------|----------|-----|-------|
| Training step avg | 134.4 ms | 134.1 ms | -0.3 ms (-0.2%) |
| Training step median | 119.6 ms | 120.0 ms | +0.4 ms (+0.3%) |
| cudaStreamSync total | 82.6 s | 83.9 s | +1.3 s (noise) |
| DtoH GPU time | 121 ms | 111 ms | -10 ms |
| DtoH copy count | 19,549 | 17,353 | -2,196 |
| cudaMemcpyAsync CPU time | 2,283 ms | 1,317 ms | -966 ms |
| DtoD volume | 286,757 MB | 286,758 MB | ~0 |

**Verdict:** The fix correctly removes the targeted DtoH copies (~1 per step per type), but the performance impact is negligible. The removed copies were too small (~2-3 us each) to cause meaningful synchronization stalls.

## What the Fix Changed

The fix removes two small DtoH Device→Pageable copies per training step by creating the ext dist coefficient tensor on the CPU/host side instead of on GPU:

| DtoH copy size | Baseline (per profile) | Fix (per profile) | Delta |
|----------------|----------------------|-------------------|-------|
| 24 bytes | 1,126 | 28 | **-1,098** (~1/step) |
| 60 bytes | 1,102 | 4 | **-1,098** (~1/step) |
| All other sizes | identical | identical | 0 |

Total DtoH Device→Pageable: 5,605 → 3,409 (-2,196 copies, -11 ms GPU time).

The remaining 28 and 4 copies at those sizes are one-time operations (not per-step). The removed copies were 24-byte and 60-byte DtoH transfers at ~2-3 us each. At that size, they complete in a single PCIe transaction and don't create a pipeline stall.

## Full Memory Transfer Comparison

| Operation | Baseline | Fix | Delta |
|-----------|----------|-----|-------|
| DtoD | 1,053 ms / 62,300 ops / 286,757 MB | 1,065 ms / 62,300 ops / 286,758 MB | noise |
| HtoD | 895 ms / 19,352 ops / 10,580 MB | 894 ms / 18,620 ops / 10,580 MB | -732 ops (same data) |
| DtoH | 121 ms / 19,549 ops / 119 MB | 111 ms / 17,353 ops / 118 MB | **-2,196 ops / -10 ms** |
| Memset | 67 ms / 46,173 ops | 67 ms / 46,173 ops | 0 |

## Synchronization Comparison

| Metric | Baseline | Fix | Delta |
|--------|----------|-----|-------|
| cudaStreamSync calls | 26,801 | 23,873 | -2,928 |
| cudaStreamSync total | 82.6 s | 83.9 s | +1.3 s (noise) |
| cudaStreamSync avg | 3.08 ms | 3.51 ms | +0.43 ms |
| EventSync calls | 653,534 | 667,409 | +13,875 |

The fix has 2,928 fewer sync calls but each is slightly longer on average.

## NVTX Training Step Comparison

| Phase | Baseline | Fix | Delta |
|-------|----------|-----|-------|
| training_step | 134.4 ms | 134.1 ms | -0.3 ms |
| training_losses | 113.5 ms | 114.0 ms | +0.5 ms |
| forward_gaussians | 92.5 ms | 93.6 ms | +1.1 ms |
| render_lidar | 77.5 ms | 78.7 ms | +1.2 ms |
| GSplatRenderer/render | 16.8 ms | 16.8 ms | 0 ms |
| manual_backward | 18.6 ms | 17.7 ms | -0.9 ms |
| optimizer_step | 1.97 ms | 1.95 ms | 0 ms |

All within run-to-run noise (1-2%).

## Top Kernel Comparison

| Kernel | Baseline | Fix | Delta |
|--------|----------|-----|-------|
| rasterize_bwd | 68,442 ms | 68,552 ms | +0.2% |
| rasterize_fwd | 34,747 ms | 34,832 ms | +0.2% |
| projection_ut_fused | 13,530 ms | 13,587 ms | +0.4% |
| collect_params_2_bwd | 7,354 ms | 7,315 ms | -0.5% |
| multi_tensor_apply | 7,302 ms | 7,350 ms | +0.7% |

All kernel times are within noise.