### PR TITLE
Update RelocationCUDA.cu: fix mcmc relocation_kernel: avoid pow(-1.0f, k) return "Nan"

### DIFF
--- a/gsplat/cuda/csrc/RelocationCUDA.cu
+++ b/gsplat/cuda/csrc/RelocationCUDA.cu
@@ -55,7 +55,8 @@ __global__ void relocation_kernel(
     for (int i = 1; i <= n_idx; ++i) {
         for (int k = 0; k <= (i - 1); ++k) {
             float bin_coeff = binoms[(i - 1) * n_max + k];
-            float term = (pow(-1.0f, k) / sqrt(static_cast<float>(k + 1))) *
+            float sign = (k % 2 == 0) ? 1.0f : -1.0f;
+            float term = (sign / sqrt(static_cast<float>(k + 1))) *
                          pow(new_opacities[idx], k + 1);
             denom_sum += (bin_coeff * term);
         }


### PR DESCRIPTION
When I was using gsplat's MCMC strategy, I found that around line 58 in RelocationCUDA.cu calculates the new scale using `pow(-1.0f, k)`. In my case, if `-use_fast_math` is used when compiling gsplat, it may cause `pow(-1.0f, k)` to return `NaN`. So I think replacing the `pow(-1.0f, k)` calculation with `float sign = (k % 2 == 0) ? 1.0f : -1.0f` be safer and faster.