### PR TITLE
[NV] Adding gaussian inference scene, with compacted quaternion-scale-opacity

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -10,9 +10,11 @@ installable package. See `design.md` for the shared architectural contract
 | `libs/scene`     | `gsplat-scene`    | `gsplat_scene`     | `torch`                   |
 | `libs/stage`     | `gsplat-stage`    | `gsplat_stage`     | `torch`, `gsplat-scene`   |
 
-## Install
+## Build and Install
 
-Use `install.sh` from this directory:
+Install from an environment that already has the repo's expected PyTorch/CUDA
+toolchain. The libraries are editable installs, so Python-only edits are picked
+up immediately by the next `python` or `pytest` process.
 
 ```bash
 cd libs
@@ -22,7 +24,21 @@ cd libs
 ./install.sh stage          # install AFTER scene
 ```
 
-Each call runs `pip install -e <package>` against the active Python env. 
+Each call installs one package into the active Python environment. Equivalent
+manual commands are:
+
+```bash
+pip install -e geometry
+pip install -e scene
+pip install -e stage
+```
+
+Native/CUDA extensions are built or loaded through the package-specific kernel
+layers. `gsplat-scene` expects the scene CUDA extension to be available through
+the active PyTorch/CUDA setup, with fallback JIT build behavior handled by
+`gsplat_scene.kernels`. Re-run the relevant editable install after changing
+`pyproject.toml`, adding top-level packages, switching Python environments, or
+modifying native/CUDA extension sources.
 
 To verify what's installed and where it points:
 
@@ -34,11 +50,9 @@ The `Editable project location:` line should point back into this repo.
 
 ## Developing
 
-Installs are editable (`pip install -e`), so edits to any `.py` file under
-`libs/<pkg>/...` are picked up by the next `python` / `pytest` invocation with
-no reinstall. Re-run `./install.sh <pkg>` only when you change `pyproject.toml`,
-add a new top-level subpackage, switch Python envs, or modify native
-extensions.
+Installs are editable (`pip install -e`), so normal development should happen in
+place under `libs/<pkg>/...`. Keep dependency order in mind when reinstalling:
+`stage` depends on `scene`.
 
 ## Testing
 
@@ -47,15 +61,15 @@ Tests are colocated with the layer they exercise (typically alongside
 
 ```bash
 pytest libs/geometry/functional
-pytest libs/scene/components
+pytest libs/scene/components libs/scene/functional libs/scene/test_package_imports.py
 pytest libs/stage/components
 ```
 
 See `design.md` for the full testing contract.
 
-## Sanity check
+## Sanity Check
 
-After installing, this should print three workspace paths:
+After installing, this should print workspace paths for all libs:
 
 ```bash
 python - <<'PY'

--- a/libs/scene/__init__.py
+++ b/libs/scene/__init__.py
@@ -15,5 +15,23 @@
 
 from .components.base import Scene
 from .components.gaussian_scene import GaussianScene
+from .components.gaussian_inference_scene import GaussianInferenceScene
+from .sh_compression import SHCompressionMode
 
-__all__ = ["Scene", "GaussianScene"]
+__all__ = [
+    "functional",
+    "Scene",
+    "GaussianScene",
+    "GaussianInferenceScene",
+    "SHCompressionMode",
+]
+
+
+def __getattr__(name: str):
+    if name == "functional":
+        from importlib import import_module
+
+        module = import_module(f"{__name__}.functional")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/scene/components/__init__.py
+++ b/libs/scene/components/__init__.py
@@ -15,5 +15,6 @@
 
 from .base import Scene
 from .gaussian_scene import GaussianScene
+from .gaussian_inference_scene import GaussianInferenceScene
 
-__all__ = ["Scene", "GaussianScene"]
+__all__ = ["Scene", "GaussianScene", "GaussianInferenceScene"]

--- a/libs/scene/components/gaussian_inference_scene.py
+++ b/libs/scene/components/gaussian_inference_scene.py
@@ -1,0 +1,657 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Any, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..sh_compression import SH_COMPRESSION_MAP, SHCompressionMode
+from .base import Scene
+
+_SH_COMPRESSION_MAP = SH_COMPRESSION_MAP
+
+
+class GaussianInferenceScene(Scene):
+    """Activated, packed Gaussian scene for inference rendering.
+
+    Holds packed tensors in the viewer-internal layout. Constructed via
+    classmethods; ``__init__`` is not part of the public API.
+    """
+
+    def __init__(self, id: str) -> None:
+        super().__init__(id)
+        self.means_planar: Optional[Tensor] = None  # [3, N] float32 CUDA
+        self.qso_packed: Optional[Tensor] = None  # [N, 8] float16 CUDA
+        self.colors_packed: Optional[Tensor] = None  # varies by sh_degree
+        self.sh_degree: Optional[int] = None
+        self.sh_compression_mode: Optional[SHCompressionMode] = None
+        self.num_gaussians: int = 0
+        self.component_names: list[str] = []
+        self.component_index: Tensor = torch.zeros(0, dtype=torch.long)
+
+    def is_empty(self) -> bool:
+        return (
+            self.means_planar is None
+            or self.qso_packed is None
+            or self.colors_packed is None
+            or self.num_gaussians == 0
+        )
+
+    def release(self) -> None:
+        self.means_planar = None
+        self.qso_packed = None
+        self.colors_packed = None
+        self.sh_degree = None
+        self.sh_compression_mode = None
+        self.num_gaussians = 0
+        self.component_names = []
+        self.component_index = torch.zeros(0, dtype=torch.long)
+
+    def put(self, name: str, component: dict) -> None:
+        if not name:
+            raise ValueError("component name must not be empty")
+        scene_empty = self.is_empty()
+        if not scene_empty and name in self.component_names:
+            raise ValueError(
+                f"component '{name}' already present in GaussianInferenceScene"
+            )
+
+        means_planar = component["means_planar"]
+        qso_packed = component["qso_packed"]
+        colors_packed = component["colors_packed"]
+        sh_degree = component["sh_degree"]
+        sh_compression_mode = component["sh_compression_mode"]
+
+        n_local = self._validate_packed_component(
+            means_planar, qso_packed, colors_packed, sh_degree, sh_compression_mode
+        )
+
+        if scene_empty:
+            # First component
+            self.means_planar = means_planar
+            self.qso_packed = qso_packed
+            self.colors_packed = colors_packed
+            self.sh_degree = sh_degree
+            self.sh_compression_mode = sh_compression_mode
+            self.num_gaussians = n_local
+            self.component_names = [name]
+            self.component_index = torch.zeros(
+                n_local, device=means_planar.device, dtype=torch.long
+            )
+        else:
+            # Validate consistency
+            if sh_degree != self.sh_degree:
+                raise ValueError(
+                    f"sh_degree mismatch: scene has {self.sh_degree}, "
+                    f"component has {sh_degree}"
+                )
+            if sh_compression_mode != self.sh_compression_mode:
+                raise ValueError(
+                    f"sh_compression_mode mismatch: scene has "
+                    f"{self.sh_compression_mode}, "
+                    f"component has {sh_compression_mode}"
+                )
+            self.means_planar = torch.cat([self.means_planar, means_planar], dim=1)
+            self.qso_packed = torch.cat([self.qso_packed, qso_packed], dim=0)
+            self.colors_packed = torch.cat([self.colors_packed, colors_packed], dim=0)
+            self.component_names.append(name)
+            self.component_index = torch.cat(
+                [
+                    self.component_index,
+                    torch.full(
+                        (n_local,),
+                        len(self.component_names) - 1,
+                        device=self.component_index.device,
+                        dtype=torch.long,
+                    ),
+                ],
+                dim=0,
+            )
+            self.num_gaussians += n_local
+
+    @staticmethod
+    def _validate_packed_component(
+        means_planar: Tensor,
+        qso_packed: Tensor,
+        colors_packed: Tensor,
+        sh_degree: int,
+        sh_compression_mode: SHCompressionMode,
+    ) -> int:
+        tensors = {
+            "means_planar": means_planar,
+            "qso_packed": qso_packed,
+            "colors_packed": colors_packed,
+        }
+        for name, tensor in tensors.items():
+            if not isinstance(tensor, Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor")
+            if not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+
+        if means_planar.dim() != 2 or means_planar.shape[0] != 3:
+            raise ValueError(
+                f"means_planar must have shape [3, N]; got {list(means_planar.shape)}"
+            )
+        if qso_packed.dim() != 2 or qso_packed.shape[1] != 8:
+            raise ValueError(
+                f"qso_packed must have shape [N, 8]; got {list(qso_packed.shape)}"
+            )
+
+        n_local = qso_packed.shape[0]
+        if means_planar.shape[1] != n_local:
+            raise ValueError(
+                f"means_planar.shape[1] ({means_planar.shape[1]}) must match "
+                f"qso_packed.shape[0] ({n_local})"
+            )
+        if colors_packed.dim() < 2 or colors_packed.shape[0] != n_local:
+            raise ValueError(
+                f"colors_packed.shape[0] must match N={n_local}; "
+                f"got shape {list(colors_packed.shape)}"
+            )
+
+        device = means_planar.device
+        for name, tensor in (
+            ("qso_packed", qso_packed),
+            ("colors_packed", colors_packed),
+        ):
+            if tensor.device != device:
+                raise ValueError(
+                    f"{name} device {tensor.device} must match means_planar device {device}"
+                )
+
+        if means_planar.dtype != torch.float32:
+            raise TypeError(
+                f"means_planar must have dtype torch.float32; got {means_planar.dtype}"
+            )
+        if qso_packed.dtype != torch.float16:
+            raise TypeError(
+                f"qso_packed must have dtype torch.float16; got {qso_packed.dtype}"
+            )
+
+        if not isinstance(sh_compression_mode, SHCompressionMode):
+            raise TypeError(
+                "sh_compression_mode must be an SHCompressionMode; "
+                f"got {type(sh_compression_mode).__name__}"
+            )
+        if sh_compression_mode is not SHCompressionMode.NONE and sh_degree != 3:
+            raise ValueError(
+                f"sh_compression_mode={sh_compression_mode} requires sh_degree=3; "
+                f"got sh_degree={sh_degree}"
+            )
+
+        if sh_degree == -1:
+            expected_shape = (n_local, 4)
+            expected_dtype = torch.float16
+        elif sh_degree in (0, 1, 2):
+            expected_shape = (n_local, (sh_degree + 1) ** 2, 3)
+            expected_dtype = torch.float32
+        elif sh_degree == 3 and sh_compression_mode is SHCompressionMode.NONE:
+            expected_shape = (n_local, 16, 3)
+            expected_dtype = torch.float16
+        elif sh_degree == 3 and sh_compression_mode is SHCompressionMode.PACKED_32B:
+            expected_shape = (n_local, 48)
+            expected_dtype = torch.float32
+        elif sh_degree == 3 and sh_compression_mode is SHCompressionMode.PACKED_16B:
+            expected_shape = (n_local, 48)
+            expected_dtype = torch.float16
+        else:
+            raise ValueError(
+                f"sh_degree must be one of [-1, 0, 1, 2, 3]; got {sh_degree}"
+            )
+
+        if tuple(colors_packed.shape) != expected_shape:
+            raise ValueError(
+                f"colors_packed must have shape {list(expected_shape)} for "
+                f"sh_degree={sh_degree}, sh_compression_mode={sh_compression_mode}; "
+                f"got {list(colors_packed.shape)}"
+            )
+        if colors_packed.dtype != expected_dtype:
+            raise TypeError(
+                f"colors_packed must have dtype {expected_dtype}; got {colors_packed.dtype}"
+            )
+
+        return n_local
+
+    def get(self, component: str | int) -> dict:
+        if self.is_empty():
+            raise RuntimeError(
+                "GaussianInferenceScene has been released and contains no packed tensors"
+            )
+
+        if isinstance(component, int):
+            if component < 0 or component >= len(self.component_names):
+                raise KeyError(f"'{component}'")
+            comp_id = component
+        else:
+            if component not in self.component_names:
+                raise KeyError(f"'{component}'")
+            comp_id = self.component_names.index(component)
+
+        mask = self.component_index == comp_id
+        return {
+            "name": self.component_names[comp_id],
+            "index": comp_id,
+            "mask": mask,
+            "means_planar": self.means_planar[:, mask],
+            "qso_packed": self.qso_packed[mask],
+            "colors_packed": self.colors_packed[mask],
+            "sh_degree": self.sh_degree,
+            "sh_compression_mode": self.sh_compression_mode,
+        }
+
+    @classmethod
+    def from_gaussian_scene(
+        cls,
+        scene,  # GaussianScene - use duck typing to avoid circular import
+        *,
+        id: str,
+        sh_compression: str = "none",
+    ) -> "GaussianInferenceScene":
+        """Build a GaussianInferenceScene from a training GaussianScene.
+
+        Applies activations automatically: ``F.normalize`` on quaternions,
+        ``.exp()`` on scales, ``.sigmoid()`` on opacities.  Colors are read
+        from ``splats["colors"]`` or concatenated ``splats["sh0"]``/``splats["shN"]``.
+
+        Appearance-optimized scenes (those containing ``"features"`` in splats) are
+        rejected — use :meth:`from_gaussian_tensors` with baked RGB instead.
+
+        Not supported under ``torch.distributed`` with ``world_size > 1``; gather
+        tensors first and call :meth:`from_gaussian_tensors`.
+
+        Args:
+            scene: A ``GaussianScene`` instance with raw (log-space) splats.
+            id: Unique identifier for the inference scene.
+            sh_compression: SH packing mode — ``"none"``, ``"32b"``, or ``"16b"``.
+                Only meaningful for ``sh_degree == 3``.
+
+        Returns:
+            A new ``GaussianInferenceScene`` with packed tensors.  Quaternions
+            follow the wxyz convention matching gsplat's rendering path.
+
+        Raises:
+            RuntimeError: If called under distributed with ``world_size > 1``.
+            ValueError: If splats contain ``"features"`` (appearance-optimized).
+            ValueError: If no color data is found in splats.
+            ValueError: If activation produces NaN or Inf.
+        """
+        # Multi-component rejection
+        if hasattr(scene, "component_names") and len(scene.component_names) > 1:
+            raise ValueError(
+                "from_gaussian_scene does not support multi-component scenes; "
+                "convert each component individually via from_gaussian_tensors"
+            )
+
+        # Distributed rejection
+        if (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size() > 1
+        ):
+            raise RuntimeError(
+                "GaussianInferenceScene.from_gaussian_scene is not supported under "
+                "distributed (world_size > 1); gather first and use "
+                "from_gaussian_tensors"
+            )
+
+        splats = scene.splats
+
+        if "features" in splats:
+            raise ValueError(
+                "from_gaussian_scene does not support appearance-optimized scenes "
+                "(splats contain 'features'). Bake activated per-view RGB and use "
+                "from_gaussian_tensors() instead."
+            )
+
+        means = splats["means"]
+        quats = F.normalize(splats["quats"], dim=-1)
+        scales = splats["scales"].exp()
+        opacities = splats["opacities"].sigmoid()
+
+        for act_name, act_tensor in [
+            ("quats (after normalize)", quats),
+            ("scales (after exp)", scales),
+            ("opacities (after sigmoid)", opacities),
+        ]:
+            if not torch.isfinite(act_tensor).all():
+                raise ValueError(
+                    f"from_gaussian_scene: {act_name} contains NaN or Inf after "
+                    f"activation; check the source GaussianScene for invalid values"
+                )
+
+        colors = splats.get("colors", None)
+        if colors is None:
+            sh0 = splats.get("sh0", None)
+            if sh0 is not None and "shN" in splats:
+                colors = torch.cat([sh0, splats["shN"]], dim=1)
+            elif sh0 is not None:
+                warnings.warn(
+                    "GaussianScene has sh0 but no shN; degrading to SH degree 0",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                colors = sh0
+            else:
+                colors = sh0
+        if colors is None:
+            raise ValueError("GaussianScene must contain 'colors' or 'sh0' in splats")
+
+        # Determine sh_degree from colors shape
+        if colors.dim() == 3:
+            K_sh = colors.shape[1]
+            basis_width = math.isqrt(K_sh)
+            if basis_width * basis_width != K_sh:
+                raise ValueError(
+                    f"colors SH basis dimension must be a perfect square; got {K_sh}"
+                )
+            sh_degree_val = basis_width - 1
+        else:
+            sh_degree_val = None
+
+        return cls._build(
+            means=means,
+            quats=quats,
+            scales=scales,
+            opacities=opacities,
+            colors=colors,
+            sh_degree=sh_degree_val,
+            sh_compression=sh_compression,
+            id=id,
+            skip_activation_checks=True,
+        )
+
+    @classmethod
+    def from_gaussian_tensors(
+        cls,
+        means: Tensor,
+        quats: Tensor,
+        scales: Tensor,
+        opacities: Tensor,
+        colors: Tensor,
+        sh_degree: Optional[int],
+        sh_compression: str,
+        *,
+        id: str,
+    ) -> "GaussianInferenceScene":
+        """Build a GaussianInferenceScene from pre-activated tensors.
+
+        All inputs must already have activations applied:
+
+        - ``quats``: unit-norm quaternions in wxyz order
+          (apply ``F.normalize(quats, dim=-1)`` if needed).
+        - ``scales``: positive values (apply ``.exp()`` if in log-space).
+        - ``opacities``: values in ``[0, 1]`` (apply ``.sigmoid()`` if in
+          logit-space).
+        - ``colors``: ``[N, 3]`` for RGB or ``[N, K, 3]`` for SH coefficients.
+
+        Args:
+            means: ``[N, 3]`` float32 CUDA — world-space positions.
+            quats: ``[N, 4]`` float32 CUDA — unit quaternions (wxyz).
+            scales: ``[N, 3]`` float32 CUDA — positive scales.
+            opacities: ``[N]`` float32 CUDA — opacities in ``[0, 1]``.
+            colors: ``[N, 3]`` or ``[N, K, 3]`` float32 CUDA.
+            sh_degree: ``None`` or ``-1`` for RGB; ``0``–``3`` for SH.
+            sh_compression: ``"none"``, ``"32b"``, or ``"16b"``.
+            id: Unique identifier for the inference scene.
+
+        Returns:
+            A new ``GaussianInferenceScene`` with packed tensors.
+
+        Raises:
+            ValueError: If activation contracts are violated (non-positive scales,
+                opacities outside ``[0, 1]``, non-unit quaternions, NaN/Inf).
+        """
+        return cls._build(
+            means=means,
+            quats=quats,
+            scales=scales,
+            opacities=opacities,
+            colors=colors,
+            sh_degree=sh_degree,
+            sh_compression=sh_compression,
+            id=id,
+            skip_activation_checks=False,
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        *,
+        means: Tensor,
+        quats: Tensor,
+        scales: Tensor,
+        opacities: Tensor,
+        colors: Tensor,
+        sh_degree: Optional[int],
+        sh_compression: str,
+        id: str,
+        skip_activation_checks: bool,
+    ) -> "GaussianInferenceScene":
+        # Validate sh_compression
+        if sh_compression not in _SH_COMPRESSION_MAP:
+            raise ValueError(
+                f"sh_compression must be one of {{'none', '32b', '16b'}}; "
+                f"got '{sh_compression}'"
+            )
+        sh_compression_mode = _SH_COMPRESSION_MAP[sh_compression]
+
+        # Validate means shape: must be [N, 3]
+        if means.dim() != 2 or means.shape[1] != 3:
+            raise ValueError(f"means must have shape [N, 3]; got {list(means.shape)}")
+
+        # Validate sh_degree vs colors shape consistency
+        if sh_degree is not None and sh_degree >= 0:
+            if colors.dim() != 3:
+                raise ValueError(
+                    f"sh_degree={sh_degree} requires colors to be 3-D [N, K, 3]; "
+                    f"got {colors.dim()}-D shape {list(colors.shape)}"
+                )
+            expected_K = (sh_degree + 1) ** 2
+            if colors.shape[1] != expected_K:
+                raise ValueError(
+                    f"sh_degree={sh_degree} requires colors.shape[1]={expected_K} "
+                    f"(got {colors.shape[1]})"
+                )
+        elif sh_degree is None or sh_degree < 0:
+            if colors.dim() != 2:
+                raise ValueError(
+                    f"sh_degree=None (pre-activated RGB) requires colors to be "
+                    f"2-D [N, 3]; got {colors.dim()}-D shape {list(colors.shape)}"
+                )
+
+        # Validate sh_compression is only used with sh_degree == 3
+        if sh_compression_mode is not SHCompressionMode.NONE and sh_degree != 3:
+            raise ValueError(
+                f"sh_compression='{sh_compression}' requires sh_degree=3; "
+                f"got sh_degree={sh_degree}"
+            )
+
+        # Activation contract checks (only for from_gaussian_tensors)
+        if not skip_activation_checks:
+            _check_activation_contract(means, quats, scales, opacities, colors)
+
+        # Detach-and-warn
+        tensors = {
+            "means": means,
+            "quats": quats,
+            "scales": scales,
+            "opacities": opacities,
+            "colors": colors,
+        }
+        detached_names = []
+        for name, t in tensors.items():
+            if t.requires_grad:
+                detached_names.append(name)
+                tensors[name] = t.detach()
+
+        if detached_names:
+            warnings.warn(
+                f"GaussianInferenceScene: detached grad-tracked inputs: "
+                f"{detached_names}. "
+                f"The resulting packed tensors will not participate in "
+                f"autograd.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+        means = tensors["means"]
+        quats = tensors["quats"]
+        scales = tensors["scales"]
+        opacities = tensors["opacities"]
+        colors = tensors["colors"]
+
+        # fp16 clamp warning check (before calling C++ op which also clamps)
+        fp16_max = torch.finfo(torch.float16).max
+        clamp_warnings: list = []
+        _check_fp16_range(scales, "scales", fp16_max, clamp_warnings)
+        _check_fp16_range(colors, "colors", fp16_max, clamp_warnings)
+
+        if clamp_warnings:
+            msg_lines = ["GaussianInferenceScene: fp16 clamping applied:"]
+            for entry in clamp_warnings:
+                if len(entry) == 5:
+                    name, count, orig_min, orig_max, nonfinite_count = entry
+                    msg = f"  {name}: clamped {count} elements (original range [{orig_min:.4g}, {orig_max:.4g}])"
+                    if nonfinite_count > 0:
+                        msg += f" ({nonfinite_count} non-finite)"
+                else:
+                    name, count, orig_min, orig_max = entry
+                    msg = f"  {name}: clamped {count} elements (original range [{orig_min:.4g}, {orig_max:.4g}])"
+                msg_lines.append(msg)
+            warnings.warn("\n".join(msg_lines), RuntimeWarning, stacklevel=3)
+
+        # Encode sh_degree for C++ op
+        sh_deg = -1 if sh_degree is None else sh_degree
+
+        # Call C++ packing op through the scene kernels layer
+        from ..kernels.gaussian_inference_ops import (
+            pack_gaussian_inference_scene as _pack,
+        )
+
+        means_planar, qso_packed, colors_packed = _pack(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_deg,
+            sh_compression_mode,
+        )
+
+        # Build scene
+        scene = cls(id)
+        scene.put(
+            id,
+            {
+                "means_planar": means_planar,
+                "qso_packed": qso_packed,
+                "colors_packed": colors_packed,
+                "sh_degree": sh_deg,
+                "sh_compression_mode": sh_compression_mode,
+            },
+        )
+        return scene
+
+
+def _check_activation_contract(
+    means: Tensor,
+    quats: Tensor,
+    scales: Tensor,
+    opacities: Tensor,
+    colors: Tensor,
+) -> None:
+    """Validate activation contract for from_gaussian_tensors."""
+    # Check for NaN/Inf in all tensors
+    for name, t in [
+        ("means", means),
+        ("quats", quats),
+        ("scales", scales),
+        ("opacities", opacities),
+        ("colors", colors),
+    ]:
+        bad = ~torch.isfinite(t)
+        if bad.any():
+            indices = (
+                torch.nonzero(bad.reshape(-1), as_tuple=False).squeeze(-1).tolist()
+            )
+            # Limit displayed indices
+            display = indices[:10]
+            suffix = f"... ({len(indices)} total)" if len(indices) > 10 else ""
+            raise ValueError(
+                f"tensor '{name}' contains NaN or Inf at indices " f"{display}{suffix}"
+            )
+
+    # scales must be positive (exp(x) > 0 always)
+    bad_scales = scales <= 0
+    if bad_scales.any():
+        indices = (
+            torch.nonzero(bad_scales.any(dim=-1), as_tuple=False).squeeze(-1).tolist()
+        )
+        display = indices[:10]
+        suffix = f"... ({len(indices)} total)" if len(indices) > 10 else ""
+        raise ValueError(
+            f"scales contain non-positive values at indices "
+            f"{display}{suffix}; did you forget to call .exp()?"
+        )
+
+    # opacities must be in [0, 1] (sigmoid bounded)
+    bad_opacities = (opacities < 0) | (opacities > 1)
+    if bad_opacities.any():
+        indices = torch.nonzero(bad_opacities, as_tuple=False).squeeze(-1).tolist()
+        display = indices[:10]
+        suffix = f"... ({len(indices)} total)" if len(indices) > 10 else ""
+        raise ValueError(
+            f"opacities outside [0, 1] at indices {display}{suffix}; "
+            f"did you forget to call .sigmoid()?"
+        )
+
+    # quats must be unit-norm (F.normalize applied)
+    norms = quats.norm(dim=-1)
+    bad_norms = (norms - 1).abs() > 1e-3
+    if bad_norms.any():
+        indices = torch.nonzero(bad_norms, as_tuple=False).squeeze(-1).tolist()
+        display = indices[:10]
+        suffix = f"... ({len(indices)} total)" if len(indices) > 10 else ""
+        raise ValueError(
+            f"quats are not unit-norm at indices {display}{suffix}; "
+            f"did you forget F.normalize(quats, dim=-1)?"
+        )
+
+
+def _check_fp16_range(
+    tensor: Tensor, name: str, fp16_max: float, warnings_list: list
+) -> None:
+    """Check if tensor has values outside fp16 range or non-finite."""
+    with torch.no_grad():
+        nonfinite = ~torch.isfinite(tensor)
+        abs_vals = tensor.abs()
+        exceed_mask = (abs_vals > fp16_max) | nonfinite
+        count = int(exceed_mask.sum().item())
+        if count > 0:
+            finite_vals = tensor[torch.isfinite(tensor)]
+            if finite_vals.numel() > 0:
+                orig_min = float(finite_vals.min().item())
+                orig_max = float(finite_vals.max().item())
+            else:
+                orig_min = float("nan")
+                orig_max = float("nan")
+            nonfinite_count = int(nonfinite.sum().item())
+            warnings_list.append((name, count, orig_min, orig_max, nonfinite_count))

--- a/libs/scene/components/test_gaussian_inference_scene.py
+++ b/libs/scene/components/test_gaussian_inference_scene.py
@@ -1,0 +1,1353 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inference Scene Packing tests.
+
+Tests for GaussianInferenceScene class, pack_gaussian_inference_scene C++ op,
+classmethod constructors, activation-contract validation, fp16 clamp
+policy, detach-and-warn behavior, distributed rejection, and parity.
+"""
+
+import pytest
+import warnings
+import torch
+
+gsplat_scene = pytest.importorskip("gsplat_scene")
+SHCompressionMode = gsplat_scene.SHCompressionMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_generator(device, seed):
+    generator = torch.Generator(device=torch.device(device))
+    generator.manual_seed(seed)
+    return generator
+
+
+def _sh_compression_mode(sh_compression):
+    from gsplat_scene.sh_compression import SH_COMPRESSION_MAP
+
+    return SH_COMPRESSION_MAP[sh_compression]
+
+
+def _make_gaussians(N=100, sh_degree=None, device="cuda", seed=11):
+    """Create activated Gaussian parameters for testing."""
+    generator = _make_generator(device, seed)
+    means = torch.randn(N, 3, device=device, generator=generator)
+    quats = torch.randn(N, 4, device=device, generator=generator)
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales = (
+        torch.rand(N, 3, device=device, generator=generator) * 0.1 + 0.01
+    )  # positive (activated)
+    opacities = torch.rand(N, device=device, generator=generator)  # [0, 1] (activated)
+    if sh_degree is not None and sh_degree >= 0:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K, 3, device=device, generator=generator)
+    else:
+        colors = torch.rand(N, 3, device=device, generator=generator)
+    return means, quats, scales, opacities, colors
+
+
+def _make_gaussian_scene(N=100, sh_degree=None, device="cuda", seed=23):
+    """Build a GaussianScene with raw (log-space) splats."""
+    from gsplat_scene import GaussianScene
+
+    generator = _make_generator(device, seed)
+    means = torch.randn(N, 3, device=device, generator=generator)
+    quats = torch.randn(N, 4, device=device, generator=generator)
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales_raw = torch.randn(N, 3, device=device, generator=generator)  # log-space
+    opacities_raw = torch.randn(N, device=device, generator=generator)  # logit-space
+    if sh_degree is not None and sh_degree >= 0:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K, 3, device=device, generator=generator)
+    else:
+        colors = torch.rand(N, 3, device=device, generator=generator)
+    splats = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(means),
+            "quats": torch.nn.Parameter(quats),
+            "scales": torch.nn.Parameter(scales_raw),
+            "opacities": torch.nn.Parameter(opacities_raw),
+            "colors": torch.nn.Parameter(colors),
+        }
+    )
+    return GaussianScene.from_splats(splats, id="test_scene")
+
+
+def _make_packed_component(N=10, device="cuda"):
+    return {
+        "means_planar": torch.empty(3, N, dtype=torch.float32, device=device),
+        "qso_packed": torch.empty(N, 8, dtype=torch.float16, device=device),
+        "colors_packed": torch.empty(N, 4, dtype=torch.float16, device=device),
+        "sh_degree": -1,
+        "sh_compression_mode": SHCompressionMode.NONE,
+    }
+
+
+def _make_camera(device="cuda"):
+    viewmat = torch.eye(4, device=device)
+    viewmat[2, 3] = 3.0
+    K = torch.tensor(
+        [
+            [500.0, 0.0, 128.0],
+            [0.0, 500.0, 128.0],
+            [0.0, 0.0, 1.0],
+        ],
+        device=device,
+    )
+    return viewmat, K
+
+
+def _pack_scene_python(
+    means, quats, scales, opacities, colors, sh_degree, sh_compression="none"
+):
+    """Pack scene in Python matching the C++ scene packing contract."""
+    N = means.size(0)
+    means_planar = means.t().contiguous()
+    qso_packed = torch.empty(N, 8, dtype=torch.float16, device=means.device)
+    qso_packed[:, 0:4] = quats.half()
+    qso_packed[:, 4:7] = scales.half()
+    qso_packed[:, 7:8] = opacities.unsqueeze(1).half()
+
+    sh_deg = -1 if sh_degree is None else sh_degree
+    K_sh = colors.size(1) if colors.dim() == 3 else 0
+    if sh_deg >= 0 and K_sh == 16:
+        if sh_compression == "none":
+            colors_packed = colors.half()
+        elif sh_compression == "32b":
+            colors_packed = colors.contiguous().view(N, 48)
+        else:
+            colors_packed = colors.half().view(N, 48)
+    elif sh_deg >= 0 and K_sh > 0:
+        colors_packed = colors.contiguous()
+    else:
+        c = torch.zeros(N, 4, dtype=torch.float16, device=means.device)
+        c[:, 0:3] = colors.half()
+        colors_packed = c
+    return means_planar, qso_packed, colors_packed
+
+
+# ======================================================================
+# A. Smoke test for pack op
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_pack_op_smoke():
+    """pack_gaussian_inference_scene op is callable via gsplat_scene_cuda and produces no grad_fn."""
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    assert callable(_SCENE_CUDA.pack_gaussian_inference_scene)
+
+    # Verify CUDA dispatch by calling it
+    means, quats, scales, opacities, colors = _make_gaussians(N=10)
+    mp, qso_packed, cp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means, quats, scales, opacities, colors, -1, 0
+    )
+    assert mp.shape == (3, 10)
+    assert qso_packed.shape == (10, 8)
+    assert qso_packed.dtype == torch.float16
+
+    # Verify no grad_fn on outputs (torch::NoGradGuard in C++)
+    means_g = means.clone().requires_grad_(True)
+    mp_g, qso_packed_g, cp_g = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means_g, quats, scales, opacities, colors, -1, 0
+    )
+    assert mp_g.grad_fn is None
+
+
+# ======================================================================
+# B. Parity between Python packing and C++ pack op
+# ======================================================================
+
+_PARITY_PACK_CASES = [
+    # (sh_degree, sh_compression)
+    (None, "none"),  # pre-activated RGB
+    (0, "none"),  # SH degree 0
+    (1, "none"),  # SH degree 1
+    (2, "none"),  # SH degree 2
+    (3, "none"),  # SH degree 3, no compression
+    (3, "32b"),  # SH degree 3, 32b compression
+    (3, "16b"),  # SH degree 3, 16b compression
+]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("sh_degree,sh_compression", _PARITY_PACK_CASES)
+def test_pack_op_parity_with_python(sh_degree, sh_compression):
+    """C++ pack op must be bit-exact with Python packing (when values in fp16 range)."""
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    means, quats, scales, opacities, colors = _make_gaussians(
+        N=200, sh_degree=sh_degree
+    )
+
+    # Python packing with values in fp16 range by construction.
+    mp_py, qso_packed_py, cp_py = _pack_scene_python(
+        means, quats, scales, opacities, colors, sh_degree, sh_compression
+    )
+
+    # C++ packing
+    sh_deg = -1 if sh_degree is None else sh_degree
+    sh_compression_mode = _sh_compression_mode(sh_compression)
+    mp_cpp, qso_packed_cpp, cp_cpp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means, quats, scales, opacities, colors, sh_deg, int(sh_compression_mode)
+    )
+
+    torch.testing.assert_close(
+        mp_cpp, mp_py, atol=0, rtol=0, msg="means_planar mismatch"
+    )
+    torch.testing.assert_close(
+        qso_packed_cpp, qso_packed_py, atol=0, rtol=0, msg="qso_packed mismatch"
+    )
+    torch.testing.assert_close(
+        cp_cpp, cp_py, atol=0, rtol=0, msg="colors_packed mismatch"
+    )
+
+
+# ======================================================================
+# C. Constructor detach-and-warn tests
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_detach_no_grad_no_warning():
+    """All inputs grad-free: no RuntimeWarning, packed tensors grad-free."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+    runtime_warns = [x for x in w if issubclass(x.category, RuntimeWarning)]
+    assert len(runtime_warns) == 0, f"unexpected warnings: {runtime_warns}"
+    assert not scene.means_planar.requires_grad
+    assert not scene.qso_packed.requires_grad
+    assert not scene.colors_packed.requires_grad
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_detach_with_grad_warns():
+    """Some inputs grad=True: single RuntimeWarning naming affected tensors."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    means_g = means.clone().requires_grad_(True)
+    scales_g = scales.clone().requires_grad_(True)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means_g,
+            quats,
+            scales_g,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+    runtime_warns = [x for x in w if issubclass(x.category, RuntimeWarning)]
+    assert len(runtime_warns) >= 1
+    msg = str(runtime_warns[0].message)
+    assert "means" in msg
+    assert "scales" in msg
+    assert "detached grad-tracked inputs" in msg
+
+    # Packed tensors must be grad-free
+    assert not scene.means_planar.requires_grad
+    assert not scene.qso_packed.requires_grad
+    assert not scene.colors_packed.requires_grad
+
+    # Bit-exact vs explicit detach
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        scene2 = GaussianInferenceScene.from_gaussian_tensors(
+            means_g.detach(),
+            quats,
+            scales_g.detach(),
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test2",
+        )
+    torch.testing.assert_close(scene.means_planar, scene2.means_planar, atol=0, rtol=0)
+    torch.testing.assert_close(scene.qso_packed, scene2.qso_packed, atol=0, rtol=0)
+    torch.testing.assert_close(
+        scene.colors_packed, scene2.colors_packed, atol=0, rtol=0
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_pack_op_with_grad_no_grad_fn():
+    """Direct pack op with grad-tracked input: no grad_fn on outputs."""
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=20)
+    means_g = means.clone().requires_grad_(True)
+    mp, qso_packed, cp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means_g, quats, scales, opacities, colors, -1, 0
+    )
+    assert mp.grad_fn is None
+    assert qso_packed.grad_fn is None
+    assert cp.grad_fn is None
+
+
+# ======================================================================
+# D. Distributed rejection test
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_distributed_rejection_from_gaussian_scene():
+    """from_gaussian_scene raises RuntimeError when world_size > 1."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = _make_gaussian_scene(N=50)
+
+    # Simulate distributed init with world_size=1 via file store
+    import os
+    import tempfile
+
+    tmpfile = tempfile.NamedTemporaryFile(delete=False)
+    tmpfile.close()
+    try:
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29501"
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(
+                backend="gloo",
+                rank=0,
+                world_size=1,
+                init_method=f"file://{tmpfile.name}",
+            )
+
+        # world_size=1 should NOT raise
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            inference_scene = GaussianInferenceScene.from_gaussian_scene(
+                scene, id="test", sh_compression="none"
+            )
+            assert not inference_scene.is_empty()
+
+        # Simulate a multi-rank process group.
+        orig_ws = torch.distributed.get_world_size
+        try:
+            torch.distributed.get_world_size = lambda: 2
+            with pytest.raises(RuntimeError, match="not supported under distributed"):
+                GaussianInferenceScene.from_gaussian_scene(
+                    scene, id="test2", sh_compression="none"
+                )
+        finally:
+            torch.distributed.get_world_size = orig_ws
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+        try:
+            os.unlink(tmpfile.name)
+        except FileNotFoundError:
+            pass
+        for key in ("MASTER_ADDR", "MASTER_PORT"):
+            os.environ.pop(key, None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_tensors_no_distributed_check():
+    """from_gaussian_tensors has no distributed check."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+
+    # This should succeed regardless of distributed state
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=None,
+        sh_compression="none",
+        id="test",
+    )
+    assert not scene.is_empty()
+
+
+# ======================================================================
+# E. fp16 clamp/warn tests
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fp16_all_safe_no_warning():
+    """All-safe: no warning, packed values bit-exact to simple fp16 cast."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+    runtime_warns = [x for x in w if issubclass(x.category, RuntimeWarning)]
+    assert len(runtime_warns) == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fp16_one_lane_exceeds():
+    """One lane > fp16 max: single RuntimeWarning, packed value = fp16 max."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    fp16_max = torch.finfo(torch.float16).max
+
+    # Set one scale value beyond fp16 range
+    scales[0, 0] = fp16_max + 1000.0
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+    runtime_warns = [x for x in w if issubclass(x.category, RuntimeWarning)]
+    assert len(runtime_warns) == 1
+    msg = str(runtime_warns[0].message)
+    assert "scales" in msg
+    assert "clamped 1 elements" in msg
+
+    # Verify the packed value is clamped to fp16 max
+    # Inference lanes 4-7 are scales; check first Gaussian, first scale dim
+    packed_scale_0 = scene.qso_packed[0, 4].float().item()
+    assert packed_scale_0 == pytest.approx(fp16_max, rel=1e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fp16_many_lanes_exceed():
+    """Many lanes > fp16 max: warning still single-shot, count accurate."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    fp16_max = torch.finfo(torch.float16).max
+
+    # Set 10 scale values beyond fp16 range
+    scales[:5, :2] = fp16_max + 5000.0  # 10 elements total
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+    runtime_warns = [x for x in w if issubclass(x.category, RuntimeWarning)]
+    assert len(runtime_warns) == 1
+    msg = str(runtime_warns[0].message)
+    assert "scales" in msg
+    assert "clamped 10 elements" in msg
+
+
+# ======================================================================
+# F. Activation-contract validation tests
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_activation_non_positive_scales():
+    """Non-positive scales: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    scales[0, 0] = -0.1
+
+    with pytest.raises(ValueError, match="scales contain non-positive values"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_activation_opacities_out_of_range():
+    """Opacities outside [0,1]: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    opacities[0] = 1.5
+
+    with pytest.raises(ValueError, match="opacities outside \\[0, 1\\]"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_activation_nan_inf():
+    """NaN/Inf in tensor: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    means[0, 0] = float("nan")
+
+    with pytest.raises(ValueError, match="contains NaN or Inf"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    colors[0, 0] = float("inf")
+
+    with pytest.raises(ValueError, match="contains NaN or Inf"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_activation_nan_inf_non_contiguous_tensor():
+    """Activation validation should report non-finite values in non-contiguous tensors."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, _ = _make_gaussians(N=50)
+    colors = torch.rand(3, 50, device="cuda", generator=_make_generator("cuda", 37)).t()
+    assert not colors.is_contiguous()
+    colors[0, 0] = float("inf")
+
+    with pytest.raises(ValueError, match="contains NaN or Inf"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_activation_invalid_sh_compression():
+    """Invalid sh_compression: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+
+    with pytest.raises(ValueError, match="sh_compression must be one of"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="invalid",
+            id="test",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_skips_activation_checks():
+    """from_gaussian_scene not affected by activation checks (raw negative scales ok)."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = _make_gaussian_scene(N=50)
+    # Raw scales may be negative (log-space). from_gaussian_scene applies exp()
+    # internally, so activation checks should be skipped.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        inference_scene = GaussianInferenceScene.from_gaussian_scene(
+            scene, id="test", sh_compression="none"
+        )
+        assert not inference_scene.is_empty()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_rgb_uses_safe_default_compression():
+    """RGB scenes should convert without explicitly overriding sh_compression."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = _make_gaussian_scene(N=50)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        inference_scene = GaussianInferenceScene.from_gaussian_scene(scene, id="test")
+
+    assert inference_scene.sh_degree == -1
+    assert inference_scene.sh_compression_mode is SHCompressionMode.NONE
+    assert inference_scene.colors_packed.shape == (50, 4)
+    assert inference_scene.colors_packed.dtype == torch.float16
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_concatenates_sh0_shn():
+    """GaussianScene with sh0/shN but no colors should preserve all SH coefficients."""
+    from gsplat_scene import GaussianInferenceScene, GaussianScene
+
+    N = 20
+    generator = _make_generator("cuda", 41)
+    means = torch.randn(N, 3, device="cuda", generator=generator)
+    quats = torch.randn(N, 4, device="cuda", generator=generator)
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales_raw = torch.randn(N, 3, device="cuda", generator=generator)
+    opacities_raw = torch.randn(N, device="cuda", generator=generator)
+    colors = torch.randn(N, 9, 3, device="cuda", generator=generator)
+    splats = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(means),
+            "quats": torch.nn.Parameter(quats),
+            "scales": torch.nn.Parameter(scales_raw),
+            "opacities": torch.nn.Parameter(opacities_raw),
+            "sh0": torch.nn.Parameter(colors[:, :1]),
+            "shN": torch.nn.Parameter(colors[:, 1:]),
+        }
+    )
+    scene = GaussianScene.from_splats(splats, id="sh_scene")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        inference_scene = GaussianInferenceScene.from_gaussian_scene(scene, id="test")
+
+    assert inference_scene.sh_degree == 2
+    assert inference_scene.colors_packed.shape == (N, 9, 3)
+    assert inference_scene.colors_packed.dtype == torch.float32
+    torch.testing.assert_close(inference_scene.colors_packed, colors, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_normalizes_non_unit_quats():
+    """Raw GaussianScene quaternions need not already be unit length."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = _make_gaussian_scene(N=30)
+    raw_quats = scene.splats["quats"].detach().clone() * 3.0
+    scene.splats["quats"].data.copy_(raw_quats)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        inference_scene = GaussianInferenceScene.from_gaussian_scene(scene, id="test")
+
+    expected = raw_quats / raw_quats.norm(dim=1, keepdim=True)
+    torch.testing.assert_close(
+        inference_scene.qso_packed[:, :4], expected.half(), atol=0, rtol=0
+    )
+
+
+# ======================================================================
+# G. Scene state error tests
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_put_duplicate_name():
+    """Duplicate put() name: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=10)
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    mp, qso_packed, cp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means, quats, scales, opacities, colors, -1, 0
+    )
+
+    scene = GaussianInferenceScene("test")
+    component = {
+        "means_planar": mp,
+        "qso_packed": qso_packed,
+        "colors_packed": cp,
+        "sh_degree": -1,
+        "sh_compression_mode": SHCompressionMode.NONE,
+    }
+    scene.put("comp1", component)
+
+    with pytest.raises(ValueError, match="already present in GaussianInferenceScene"):
+        scene.put("comp1", component)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_put_empty_name():
+    """Empty put() name: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = GaussianInferenceScene("test")
+    with pytest.raises(ValueError, match="component name must not be empty"):
+        scene.put("", {"means_planar": None})
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_put_rejects_non_contiguous_packed_tensors():
+    """Packed scene tensors must satisfy the render-time layout contract."""
+    from gsplat_scene import GaussianInferenceScene
+
+    n = 10
+    component = {
+        "means_planar": torch.empty(n, 3, device="cuda").t(),
+        "qso_packed": torch.empty(n, 8, dtype=torch.float16, device="cuda"),
+        "colors_packed": torch.empty(n, 4, dtype=torch.float16, device="cuda"),
+        "sh_degree": -1,
+        "sh_compression_mode": SHCompressionMode.NONE,
+    }
+
+    assert not component["means_planar"].is_contiguous()
+    scene = GaussianInferenceScene("test")
+    with pytest.raises(ValueError, match="means_planar must be contiguous"):
+        scene.put("comp", component)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "case,match",
+    [
+        ("means_shape", "means_planar must have shape"),
+        ("qso_packed_shape", "qso_packed must have shape"),
+        ("colors_rows", "colors_packed.shape\\[0\\] must match"),
+        ("means_dtype", "means_planar must have dtype"),
+        ("colors_device", "colors_packed device"),
+    ],
+)
+def test_put_rejects_bad_packed_tensor_invariants(case, match):
+    """put() validates packed shapes, devices, and dtypes before storing state."""
+    from gsplat_scene import GaussianInferenceScene
+
+    component = _make_packed_component(N=10)
+    override = {
+        "means_shape": {
+            "means_planar": torch.empty(10, 3, dtype=torch.float32, device="cuda")
+        },
+        "qso_packed_shape": {
+            "qso_packed": torch.empty(10, 7, dtype=torch.float16, device="cuda")
+        },
+        "colors_rows": {
+            "colors_packed": torch.empty(11, 4, dtype=torch.float16, device="cuda")
+        },
+        "means_dtype": {
+            "means_planar": torch.empty(3, 10, dtype=torch.float16, device="cuda")
+        },
+        "colors_device": {"colors_packed": torch.empty(10, 4, dtype=torch.float16)},
+    }[case]
+    component.update(override)
+    scene = GaussianInferenceScene("test")
+
+    with pytest.raises((TypeError, ValueError), match=match):
+        scene.put("comp", component)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_get_unknown_component():
+    """Unknown get() component: KeyError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=10)
+
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=None,
+        sh_compression="none",
+        id="test",
+    )
+
+    with pytest.raises(KeyError):
+        scene.get("nonexistent")
+
+    with pytest.raises(KeyError):
+        scene.get(99)
+
+
+# ======================================================================
+# H. Parity between two classmethods
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_classmethod_parity():
+    """from_gaussian_scene and from_gaussian_tensors with manual activation must be bit-exact."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = _make_gaussian_scene(N=100)
+    splats = scene.splats
+
+    # from_gaussian_scene (auto-activates)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        inference_a = GaussianInferenceScene.from_gaussian_scene(
+            scene, id="test_a", sh_compression="none"
+        )
+
+    # from_gaussian_tensors (manual activation)
+    means = splats["means"].detach()
+    quats = splats["quats"].detach()
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales = splats["scales"].detach().exp()
+    opacities = splats["opacities"].detach().sigmoid()
+    colors = splats["colors"].detach()
+
+    inference_b = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=None,
+        sh_compression="none",
+        id="test_b",
+    )
+
+    torch.testing.assert_close(
+        inference_a.means_planar,
+        inference_b.means_planar,
+        atol=0,
+        rtol=0,
+        msg="means_planar mismatch between classmethods",
+    )
+    torch.testing.assert_close(
+        inference_a.qso_packed,
+        inference_b.qso_packed,
+        atol=0,
+        rtol=0,
+        msg="qso_packed mismatch between classmethods",
+    )
+    torch.testing.assert_close(
+        inference_a.colors_packed,
+        inference_b.colors_packed,
+        atol=0,
+        rtol=0,
+        msg="colors_packed mismatch between classmethods",
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_classmethod_parity_sh3():
+    """from_gaussian_scene and from_gaussian_tensors parity with SH degree 3."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = _make_gaussian_scene(N=100, sh_degree=3)
+    splats = scene.splats
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        inference_a = GaussianInferenceScene.from_gaussian_scene(
+            scene, id="test_a", sh_compression="32b"
+        )
+
+    means = splats["means"].detach()
+    quats = splats["quats"].detach()
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales = splats["scales"].detach().exp()
+    opacities = splats["opacities"].detach().sigmoid()
+    colors = splats["colors"].detach()
+
+    inference_b = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=3,
+        sh_compression="32b",
+        id="test_b",
+    )
+
+    torch.testing.assert_close(
+        inference_a.means_planar, inference_b.means_planar, atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        inference_a.qso_packed, inference_b.qso_packed, atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        inference_a.colors_packed, inference_b.colors_packed, atol=0, rtol=0
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "sh_compression,expected_mode,expected_dtype,expected_shape",
+    [
+        ("none", SHCompressionMode.NONE, torch.float16, (40, 16, 3)),
+        ("32b", SHCompressionMode.PACKED_32B, torch.float32, (40, 48)),
+        ("16b", SHCompressionMode.PACKED_16B, torch.float16, (40, 48)),
+    ],
+)
+def test_sh3_compression_metadata_layout_and_values(
+    sh_compression, expected_mode, expected_dtype, expected_shape
+):
+    """GaussianInferenceScene records SH3 mode metadata and mode-specific layouts."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=40, sh_degree=3)
+
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=3,
+        sh_compression=sh_compression,
+        id="test",
+    )
+
+    assert scene.sh_degree == 3
+    assert scene.sh_compression_mode is expected_mode
+    assert scene.colors_packed.dtype == expected_dtype
+    assert scene.colors_packed.shape == expected_shape
+
+    component = scene.get("test")
+    assert component["sh_degree"] == 3
+    assert component["sh_compression_mode"] is expected_mode
+    assert component["colors_packed"].dtype == expected_dtype
+    assert component["colors_packed"].shape == expected_shape
+
+    if sh_compression == "none":
+        expected = colors.half()
+    elif sh_compression == "32b":
+        expected = colors.contiguous().view(40, 48)
+    else:
+        expected = colors.half().view(40, 48)
+    torch.testing.assert_close(scene.colors_packed, expected, atol=0, rtol=0)
+
+
+# ======================================================================
+# I. is_empty / release tests
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_is_empty_and_release():
+    """After construction: not empty. After release: empty. Release is idempotent."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=None,
+        sh_compression="none",
+        id="test",
+    )
+
+    # After construction
+    assert not scene.is_empty()
+    assert scene.num_gaussians == 50
+
+    # After release
+    scene.release()
+    assert scene.is_empty()
+    assert scene.num_gaussians == 0
+    assert scene.means_planar is None
+    assert scene.qso_packed is None
+    assert scene.colors_packed is None
+    assert scene.component_names == []
+    assert scene.component_index.shape == (0,)
+
+    # Idempotent
+    scene.release()
+    assert scene.is_empty()
+
+
+def test_zero_length_component_is_empty_and_replaceable():
+    """Zero-length packed components should behave like an empty scene."""
+    from gsplat_scene import GaussianInferenceScene
+
+    scene = GaussianInferenceScene("test")
+    scene.put("empty", _make_packed_component(N=0, device="cpu"))
+
+    assert scene.is_empty()
+    assert scene.num_gaussians == 0
+
+    scene.put("nonempty", _make_packed_component(N=2, device="cpu"))
+
+    assert not scene.is_empty()
+    assert scene.num_gaussians == 2
+    assert scene.component_names == ["nonempty"]
+    torch.testing.assert_close(scene.component_index, torch.zeros(2, dtype=torch.long))
+
+
+# ======================================================================
+# J. Parity between one-shot and packed-scene APIs
+# ======================================================================
+
+_RENDER_PARITY_CASES = [
+    # (sh_degree, sh_compression)
+    (None, "none"),  # RGB
+    (1, "none"),  # SH1
+    (3, "none"),  # SH3, no compression
+    (3, "32b"),  # SH3, 32b compression
+    (3, "16b"),  # SH3, 16b compression
+]
+
+
+@pytest.mark.skip(reason="experimental.render not available in this repo")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("sh_degree,sh_compression", _RENDER_PARITY_CASES)
+def test_render_parity_cpp_packed_vs_python_packed(sh_degree, sh_compression):
+    """Pack with C++ op, render via gaussian_render_inference_only, compare with Python packing."""
+    from experimental.render.kernels._backend import _C  # noqa: F401
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    width, height = 256, 256
+    means, quats, scales, opacities, colors = _make_gaussians(
+        N=200, sh_degree=sh_degree
+    )
+    viewmat, K = _make_camera()
+
+    sh_deg = -1 if sh_degree is None else sh_degree
+    sh_compression_mode = _sh_compression_mode(sh_compression)
+
+    # Python-packed reference path
+    means_planar_py, qso_packed_py, colors_packed_py = _pack_scene_python(
+        means, quats, scales, opacities, colors, sh_degree, sh_compression
+    )
+
+    with torch.no_grad():
+        renders_py, alphas_py = torch.ops.experimental.gaussian_render_inference_only(
+            means_planar_py,
+            qso_packed_py,
+            colors_packed_py,
+            viewmat,
+            K,
+            width,
+            height,
+            sh_deg,
+            16,
+            0.01,
+            1e10,
+            0.0,
+            0.3,
+            int(sh_compression_mode),
+            None,
+        )
+
+    # Pack with C++ op
+    mp, qso_packed, cp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means, quats, scales, opacities, colors, sh_deg, int(sh_compression_mode)
+    )
+
+    # Render with C++-packed scene
+    with torch.no_grad():
+        renders_new, alphas_new = torch.ops.experimental.gaussian_render_inference_only(
+            mp,
+            qso_packed,
+            cp,
+            viewmat,
+            K,
+            width,
+            height,
+            sh_deg,
+            16,
+            0.01,
+            1e10,
+            0.0,
+            0.3,
+            int(sh_compression_mode),
+            None,
+        )
+
+    torch.testing.assert_close(
+        renders_new, renders_py, atol=0, rtol=0, msg="renders mismatch"
+    )
+    torch.testing.assert_close(
+        alphas_new, alphas_py, atol=0, rtol=0, msg="alphas mismatch"
+    )
+
+
+# ======================================================================
+# Additional: Multi-component put/get test
+# ======================================================================
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_multi_component_put_get():
+    """Multiple components can be put and retrieved correctly."""
+    from gsplat_scene import GaussianInferenceScene
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    N1, N2 = 30, 50
+    means1, quats1, scales1, opacities1, colors1 = _make_gaussians(N=N1)
+    means2, quats2, scales2, opacities2, colors2 = _make_gaussians(N=N2)
+
+    mp1, qso_packed1, cp1 = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means1, quats1, scales1, opacities1, colors1, -1, 0
+    )
+    mp2, qso_packed2, cp2 = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means2, quats2, scales2, opacities2, colors2, -1, 0
+    )
+
+    scene = GaussianInferenceScene("multi")
+    scene.put(
+        "comp_a",
+        {
+            "means_planar": mp1,
+            "qso_packed": qso_packed1,
+            "colors_packed": cp1,
+            "sh_degree": -1,
+            "sh_compression_mode": SHCompressionMode.NONE,
+        },
+    )
+    scene.put(
+        "comp_b",
+        {
+            "means_planar": mp2,
+            "qso_packed": qso_packed2,
+            "colors_packed": cp2,
+            "sh_degree": -1,
+            "sh_compression_mode": SHCompressionMode.NONE,
+        },
+    )
+
+    assert scene.num_gaussians == N1 + N2
+    assert scene.means_planar.shape == (3, N1 + N2)
+    assert scene.qso_packed.shape == (N1 + N2, 8)
+
+    # Get by name
+    comp_a = scene.get("comp_a")
+    assert comp_a["name"] == "comp_a"
+    assert comp_a["index"] == 0
+    assert comp_a["qso_packed"].shape == (N1, 8)
+    torch.testing.assert_close(comp_a["qso_packed"], qso_packed1, atol=0, rtol=0)
+
+    # Get by index
+    comp_b = scene.get(1)
+    assert comp_b["name"] == "comp_b"
+    assert comp_b["qso_packed"].shape == (N2, 8)
+    torch.testing.assert_close(comp_b["qso_packed"], qso_packed2, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_rejects_app_opt():
+    """from_gaussian_scene raises ValueError for scenes with 'features'."""
+    from gsplat_scene import GaussianInferenceScene, GaussianScene
+
+    N = 20
+    generator = _make_generator("cuda", 51)
+    means = torch.randn(N, 3, device="cuda", generator=generator)
+    quats = torch.randn(N, 4, device="cuda", generator=generator)
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales_raw = torch.randn(N, 3, device="cuda", generator=generator)
+    opacities_raw = torch.randn(N, device="cuda", generator=generator)
+    colors = torch.rand(N, 3, device="cuda", generator=generator)
+    features = torch.randn(N, 32, device="cuda", generator=generator)
+    splats = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(means),
+            "quats": torch.nn.Parameter(quats),
+            "scales": torch.nn.Parameter(scales_raw),
+            "opacities": torch.nn.Parameter(opacities_raw),
+            "colors": torch.nn.Parameter(colors),
+            "features": torch.nn.Parameter(features),
+        }
+    )
+    scene = GaussianScene.from_splats(splats, id="app_opt_scene")
+
+    with pytest.raises(ValueError, match="appearance-optimized"):
+        GaussianInferenceScene.from_gaussian_scene(scene, id="test")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_activation_non_unit_quats():
+    """Non-unit-norm quaternions: ValueError."""
+    from gsplat_scene import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N=50)
+    quats = quats * 5.0  # break unit-norm
+
+    with pytest.raises(ValueError, match="quats are not unit-norm"):
+        GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_nan_input_raises():
+    """from_gaussian_scene raises ValueError when activation produces Inf."""
+    from gsplat_scene import GaussianInferenceScene, GaussianScene
+
+    N = 20
+    generator = _make_generator("cuda", 53)
+    means = torch.randn(N, 3, device="cuda", generator=generator)
+    quats = torch.randn(N, 4, device="cuda", generator=generator)
+    scales_raw = torch.randn(N, 3, device="cuda", generator=generator)
+    scales_raw[0, 0] = 1e6  # exp(1e6) = Inf
+    opacities_raw = torch.randn(N, device="cuda", generator=generator)
+    colors = torch.rand(N, 3, device="cuda", generator=generator)
+    splats = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(means),
+            "quats": torch.nn.Parameter(quats),
+            "scales": torch.nn.Parameter(scales_raw),
+            "opacities": torch.nn.Parameter(opacities_raw),
+            "colors": torch.nn.Parameter(colors),
+        }
+    )
+    scene = GaussianScene.from_splats(splats, id="nan_scene")
+
+    with pytest.raises(ValueError, match="contains NaN or Inf after activation"):
+        GaussianInferenceScene.from_gaussian_scene(scene, id="test")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_quat_column_order_wxyz():
+    """Packed qso quaternion columns preserve wxyz input order."""
+    from gsplat_scene import GaussianInferenceScene
+
+    N = 5
+    quats = torch.tensor([[1.0, 2.0, 3.0, 4.0]] * N, device="cuda")
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    means = torch.randn(N, 3, device="cuda", generator=_make_generator("cuda", 55))
+    scales = (
+        torch.rand(N, 3, device="cuda", generator=_make_generator("cuda", 56)) + 0.01
+    )
+    opacities = torch.rand(N, device="cuda", generator=_make_generator("cuda", 57))
+    colors = torch.rand(N, 3, device="cuda", generator=_make_generator("cuda", 58))
+
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=None,
+        sh_compression="none",
+        id="test",
+    )
+
+    torch.testing.assert_close(
+        scene.qso_packed[:, :4],
+        quats.half(),
+        atol=0,
+        rtol=0,
+        msg="qso_packed quaternion columns must preserve wxyz order",
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_from_gaussian_scene_rejects_multi_component():
+    """from_gaussian_scene raises ValueError for multi-component scenes."""
+    from gsplat_scene import GaussianInferenceScene, GaussianScene
+
+    N = 20
+    generator = _make_generator("cuda", 61)
+    means = torch.randn(N, 3, device="cuda", generator=generator)
+    quats = torch.randn(N, 4, device="cuda", generator=generator)
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales_raw = torch.randn(N, 3, device="cuda", generator=generator)
+    opacities_raw = torch.randn(N, device="cuda", generator=generator)
+    colors = torch.rand(N, 3, device="cuda", generator=generator)
+    splats = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(means),
+            "quats": torch.nn.Parameter(quats),
+            "scales": torch.nn.Parameter(scales_raw),
+            "opacities": torch.nn.Parameter(opacities_raw),
+            "colors": torch.nn.Parameter(colors),
+        }
+    )
+    scene = GaussianScene.from_splats(splats, id="first")
+
+    means2 = torch.randn(10, 3, device="cuda", generator=generator)
+    quats2 = torch.randn(10, 4, device="cuda", generator=generator)
+    quats2 = quats2 / quats2.norm(dim=1, keepdim=True)
+    scales2 = torch.randn(10, 3, device="cuda", generator=generator)
+    opacities2 = torch.randn(10, device="cuda", generator=generator)
+    colors2 = torch.rand(10, 3, device="cuda", generator=generator)
+    splats2 = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(means2),
+            "quats": torch.nn.Parameter(quats2),
+            "scales": torch.nn.Parameter(scales2),
+            "opacities": torch.nn.Parameter(opacities2),
+            "colors": torch.nn.Parameter(colors2),
+        }
+    )
+    scene.put("second", splats2)
+
+    with pytest.raises(ValueError, match="multi-component"):
+        GaussianInferenceScene.from_gaussian_scene(scene, id="test")

--- a/libs/scene/design.md
+++ b/libs/scene/design.md
@@ -1,5 +1,103 @@
 # Scene Design
 
+## Scene Types
+
+`GaussianScene` is the training-oriented Gaussian container. It owns the
+parameter dictionary used by optimizer and strategy code (`means`, `quats`,
+`scales`, `opacities`, and either RGB or SH color tensors) and keeps those
+tensors in the source representation expected by training paths. Topology hooks
+mutate this owned state when gaussians are duplicated, split, removed,
+relocated, sampled, or permuted.
+
+`GaussianInferenceScene` is the packed QSO inference container. It owns detached
+render-time tensors in viewer/kernel layout: planar means, packed
+quaternion/scale/opacity (`qso_packed`), packed colors, SH metadata, and
+component indexing. It can be built from a `GaussianScene` or from already
+activated tensors, then used by inference render paths that expect packed
+storage. The conversion boundary is one-way: training code owns the
+editable Gaussian parameters, while inference scenes own compact packed tensors
+and do not participate in autograd.
+
+### Scene Type Summary
+
+| Scene Type                 | Representation           | Tensor Layout                         | Typical Use                  |
+| -------------------------- | ------------------------ | ------------------------------------- | ---------------------------- |
+| `GaussianScene`            | Raw log-space parameters | `splats` ParameterDict, row-aligned N | Training, optimization       |
+| `GaussianInferenceScene`   | Activated, packed QSO    | `means_planar` [3,N], `qso_packed` [N,8] fp16, `colors_packed` varies | Inference rendering  |
+
+Supported conversions:
+
+- `GaussianScene` → `GaussianInferenceScene` via `from_gaussian_scene()` (one-way, single-component only)
+- Raw tensors → `GaussianInferenceScene` via `from_gaussian_tensors()` (pre-activated inputs)
+- `GaussianInferenceScene` → training scene: not supported (the conversion boundary is one-way)
+
+## Module Layout
+
+```text
+libs/scene/
+  design.md
+  __init__.py
+  pyproject.toml
+  sh_compression.py
+  test_package_imports.py
+  kernels/
+    __init__.py
+    _backend.py
+    gaussian_inference_ops.py
+    cuda/
+      __init__.py
+      build.py
+      ext.cpp
+      csrc/
+        gaussian_scene_pack.cpp
+        gaussian_scene_pack.cuh
+  functional/
+    __init__.py
+    gaussian_inference.py
+    test_gaussian_inference.py
+  components/
+    __init__.py
+    base.py
+    gaussian_scene.py
+    gaussian_inference_scene.py
+    test_gaussian_scene.py
+    test_gaussian_inference_scene.py
+```
+
+## Package Roles
+
+### `functional/`
+
+`functional/` is the public Python surface of the scene module.
+
+It exports scene operators such as `pack_gaussian_inference_scene` and defines the
+API-level contract for arguments, shapes, dtypes, and return values.  Downstream
+code should import from `gsplat_scene.functional`.
+
+### `kernels/`
+
+`kernels/` is the backend implementation layer.
+
+- `_backend.py` loads the `gsplat_scene_cuda` extension (prebuilt then JIT).
+- `gaussian_inference_ops.py` owns Python-level input validation and native dispatch.
+- `kernels/cuda/` contains `build.py`, `ext.cpp` (PYBIND11), and `csrc/*.cu`.
+
+`kernels/` is not a curated user-facing API.
+
+### `components/`
+
+Scene class implementations (`Scene`, `GaussianScene`, `GaussianInferenceScene`) and
+their tests.  Components call into `kernels/` for CUDA work.
+
+### Dependency direction
+
+```text
+functional/  ->  kernels/  ->  kernels/cuda/
+components/  ->  kernels/
+```
+
+Scene CUDA ops live in `libs/scene/kernels/`.
+
 ## Goal
 
 Provide a minimal shared scene abstraction for the current Gaussian-based paths in:
@@ -20,7 +118,8 @@ The scene code lives under:
 The package exports:
 
 ```python
-from gsplat_scene import Scene, GaussianScene
+from gsplat_scene import Scene, GaussianScene, GaussianInferenceScene, SHCompressionMode
+from gsplat_scene.functional import pack_gaussian_inference_scene
 ```
 
 ## Base `Scene`
@@ -191,18 +290,11 @@ class GaussianScene(Scene):
     def on_permute(self, order: torch.Tensor) -> None: ...
 ```
 
-Notably absent from the current implementation:
-
-- `set_component()`
-- `names()`
-- `items()`
-- a separate radiance API
-
 ### `put(name, splats)`
 
 `put()` adds a named component backed by a `torch.nn.ParameterDict`.
 
-Current behavior:
+Behavior:
 
 - the first `put()` stores the passed `ParameterDict` directly
 - later `put()` calls append rows by concatenating the existing splat tensors with the new component tensors
@@ -217,7 +309,7 @@ Errors raised:
 - `ValueError("component splats must not be empty")` if the `ParameterDict` is empty or missing `"means"`
 - the splat-key concatenation iterates over keys of the *existing* `splats`; new keys present in `component` but not in `self.splats` are silently dropped, and missing keys raise `KeyError` from the underlying `torch.cat`
 
-Current limitations:
+Limitations:
 
 - `put()` only accepts splats; signal cannot be added per-component (callers seed it via `from_splats(..., signal=...)`)
 - appended components must match the existing splat-key layout
@@ -243,6 +335,60 @@ Notes:
 - `GaussianScene` extends that by also accepting integer component ids
 - this is a selected subset, not a zero-copy writable scene view
 
+## `GaussianInferenceScene`
+
+`GaussianInferenceScene` is the packed inference container.
+
+```python
+class GaussianInferenceScene(Scene):
+    def __init__(self, id: str) -> None: ...
+
+    means_planar: Optional[Tensor]        # [3, N] float32 CUDA
+    qso_packed: Optional[Tensor]          # [N, 8] float16 CUDA
+    colors_packed: Optional[Tensor]       # varies by sh_degree/compression
+    sh_degree: Optional[int]
+    sh_compression_mode: Optional[SHCompressionMode]
+    num_gaussians: int
+    component_names: list[str]
+    component_index: Tensor
+```
+
+### `from_gaussian_scene(scene, *, id, sh_compression="none")`
+
+Builds an inference scene from a training `GaussianScene`. Applies activations
+automatically (`F.normalize` on quaternions, `.exp()` on scales, `.sigmoid()` on
+opacities). Rejects appearance-optimized scenes (those with `"features"` in
+splats) and multi-component scenes. Not supported under `torch.distributed` with
+`world_size > 1`.
+
+### `from_gaussian_tensors(means, quats, scales, opacities, colors, sh_degree, sh_compression, *, id)`
+
+Builds an inference scene from pre-activated tensors. Validates activation
+contracts: quaternions must be unit-norm (wxyz order), scales positive, opacities
+in `[0, 1]`, all values finite.
+
+### `put(name, component)`
+
+Adds a pre-packed component dict with keys `means_planar`, `qso_packed`,
+`colors_packed`, `sh_degree`, `sh_compression_mode`. Validates shapes, dtypes,
+devices, and consistency with existing components.
+
+### `get(component)`
+
+Returns a component view by name or integer index, including a boolean `mask`
+for indexing into the concatenated tensors.
+
+### `is_empty()` / `release()`
+
+`is_empty()` returns `True` when the scene has no packed tensors or zero
+gaussians. `release()` clears all packed state and resets to empty.
+
+Out of scope for this API:
+
+- topology mutation hooks
+- scene-owned rendering helpers
+- scene-owned optimizer logic
+
 ## Validation Rules
 
 `validate()` checks:
@@ -254,11 +400,11 @@ Notes:
 - `component_names` is non-empty when `splats` is non-empty
 - `component_index` stays within `[0, len(component_names))`
 
-The implementation currently relies on assertions for most invariant checks.
+Validation relies on assertions for most invariant checks.
 
 ## Scene Serialization
 
-`GaussianScene.state_dict()` currently returns:
+`GaussianScene.state_dict()` returns:
 
 ```python
 {
@@ -283,7 +429,7 @@ The implementation currently relies on assertions for most invariant checks.
 5. `component_index`
 6. validation
 
-Legacy behavior supported today:
+Compatibility defaults:
 
 - missing `component_names` defaults to `["scene"]`
 - missing `component_index` defaults to all zeros
@@ -333,7 +479,7 @@ Key points:
 - simple trainer also does not save `scene.state_dict()`
 - on checkpoint load, it rebuilds the scene as `GaussianScene.from_splats(runner.splats, id=...)`
 
-> ⚠️ **Persistence trade-off**: trainer checkpoints currently store only `splats + scene_id`, **not** `scene.state_dict()`. Restored scenes therefore lose:
+> Trainer checkpoints store only `splats + scene_id`, **not** `scene.state_dict()`. Restored scenes therefore lose:
 >
 > - any custom `signal` rows the trainer added during training
 > - multi-component bookkeeping (`component_names`, `component_index`)
@@ -344,7 +490,7 @@ Key points:
 
 `GaussianScene` provides hooks so `component_index` and `signal` stay aligned with `splats` during topology-changing operations.
 
-Current update rules are:
+Update rules:
 
 ### Duplicate
 
@@ -404,9 +550,30 @@ The trainer and render paths remain responsible for:
 
 That keeps the scene object focused on storage and bookkeeping.
 
-## Current Scope
+## Gaussian Inference SH Packing
 
-Included today:
+`GaussianInferenceScene` stores packed geometry in `qso_packed`: an `[N, 8]`
+float16 tensor with quaternion in columns 0-3, scale in columns 4-6, and opacity
+in column 7.
+
+`GaussianInferenceScene` stores the public `sh_compression` string as
+`SHCompressionMode` metadata: `NONE` = `"none"`, `PACKED_32B` = `"32b"`, and
+`PACKED_16B` = `"16b"`. Nonzero compression modes are valid only for SH degree
+3. The Python wrappers require this enum; the native C++ ABI still receives the
+corresponding integer value and validates it before casting to its local enum.
+
+For SH3, scene packing uses distinct `colors_packed` layouts:
+
+- `NONE` (`"none"`): `[N, 16, 3]` float16, preserving raw SH layout
+- `PACKED_32B` (`"32b"`): `[N, 48]` float32, flattening coefficients into 32-bit lanes
+- `PACKED_16B` (`"16b"`): `[N, 48]` float16, flattening coefficients into fp16 lanes
+
+RGB remains `[N, 4]` float16 with an alignment pad, and SH0-SH2 remain
+`[N, K, 3]` float32.
+
+## Supported Surface
+
+Standardized scene APIs:
 
 - minimal abstract `Scene`
 - concrete `GaussianScene`
@@ -415,11 +582,17 @@ Included today:
 - exclusive components via `component_index`
 - sidecar update hooks for topology changes
 - AV checkpoint evaluation support from saved splats
+- concrete `GaussianInferenceScene` with packed QSO layout
+- `SHCompressionMode` enum (`NONE`, `PACKED_32B`, `PACKED_16B`)
+- `pack_gaussian_inference_scene` functional operator
+- `put`/`get` multi-component assembly for inference scenes
 
-Explicitly not standardized yet:
+Out of scope:
 
 - hierarchical scene access
 - scene-owned rendering helpers
 - scene-owned optimizer logic
 - generalized component mutation APIs like `set_component()`
 - trainer checkpoint persistence of full `GaussianScene.state_dict()`
+- appearance-optimized (`features`) conversion to inference scenes
+- inference-to-training scene conversion (the one-way boundary)

--- a/libs/scene/functional/__init__.py
+++ b/libs/scene/functional/__init__.py
@@ -13,10 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[pytest]
-testpaths = tests libs/geometry/functional libs/scene/components libs/scene/functional libs/scene/test_package_imports.py libs/stage/components
-pythonpath = .
-env =
-    VERBOSE=1
-    BUILD_CAMERA_WRAPPERS=1
-    NUM_CHANNELS=1,3,4,5,8,24,32,128
+"""Public scene API: Gaussian scene packing operators."""
+
+__all__ = [
+    "pack_gaussian_inference_scene",
+]
+
+
+def __getattr__(name: str):
+    if name == "pack_gaussian_inference_scene":
+        from .gaussian_inference import pack_gaussian_inference_scene
+
+        globals()[name] = pack_gaussian_inference_scene
+        return pack_gaussian_inference_scene
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/scene/functional/gaussian_inference.py
+++ b/libs/scene/functional/gaussian_inference.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public functional API for Gaussian Inference scene operations."""
+
+from __future__ import annotations
+
+from torch import Tensor
+
+from ..sh_compression import SHCompressionMode
+from ..kernels.gaussian_inference_ops import (
+    pack_gaussian_inference_scene as _pack_gaussian_inference_scene,
+)
+
+
+def pack_gaussian_inference_scene(
+    means: Tensor,
+    quats: Tensor,
+    scales: Tensor,
+    opacities: Tensor,
+    colors: Tensor,
+    sh_degree: int,
+    sh_compression_mode: SHCompressionMode,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Pack activated Gaussian splat tensors into the inference-internal layout.
+
+    Converts from the standard training layout (one tensor per attribute, float32)
+    into the packed layout used by inference rendering:
+
+    - ``means_planar``: transposed to ``[3, N]`` for cache-friendly access patterns
+      in the render kernel.
+    - ``qso_packed``: ``[N, 8]`` float16 packing quaternion (cols 0-3), scale (cols 4-6),
+      and opacity (col 7).
+    - ``colors_packed``: dtype and layout depend on ``sh_degree`` and
+      ``sh_compression_mode`` (see below).
+
+    All inputs must be contiguous float32 CUDA tensors.  Activations must already
+    be applied: ``scales`` must be positive (``exp()`` applied), ``opacities`` must
+    be in ``[0, 1]`` (``sigmoid()`` applied).
+
+    Args:
+        means:               ``[N, 3]`` float32 CUDA — world-space positions.
+        quats:               ``[N, 4]`` float32 CUDA — unit quaternions in wxyz order.
+        scales:              ``[N, 3]`` float32 CUDA — positive scales (after ``exp()``).
+        opacities:           ``[N]`` float32 CUDA — opacities in ``[0, 1]``
+                             (after ``sigmoid()``).
+        colors:              ``[N, 3]`` float32 CUDA for RGB mode
+                             (``sh_degree == -1``), or ``[N, K, 3]`` float32 CUDA
+                             for SH mode (``sh_degree >= 0``).
+        sh_degree:           ``-1`` for RGB (no SH); ``0``–``3`` for SH coefficients.
+        sh_compression_mode: SH compression mode enum. ``NONE`` preserves
+                             raw SH3 layout in fp16, ``PACKED_32B`` flattens
+                             SH3 coefficients into float32 lanes, and
+                             ``PACKED_16B`` flattens them into fp16 lanes.
+
+    Returns:
+        A 3-tuple ``(means_planar, qso_packed, colors_packed)``:
+
+        - ``means_planar``: ``[3, N]`` float32.
+        - ``qso_packed``: ``[N, 8]`` float16.
+        - ``colors_packed``: ``[N, 4]`` float16 for RGB; ``[N, K, 3]`` float32
+          for SH0–2; ``[N, 16, 3]`` float16 for SH3 ``NONE``;
+          ``[N, 48]`` float32 for SH3 ``PACKED_32B``; ``[N, 48]``
+          float16 for SH3 ``PACKED_16B``.
+
+    Raises:
+        TypeError: if any tensor has the wrong Python type or dtype.
+        ValueError: if any tensor is on the wrong device, has the wrong shape, or
+            ``sh_degree`` / ``sh_compression_mode`` is out of range.
+    """
+    return _pack_gaussian_inference_scene(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree,
+        sh_compression_mode,
+    )

--- a/libs/scene/functional/test_gaussian_inference.py
+++ b/libs/scene/functional/test_gaussian_inference.py
@@ -1,0 +1,605 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functional tests for pack_gaussian_inference_scene.
+
+Run with:
+    pytest libs/scene/functional/test_gaussian_inference.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+gsplat_scene = pytest.importorskip("gsplat_scene")
+SHCompressionMode = gsplat_scene.SHCompressionMode
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+pytestmark = pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEVICE = "cuda"
+N = 128  # default Gaussian count for tests
+
+
+def _make_generator(device, seed):
+    generator = torch.Generator(device=torch.device(device))
+    generator.manual_seed(seed)
+    return generator
+
+
+def _make_inputs(
+    n: int = N,
+    sh_degree: int = -1,
+    dtype: torch.dtype = torch.float32,
+    device: str = DEVICE,
+    seed: int = 11,
+):
+    """Return a dict of valid activated Gaussian tensors."""
+    generator = _make_generator(device, seed)
+    means = torch.randn(n, 3, dtype=dtype, device=device, generator=generator)
+    quats = torch.randn(n, 4, dtype=dtype, device=device, generator=generator)
+    quats = quats / quats.norm(dim=-1, keepdim=True)  # unit quaternions
+    scales = (
+        torch.rand(n, 3, dtype=dtype, device=device, generator=generator) + 0.01
+    )  # positive
+    opacities = torch.sigmoid(
+        torch.randn(n, dtype=dtype, device=device, generator=generator)
+    )
+
+    if sh_degree == -1:
+        colors = torch.randn(n, 3, dtype=dtype, device=device, generator=generator)
+    else:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(n, K, 3, dtype=dtype, device=device, generator=generator)
+
+    return dict(
+        means=means,
+        quats=quats,
+        scales=scales,
+        opacities=opacities,
+        colors=colors,
+    )
+
+
+def _call(
+    n: int = N,
+    sh_degree: int = -1,
+    sh_compression_mode: SHCompressionMode = SHCompressionMode.NONE,
+    seed: int = 11,
+):
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(n=n, sh_degree=sh_degree, seed=seed)
+    return pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=sh_degree,
+        sh_compression_mode=sh_compression_mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Import test
+# ---------------------------------------------------------------------------
+
+
+def test_import():
+    from gsplat_scene.functional import pack_gaussian_inference_scene  # noqa: F401
+
+    assert callable(pack_gaussian_inference_scene)
+
+
+def test_import_from_kernels():
+    from gsplat_scene.kernels.gaussian_inference_ops import (
+        pack_gaussian_inference_scene,
+    )  # noqa: F401
+
+    assert callable(pack_gaussian_inference_scene)
+
+
+# ---------------------------------------------------------------------------
+# Output shapes
+# ---------------------------------------------------------------------------
+
+
+def test_means_planar_shape():
+    means_planar, qso_packed, _ = _call(N, sh_degree=-1)
+    assert means_planar.shape == (3, N), f"expected (3, {N}), got {means_planar.shape}"
+
+
+def test_qso_packed_shape():
+    _, qso_packed, _ = _call(N, sh_degree=-1)
+    assert qso_packed.shape == (N, 8), f"expected ({N}, 8), got {qso_packed.shape}"
+
+
+@pytest.mark.parametrize(
+    "sh_degree,sh_compression_mode",
+    [
+        (-1, SHCompressionMode.NONE),
+        (0, SHCompressionMode.NONE),
+        (1, SHCompressionMode.NONE),
+        (2, SHCompressionMode.NONE),
+        (3, SHCompressionMode.NONE),
+        (3, SHCompressionMode.PACKED_32B),
+        (3, SHCompressionMode.PACKED_16B),
+    ],
+)
+def test_shapes_all_valid_modes(sh_degree, sh_compression_mode):
+    means_planar, qso_packed, colors_packed = _call(
+        N, sh_degree=sh_degree, sh_compression_mode=sh_compression_mode
+    )
+    assert means_planar.shape == (3, N)
+    assert qso_packed.shape == (N, 8)
+    # colors_packed must have N rows on leading dim
+    assert colors_packed.shape[0] == N
+
+
+@pytest.mark.parametrize("n", [0, 1])
+@pytest.mark.parametrize(
+    "sh_degree,sh_compression_mode",
+    [
+        (-1, SHCompressionMode.NONE),
+        (0, SHCompressionMode.NONE),
+        (3, SHCompressionMode.PACKED_32B),
+    ],
+)
+def test_shapes_small_n_supported(n, sh_degree, sh_compression_mode):
+    means_planar, qso_packed, colors_packed = _call(
+        n, sh_degree=sh_degree, sh_compression_mode=sh_compression_mode
+    )
+    assert means_planar.shape == (3, n)
+    assert qso_packed.shape == (n, 8)
+    assert colors_packed.shape[0] == n
+
+
+# ---------------------------------------------------------------------------
+# Output dtypes
+# ---------------------------------------------------------------------------
+
+
+def test_means_planar_dtype():
+    means_planar, _, _ = _call(N, sh_degree=-1)
+    assert means_planar.dtype == torch.float32
+
+
+def test_qso_packed_dtype():
+    _, qso_packed, _ = _call(N, sh_degree=-1)
+    assert qso_packed.dtype == torch.float16
+
+
+def test_colors_rgb_dtype_and_shape():
+    """RGB mode: colors_packed should be [N, 4] float16."""
+    _, _, colors_packed = _call(
+        N, sh_degree=-1, sh_compression_mode=SHCompressionMode.NONE
+    )
+    assert colors_packed.dtype == torch.float16
+    assert colors_packed.shape == (N, 4)
+
+
+@pytest.mark.parametrize(
+    "sh_compression_mode,expected_dtype,expected_shape",
+    [
+        (SHCompressionMode.NONE, torch.float16, (N, 16, 3)),
+        (SHCompressionMode.PACKED_32B, torch.float32, (N, 48)),
+        (SHCompressionMode.PACKED_16B, torch.float16, (N, 48)),
+    ],
+)
+def test_colors_sh3_mode_dtype_and_shape(
+    sh_compression_mode, expected_dtype, expected_shape
+):
+    """SH3 compression modes must produce distinct color layouts."""
+    _, _, colors_packed = _call(N, sh_degree=3, sh_compression_mode=sh_compression_mode)
+    assert colors_packed.dtype == expected_dtype
+    assert colors_packed.shape == expected_shape
+
+
+@pytest.mark.parametrize("sh_compression_mode", list(SHCompressionMode))
+def test_colors_sh3_mode_values(sh_compression_mode):
+    """SH3 packing preserves values exactly except for fp16 modes' casts."""
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=3)
+    _, _, colors_packed = pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=3,
+        sh_compression_mode=sh_compression_mode,
+    )
+
+    if sh_compression_mode is SHCompressionMode.NONE:
+        expected = inp["colors"].to(torch.float16)
+    elif sh_compression_mode is SHCompressionMode.PACKED_32B:
+        expected = inp["colors"].contiguous().view(N, 48)
+    else:
+        expected = inp["colors"].to(torch.float16).view(N, 48)
+    torch.testing.assert_close(colors_packed, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("sh_degree", [0, 1, 2])
+def test_colors_low_sh_dtype(sh_degree):
+    """SH 0-2: colors_packed should be float32 (pass-through)."""
+    _, _, colors_packed = _call(
+        N, sh_degree=sh_degree, sh_compression_mode=SHCompressionMode.NONE
+    )
+    assert colors_packed.dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# Value correctness
+# ---------------------------------------------------------------------------
+
+
+def test_means_planar_is_transpose():
+    """means_planar must be the exact transpose of the input means."""
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    means_planar, _, _ = pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=-1,
+        sh_compression_mode=SHCompressionMode.NONE,
+    )
+    expected = inp["means"].t().contiguous()
+    assert torch.allclose(
+        means_planar, expected
+    ), "means_planar is not the transpose of means"
+
+
+def test_qso_packed_quats_columns():
+    """qso_packed columns 0-3 must round-trip quaternions through fp16 accurately."""
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    _, qso_packed, _ = pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=-1,
+        sh_compression_mode=SHCompressionMode.NONE,
+    )
+    qso_packed_quats = qso_packed[:, :4].float()
+    expected = inp["quats"].to(torch.float16).float()
+    assert torch.allclose(
+        qso_packed_quats, expected
+    ), "qso_packed quaternion columns mismatch"
+
+
+def test_qso_packed_scales_columns():
+    """qso_packed columns 4-6 must match scales clamped to fp16 range."""
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    _, qso_packed, _ = pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=-1,
+        sh_compression_mode=SHCompressionMode.NONE,
+    )
+    FP16_MAX = 65504.0
+    qso_packed_scales = qso_packed[:, 4:7].float()
+    expected = inp["scales"].clamp(-FP16_MAX, FP16_MAX).to(torch.float16).float()
+    assert torch.allclose(
+        qso_packed_scales, expected
+    ), "qso_packed scale columns mismatch"
+
+
+def test_qso_packed_opacity_column():
+    """qso_packed column 7 must match opacities cast to fp16."""
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    _, qso_packed, _ = pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=-1,
+        sh_compression_mode=SHCompressionMode.NONE,
+    )
+    qso_packed_opacity = qso_packed[:, 7].float()
+    expected = inp["opacities"].to(torch.float16).float()
+    assert torch.allclose(
+        qso_packed_opacity, expected
+    ), "qso_packed opacity column mismatch"
+
+
+def test_colors_rgb_padding_zero():
+    """RGB mode: the 4th channel (padding) in colors_packed must be 0."""
+    _, _, colors_packed = _call(
+        N, sh_degree=-1, sh_compression_mode=SHCompressionMode.NONE
+    )
+    padding = colors_packed[:, 3].float()
+    assert (padding == 0).all(), "RGB padding channel is not zero"
+
+
+# ---------------------------------------------------------------------------
+# fp16 clamping
+# ---------------------------------------------------------------------------
+
+
+def test_fp16_clamping_no_error():
+    """Scales above fp16 max are silently clamped; no exception raised."""
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    # Set one scale way above fp16 max
+    inp["scales"][0, 0] = 1e9
+    means_planar, qso_packed, colors_packed = pack_gaussian_inference_scene(
+        inp["means"],
+        inp["quats"],
+        inp["scales"],
+        inp["opacities"],
+        inp["colors"],
+        sh_degree=-1,
+        sh_compression_mode=SHCompressionMode.NONE,
+    )
+    # Should not raise; clamped value should equal fp16 max
+    FP16_MAX = torch.finfo(torch.float16).max
+    assert float(qso_packed[0, 4].float()) == pytest.approx(FP16_MAX, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Input validation errors (Python wrapper)
+# ---------------------------------------------------------------------------
+
+
+def test_error_cpu_tensor():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(ValueError, match="CUDA"):
+        pack_gaussian_inference_scene(
+            inp["means"].cpu(),
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=-1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_wrong_dtype():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(TypeError, match="float32"):
+        pack_gaussian_inference_scene(
+            inp["means"].to(torch.float16),
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=-1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_wrong_means_shape():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(ValueError, match="means"):
+        pack_gaussian_inference_scene(
+            inp["means"][:, :2],  # wrong last dim
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=-1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_invalid_sh_degree():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(ValueError, match="sh_degree"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=5,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_invalid_sh_compression_mode():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(TypeError, match="SHCompressionMode"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=-1,
+            sh_compression_mode=3,
+        )
+
+
+def test_error_non_tensor():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        pack_gaussian_inference_scene(
+            "not_a_tensor",
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=-1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_sh_degree_not_int():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(TypeError, match="sh_degree"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=1.0,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_rgb_colors_with_sh_degree():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(ValueError, match="requires colors to be 3D"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_wrong_sh_k():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=2)
+    inp["colors"] = inp["colors"][:, :4, :]
+    with pytest.raises(ValueError, match=r"requires colors shape .*9"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=2,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+@pytest.mark.parametrize("sh_degree", [-1, 0, 1, 2])
+@pytest.mark.parametrize(
+    "sh_compression_mode",
+    [SHCompressionMode.PACKED_32B, SHCompressionMode.PACKED_16B],
+)
+def test_error_compression_requires_sh3(sh_degree, sh_compression_mode):
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=sh_degree)
+    with pytest.raises(ValueError, match="requires sh_degree=3"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=sh_degree,
+            sh_compression_mode=sh_compression_mode,
+        )
+
+
+def test_error_rgb_mode_rejects_3d_colors():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=0)
+    with pytest.raises(ValueError, match="colors"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=-1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_sh_last_dim_must_be_three():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=0)
+    inp["colors"] = torch.randn(
+        N, 1, 4, device=DEVICE, generator=_make_generator(DEVICE, 29)
+    )
+    with pytest.raises(ValueError, match=r"requires colors shape .*1, 3"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"],
+            sh_degree=0,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+def test_error_colors_leading_dim_must_match_means():
+    from gsplat_scene.functional import pack_gaussian_inference_scene
+
+    inp = _make_inputs(N, sh_degree=-1)
+    with pytest.raises(ValueError, match="colors dim 0"):
+        pack_gaussian_inference_scene(
+            inp["means"],
+            inp["quats"],
+            inp["scales"],
+            inp["opacities"],
+            inp["colors"][:-1],
+            sh_degree=-1,
+            sh_compression_mode=SHCompressionMode.NONE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Device consistency
+# ---------------------------------------------------------------------------
+
+
+def test_output_on_cuda():
+    means_planar, qso_packed, colors_packed = _call(N, sh_degree=-1)
+    assert means_planar.device.type == "cuda"
+    assert qso_packed.device.type == "cuda"
+    assert colors_packed.device.type == "cuda"

--- a/libs/scene/kernels/__init__.py
+++ b/libs/scene/kernels/__init__.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[pytest]
-testpaths = tests libs/geometry/functional libs/scene/components libs/scene/functional libs/scene/test_package_imports.py libs/stage/components
-pythonpath = .
-env =
-    VERBOSE=1
-    BUILD_CAMERA_WRAPPERS=1
-    NUM_CHANNELS=1,3,4,5,8,24,32,128
+"""Backend implementation: extension loading and CUDA dispatch.
+
+This package is not a curated user-facing API. Prefer
+:mod:`gsplat_scene.functional` for scene operators. Submodules such as
+``kernels.gaussian_inference_ops`` remain importable for in-package use and tests.
+"""
+
+__all__: list[str] = []

--- a/libs/scene/kernels/_backend.py
+++ b/libs/scene/kernels/_backend.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load native scene CUDA ops, preferring prebuilt then JIT build."""
+
+from __future__ import annotations
+
+_SCENE_CUDA = None
+
+try:
+    import gsplat_scene_cuda as _SCENE_CUDA  # pyright: ignore[reportMissingImports]
+except ImportError as prebuilt_error:
+    from .cuda.build import build_and_load_scene_cuda
+
+    try:
+        _SCENE_CUDA = build_and_load_scene_cuda()
+    except Exception as jit_error:
+        raise ImportError(
+            "Failed to load gsplat_scene_cuda via both prebuilt import and "
+            "JIT build/load.\n"
+            f"Prebuilt import error: {prebuilt_error!r}\n"
+            f"JIT build/load error: {jit_error!r}"
+        ) from jit_error
+
+
+__all__ = [
+    "_SCENE_CUDA",
+]

--- a/libs/scene/kernels/cuda/__init__.py
+++ b/libs/scene/kernels/cuda/__init__.py
@@ -12,11 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-[pytest]
-testpaths = tests libs/geometry/functional libs/scene/components libs/scene/functional libs/scene/test_package_imports.py libs/stage/components
-pythonpath = .
-env =
-    VERBOSE=1
-    BUILD_CAMERA_WRAPPERS=1
-    NUM_CHANNELS=1,3,4,5,8,24,32,128

--- a/libs/scene/kernels/cuda/build.py
+++ b/libs/scene/kernels/cuda/build.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JIT build for the gsplat_scene_cuda extension (Gaussian scene packing ops)."""
+
+from __future__ import annotations
+
+import os
+import json
+import shutil
+import sys
+import time
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+
+import torch
+import torch.utils.cpp_extension as jit
+
+PATH = os.path.dirname(os.path.abspath(__file__))
+DEBUG = os.getenv("DEBUG", "0") == "1"
+NINJA_STATUS = os.getenv("NINJA_STATUS")
+VERBOSE = os.getenv("VERBOSE", "0") == "1"
+
+
+def get_build_parameters() -> SimpleNamespace:
+    name = "gsplat_scene_cuda"
+    sources = [
+        os.path.join(PATH, "ext.cpp"),
+        os.path.join(PATH, "csrc", "gaussian_scene_pack.cpp"),
+    ]
+    torch_include_paths = set(jit.include_paths("cpu"))
+    extra_include_paths: list[str] = [
+        path for path in jit.include_paths("cuda") if path not in torch_include_paths
+    ]
+
+    extra_cflags: list[str] = []
+    extra_ldflags: list[str] = []
+
+    if sys.platform == "win32":
+        extra_cflags = ["/std:c++17", "-DWIN32_LEAN_AND_MEAN"]
+    else:
+        extra_cflags = ["-std=c++17"]
+
+    extra_cflags += ["-g", "-O0"] if DEBUG else ["-O3", "-DNDEBUG"]
+    if os.name != "nt":
+        extra_cflags += ["-Wno-attributes", "-Wno-sign-compare"]
+
+    if torch.version.hip:
+        extra_cflags += ["-DUSE_ROCM", "-U__HIP_NO_HALF_CONVERSIONS__"]
+        torch_cuda_libs = ["c10_hip", "torch_hip"]
+    else:
+        torch_cuda_libs = ["c10_cuda", "torch_cuda"]
+
+    if sys.platform == "win32":
+        extra_ldflags += [
+            os.path.join(jit.TORCH_LIB_PATH, f"{lib}.lib") for lib in torch_cuda_libs
+        ]
+    else:
+        extra_ldflags += [
+            os.path.join(jit.TORCH_LIB_PATH, f"lib{lib}.so") for lib in torch_cuda_libs
+        ]
+
+    return SimpleNamespace(
+        name=name,
+        extra_include_paths=extra_include_paths,
+        sources=sources,
+        extra_cflags=extra_cflags,
+        extra_ldflags=extra_ldflags,
+    )
+
+
+@contextmanager
+def _status_context(msg: str):
+    tic = time.time()
+    print(msg, flush=True)
+    try:
+        yield
+    finally:
+        print(
+            f"gsplat_scene: CUDA extension ready in {time.time() - tic:.2f}s",
+            flush=True,
+        )
+
+
+def build_and_load_scene_cuda():
+    build_params = get_build_parameters()
+    build_dir = jit._get_build_directory(build_params.name, verbose=False)
+
+    lock_path = os.path.join(build_dir, "lock")
+    lock_max_age_s = int(os.environ.get("GSPLAT_BUILD_LOCK_AGE_S", "1800"))
+    try:
+        age = time.time() - os.path.getmtime(lock_path)
+        if age > lock_max_age_s:
+            os.remove(lock_path)
+    except OSError:
+        pass
+
+    saved_build_params_fname = os.path.join(build_dir, "build_params.json")
+    saved_build_params = None
+    build_params_changed = False
+    try:
+        if os.path.exists(saved_build_params_fname):
+            with open(saved_build_params_fname, encoding="utf-8") as f:
+                saved_build_params = json.load(f)
+            build_params_changed = saved_build_params != vars(build_params)
+    except Exception as e:
+        print(
+            f"gsplat_scene: rebuilding (could not load saved build params: {e})",
+            flush=True,
+        )
+
+    if build_params_changed and saved_build_params is not None:
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+    os.makedirs(build_dir, exist_ok=True)
+
+    with open(saved_build_params_fname, "w", encoding="utf-8") as f:
+        json.dump(vars(build_params), f, sort_keys=True)
+
+    module_exists = os.path.exists(
+        os.path.join(build_dir, f"{build_params.name}.so")
+    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.lib"))
+
+    ctx = (
+        _status_context(
+            "gsplat_scene: compiling CUDA extension "
+            "(first run may take a few minutes)..."
+        )
+        if (not module_exists or build_params_changed)
+        else nullcontext()
+    )
+
+    envvars_to_remove: list[str] = []
+    try:
+        with ctx:
+            if not NINJA_STATUS:
+                envvars_to_remove.append("NINJA_STATUS")
+                os.environ["NINJA_STATUS"] = "[%f/%t %r %es] "
+
+            return jit.load(
+                name=build_params.name,
+                sources=build_params.sources,
+                extra_cflags=build_params.extra_cflags,
+                extra_include_paths=build_params.extra_include_paths,
+                extra_ldflags=build_params.extra_ldflags,
+                build_directory=build_dir,
+                verbose=VERBOSE,
+            )
+    except OSError as jit_error:
+        if module_exists and not build_params_changed:
+            try:
+                return jit._import_module_from_library(
+                    build_params.name, build_dir, True
+                )
+            except OSError as import_error:
+                raise OSError(
+                    "Failed to load cached gsplat_scene CUDA extension after "
+                    f"jit.load() failed for build directory {build_dir!r}.\n"
+                    f"jit.load error: {jit_error!r}\n"
+                    f"cached import error: {import_error!r}"
+                ) from import_error
+        raise
+    finally:
+        for envvar in envvars_to_remove:
+            os.environ.pop(envvar, None)
+
+
+__all__ = ["build_and_load_scene_cuda", "get_build_parameters"]

--- a/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cpp
+++ b/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gaussian_scene_pack.cuh"
+
+#include <ATen/core/Tensor.h>
+#include <ATen/Functions.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/zeros.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+
+#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+#define CHECK_FLOAT(x) TORCH_CHECK(x.dtype() == at::kFloat, #x " must have dtype float32")
+#define DEVICE_GUARD(x) const at::cuda::OptionalCUDAGuard device_guard(device_of(x))
+
+namespace gsplat {
+namespace scene {
+
+enum class ShCompressionMode : int64_t {
+    None = 0,
+    Packed32B = 1,
+    Packed16B = 2,
+};
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> pack_gaussian_inference_scene_cuda(
+    const at::Tensor &means,      // [N, 3] float32
+    const at::Tensor &quats,      // [N, 4] float32
+    const at::Tensor &scales,     // [N, 3] float32
+    const at::Tensor &opacities,  // [N]    float32
+    const at::Tensor &colors,     // [N, 3] or [N, K, 3] float32
+    int64_t sh_degree,            // -1 for RGB, 0-3 for SH
+    int64_t sh_compression_mode   // 0=none, 1=32b, 2=16b
+) {
+    // Disable grad tracking for all ATen ops inside this function.
+    // Without this, intermediate ops like .t() and .contiguous() on
+    // grad-tracked inputs would propagate CloneBackward0 to the outputs.
+    torch::NoGradGuard no_grad;
+
+    DEVICE_GUARD(means);
+    CHECK_INPUT(means);
+    CHECK_INPUT(quats);
+    CHECK_INPUT(scales);
+    CHECK_INPUT(opacities);
+    CHECK_INPUT(colors);
+
+    CHECK_FLOAT(means);
+    CHECK_FLOAT(quats);
+    CHECK_FLOAT(scales);
+    CHECK_FLOAT(opacities);
+    CHECK_FLOAT(colors);
+
+    TORCH_CHECK(means.dim() == 2 && means.size(1) == 3,
+        "means must be [N, 3]; got ", means.sizes());
+    TORCH_CHECK(quats.dim() == 2 && quats.size(1) == 4,
+        "quats must be [N, 4]; got ", quats.sizes());
+    TORCH_CHECK(scales.dim() == 2 && scales.size(1) == 3,
+        "scales must be [N, 3]; got ", scales.sizes());
+    TORCH_CHECK(opacities.dim() == 1,
+        "opacities must be 1-D [N]; got dim=", opacities.dim());
+
+    int64_t N = means.size(0);
+    TORCH_CHECK(quats.size(0) == N,
+        "quats.size(0) must match means.size(0)=", N, "; got ", quats.size(0));
+    TORCH_CHECK(scales.size(0) == N,
+        "scales.size(0) must match means.size(0)=", N, "; got ", scales.size(0));
+    TORCH_CHECK(opacities.size(0) == N,
+        "opacities.size(0) must match means.size(0)=", N, "; got ", opacities.size(0));
+    TORCH_CHECK(colors.size(0) == N,
+        "colors.size(0) must match means.size(0)=", N, "; got ", colors.size(0));
+
+    TORCH_CHECK(sh_degree >= -1 && sh_degree <= 3,
+        "sh_degree must be in [-1, 3]; got ", sh_degree);
+
+    if (sh_degree >= 0) {
+        int64_t K_expected = (sh_degree + 1) * (sh_degree + 1);
+        TORCH_CHECK(colors.dim() == 3 && colors.size(1) == K_expected && colors.size(2) == 3,
+            "For sh_degree=", sh_degree, ", colors must be [N, ",
+            K_expected, ", 3]; got ", colors.sizes());
+    } else {
+        TORCH_CHECK(colors.dim() == 2 && colors.size(1) == 3,
+            "For sh_degree=-1, colors must be [N, 3]; got ", colors.sizes());
+    }
+
+    TORCH_CHECK(
+        sh_compression_mode >= 0 && sh_compression_mode <= 2,
+        "sh_compression_mode must be one of [0, 1, 2]; got ",
+        sh_compression_mode
+    );
+    TORCH_CHECK(
+        sh_compression_mode == 0 || sh_degree == 3,
+        "sh_compression_mode=",
+        sh_compression_mode,
+        " requires sh_degree=3; got sh_degree=",
+        sh_degree
+    );
+    const auto sh_compression = static_cast<ShCompressionMode>(sh_compression_mode);
+
+    auto opts_h = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
+
+    // means_planar: [N, 3] -> [3, N]
+    auto means_planar = means.t().contiguous();
+
+    // qso_packed [N, 8] fp16 with clamping for finite fp16 range
+    constexpr float fp16_max = 65504.0f;
+    auto qso_packed = at::empty({N, 8}, opts_h);
+    // quats are unit-norm, values in [-1, 1], no clamping needed
+    qso_packed.narrow(1, 0, 4).copy_(quats.to(at::kHalf));
+    // scales: positive but may be large; clamp to fp16 range
+    qso_packed.narrow(1, 4, 3).copy_(scales.clamp(-fp16_max, fp16_max).to(at::kHalf));
+    // opacities are sigmoid-bounded [0, 1], no clamping needed
+    qso_packed.narrow(1, 7, 1).copy_(opacities.unsqueeze(1).to(at::kHalf));
+
+    // Pack colors based on SH degree and compression mode.
+    int64_t K_sh = (sh_degree >= 0 && colors.dim() == 3) ? colors.size(1) : 0;
+    at::Tensor colors_packed;
+    if (sh_degree >= 0 && K_sh == 16) {
+        if (sh_compression == ShCompressionMode::None) {
+            // SH3 "none": preserve the raw SH layout in fp16 lanes.
+            colors_packed = colors.clamp(-fp16_max, fp16_max).to(at::kHalf);
+        } else if (sh_compression == ShCompressionMode::Packed32B) {
+            // SH3 "32b": pack into contiguous 32-bit coefficient lanes.
+            colors_packed = colors.contiguous().view({N, 48});
+        } else {
+            // SH3 "16b": pack into contiguous fp16 coefficient lanes.
+            colors_packed = colors.clamp(-fp16_max, fp16_max).to(at::kHalf).view({N, 48});
+        }
+    } else if (sh_degree >= 0 && K_sh > 0) {
+        // Lower-degree SH (0-2): keep float32
+        colors_packed = colors.contiguous();
+    } else {
+        // RGB: [N, 3] -> [N, 4] fp16 {R, G, B, 0} with padding for alignment
+        auto c = at::zeros({N, 4}, opts_h);
+        c.narrow(1, 0, 3).copy_(colors.clamp(-fp16_max, fp16_max).to(at::kHalf));
+        colors_packed = c;
+    }
+
+    return std::make_tuple(means_planar, qso_packed, colors_packed);
+}
+
+} // namespace scene
+} // namespace gsplat

--- a/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cuh
+++ b/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cuh
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+namespace at {
+class Tensor;
+}
+
+namespace gsplat {
+namespace scene {
+
+/**
+ * Pack activated Gaussian splat tensors into the inference viewer-internal layout.
+ *
+ * Inputs (all float32 CUDA, N gaussians):
+ *   means      [N, 3]           world-space positions (after activation)
+ *   quats      [N, 4]           unit quaternions in wxyz order
+ *   scales     [N, 3]           positive scales (after exp())
+ *   opacities  [N]              opacities in [0, 1] (after sigmoid())
+ *   colors     [N, 3]           RGB, or [N, K, 3] for SH coefficients
+ *   sh_degree  int64            -1 for RGB mode, 0–3 for SH
+ *   sh_compression_mode int64   0=none, 1=32b, 2=16b
+ *
+ * Outputs:
+ *   means_planar [3, N]  float32  transposed means for cache-friendly viewer access
+ *   qso_packed        [N, 8]  float16  packed quaternion cols 0-3,
+ *                              scale cols 4-6, opacity col 7
+ *   colors_packed        [N, 4] fp16 for RGB; [N, K, 3] fp32 for SH0-2;
+ *                        [N, 16, 3] fp16 for SH3 mode 0;
+ *                        [N, 48] fp32 for SH3 mode 1;
+ *                        [N, 48] fp16 for SH3 mode 2
+ */
+std::tuple<at::Tensor, at::Tensor, at::Tensor> pack_gaussian_inference_scene_cuda(
+    const at::Tensor &means,
+    const at::Tensor &quats,
+    const at::Tensor &scales,
+    const at::Tensor &opacities,
+    const at::Tensor &colors,
+    int64_t sh_degree,
+    int64_t sh_compression_mode
+);
+
+} // namespace scene
+} // namespace gsplat

--- a/libs/scene/kernels/cuda/ext.cpp
+++ b/libs/scene/kernels/cuda/ext.cpp
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <torch/extension.h>
+#include "csrc/gaussian_scene_pack.cuh"
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> pack_gaussian_inference_scene(
+    const at::Tensor &means,
+    const at::Tensor &quats,
+    const at::Tensor &scales,
+    const at::Tensor &opacities,
+    const at::Tensor &colors,
+    int64_t sh_degree,
+    int64_t sh_compression_mode
+) {
+    return gsplat::scene::pack_gaussian_inference_scene_cuda(
+        means, quats, scales, opacities, colors, sh_degree, sh_compression_mode
+    );
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def(
+        "pack_gaussian_inference_scene",
+        &pack_gaussian_inference_scene,
+        "Pack activated Gaussian splat tensors into the inference viewer-internal layout.\n\n"
+        "Args:\n"
+        "    means      [N, 3] float32 CUDA\n"
+        "    quats      [N, 4] float32 CUDA  (unit quaternions in wxyz order)\n"
+        "    scales     [N, 3] float32 CUDA  (positive, after exp())\n"
+        "    opacities  [N]    float32 CUDA  (in [0,1], after sigmoid())\n"
+        "    colors     [N, 3] or [N, K, 3] float32 CUDA\n"
+        "    sh_degree        int  (-1=RGB, 0-3=SH)\n"
+        "    sh_compression_mode  int  (0=none, 1=32b, 2=16b)\n\n"
+        "Returns:\n"
+        "    (means_planar [3,N] float32,\n"
+        "     qso_packed [N,8] float16,\n"
+        "     colors_packed [N,4] fp16 RGB, [N,K,3] fp32 SH0-2,\n"
+        "                   [N,16,3] fp16 SH3 none, [N,48] fp32 SH3 32b,\n"
+        "                   or [N,48] fp16 SH3 16b)"
+    );
+}

--- a/libs/scene/kernels/gaussian_inference_ops.py
+++ b/libs/scene/kernels/gaussian_inference_ops.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python-level wrapper for the native pack_gaussian_inference_scene op.
+
+Provides input validation before calling into C++, following the same pattern as
+:mod:`gsplat_geometry.kernels.quaternion_ops` and ``pose_ops``: callers get
+clear ``TypeError`` / ``ValueError`` messages rather than opaque C++ errors.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from ..sh_compression import SH_COMPRESSION_MODE_VALUES, SHCompressionMode
+
+# Valid sh_degree values; -1 means RGB (no SH)
+_VALID_SH_DEGREES = frozenset({-1, 0, 1, 2, 3})
+
+
+# ---------------------------------------------------------------------------
+# Internal validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _expect_tensor(name: str, x: object) -> Tensor:
+    if not isinstance(x, Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor; got {type(x).__name__}")
+    return x
+
+
+def _require_cuda(name: str, t: Tensor) -> None:
+    if t.device.type != "cuda":
+        raise ValueError(f"{name} must be a CUDA tensor; got device {t.device}")
+
+
+def _require_float32(name: str, t: Tensor) -> None:
+    if t.dtype != torch.float32:
+        raise TypeError(f"{name} must have dtype float32; got {t.dtype}")
+
+
+def _require_shape(name: str, t: Tensor, *expected: int | None) -> None:
+    """Check that t.shape matches expected dims, where None means 'any'."""
+    if t.dim() != len(expected):
+        raise ValueError(
+            f"{name} must have {len(expected)}D shape "
+            f"{'x'.join(str(d) if d is not None else 'N' for d in expected)}; "
+            f"got shape {tuple(t.shape)}"
+        )
+    for i, (actual, exp) in enumerate(zip(t.shape, expected)):
+        if exp is not None and actual != exp:
+            raise ValueError(
+                f"{name} dim {i} must be {exp}; got shape {tuple(t.shape)}"
+            )
+
+
+def _require_same_device(pairs: list[tuple[str, Tensor]], ref_name: str) -> None:
+    ref = pairs[0][1]
+    for name, t in pairs[1:]:
+        if t.device != ref.device:
+            raise ValueError(
+                f"{name} must be on the same device as {ref_name} "
+                f"({ref.device}); got {t.device}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public kernel wrapper
+# ---------------------------------------------------------------------------
+
+
+def pack_gaussian_inference_scene(
+    means: Tensor,
+    quats: Tensor,
+    scales: Tensor,
+    opacities: Tensor,
+    colors: Tensor,
+    sh_degree: int,
+    sh_compression_mode: SHCompressionMode,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Pack activated Gaussian splat tensors into the inference-internal layout.
+
+    This is the kernels-layer entry point.  Downstream code should use
+    :func:`gsplat_scene.functional.pack_gaussian_inference_scene` instead.
+
+    All tensor inputs must be contiguous float32 CUDA tensors with N rows on the
+    leading dimension.
+
+    Args:
+        means:               [N, 3] float32 CUDA — world-space positions
+        quats:               [N, 4] float32 CUDA — unit quaternions wxyz
+        scales:              [N, 3] float32 CUDA — positive scales (after exp())
+        opacities:           [N]    float32 CUDA — opacities in [0, 1] (after sigmoid())
+        colors:              [N, 3] float32 CUDA for RGB, or
+                             [N, (sh_degree + 1) ** 2, 3] float32 CUDA
+                             for SH coefficients
+        sh_degree:           -1 for RGB mode; 0–3 for SH
+        sh_compression_mode: SHCompressionMode enum. Nonzero modes require SH3.
+
+    Returns:
+        means_planar:   [3, N] float32  transposed means
+        qso_packed:     [N, 8] float16  packed quaternion cols 0-3,
+                        scale cols 4-6, opacity col 7
+        colors_packed:  [N, 4] float16 for RGB; [N, K, 3] float32 for SH0-2;
+                        [N, 16, 3] float16 for SH3 NONE;
+                        [N, 48] float32 for SH3 PACKED_32B;
+                        [N, 48] float16 for SH3 PACKED_16B
+    """
+    # --- scalar validation -----------------------------------------------
+    if not isinstance(sh_degree, int):
+        raise TypeError(f"sh_degree must be an int; got {type(sh_degree).__name__}")
+    if sh_degree not in _VALID_SH_DEGREES:
+        raise ValueError(
+            f"sh_degree must be one of {sorted(_VALID_SH_DEGREES)}; " f"got {sh_degree}"
+        )
+    if not isinstance(sh_compression_mode, SHCompressionMode):
+        raise TypeError(
+            f"sh_compression_mode must be an SHCompressionMode; "
+            f"got {type(sh_compression_mode).__name__}"
+        )
+    if sh_compression_mode not in SH_COMPRESSION_MODE_VALUES:
+        raise ValueError(
+            f"sh_compression_mode must be one of "
+            f"{sorted(SH_COMPRESSION_MODE_VALUES)}; "
+            f"got {sh_compression_mode}"
+        )
+    if sh_compression_mode is not SHCompressionMode.NONE and sh_degree != 3:
+        raise ValueError(
+            f"sh_compression_mode={sh_compression_mode} requires sh_degree=3; "
+            f"got sh_degree={sh_degree}"
+        )
+
+    # --- tensor type / device / dtype checks -----------------------------
+    means = _expect_tensor("means", means)
+    quats = _expect_tensor("quats", quats)
+    scales = _expect_tensor("scales", scales)
+    opacities = _expect_tensor("opacities", opacities)
+    colors = _expect_tensor("colors", colors)
+
+    for name, t in [
+        ("means", means),
+        ("quats", quats),
+        ("scales", scales),
+        ("opacities", opacities),
+        ("colors", colors),
+    ]:
+        _require_cuda(name, t)
+        _require_float32(name, t)
+
+    _require_same_device(
+        [
+            ("means", means),
+            ("quats", quats),
+            ("scales", scales),
+            ("opacities", opacities),
+            ("colors", colors),
+        ],
+        ref_name="means",
+    )
+
+    # --- shape checks ----------------------------------------------------
+    N = means.shape[0]
+    _require_shape("means", means, N, 3)
+    _require_shape("quats", quats, N, 4)
+    _require_shape("scales", scales, N, 3)
+    _require_shape("opacities", opacities, N)
+
+    if sh_degree >= 0:
+        expected_K = (sh_degree + 1) ** 2
+        if colors.dim() != 3:
+            raise ValueError(
+                f"sh_degree={sh_degree} requires colors to be 3D "
+                f"[N, {expected_K}, 3]; got {colors.dim()}D shape "
+                f"{tuple(colors.shape)}"
+            )
+        if colors.shape != (N, expected_K, 3):
+            raise ValueError(
+                f"sh_degree={sh_degree} requires colors shape "
+                f"({N}, {expected_K}, 3); got {tuple(colors.shape)}"
+            )
+    else:
+        # RGB mode
+        _require_shape("colors", colors, N, 3)
+
+    # --- contiguity (C++ CHECK_INPUT requires contiguous) ----------------
+    means = means.contiguous()
+    quats = quats.contiguous()
+    scales = scales.contiguous()
+    opacities = opacities.contiguous()
+    colors = colors.contiguous()
+
+    # --- dispatch --------------------------------------------------------
+    from . import _backend
+
+    return _backend._SCENE_CUDA.pack_gaussian_inference_scene(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        int(sh_degree),
+        int(sh_compression_mode),
+    )

--- a/libs/scene/pyproject.toml
+++ b/libs/scene/pyproject.toml
@@ -32,5 +32,14 @@ dependencies = [
 packages = [
     "gsplat_scene",
     "gsplat_scene.components",
+    "gsplat_scene.kernels",
+    "gsplat_scene.kernels.cuda",
+    "gsplat_scene.functional",
 ]
 package-dir = { "gsplat_scene" = "." }
+
+[tool.setuptools.package-data]
+gsplat_scene = [
+    "kernels/cuda/ext.cpp",
+    "kernels/cuda/csrc/*",
+]

--- a/libs/scene/sh_compression.py
+++ b/libs/scene/sh_compression.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class SHCompressionMode(IntEnum):
+    """Scene packer SH layout modes.
+
+    These control how SH coefficients are stored in GaussianInferenceScene.colors_packed.
+    PACKED modes are simple layout transforms (flatten + optional fp16 cast),
+    distinct from the render kernel's COMPRESS modes which apply full YCoCg quantization.
+    """
+
+    NONE = 0  # [N, 16, 3] float16 — raw coefficients
+    PACKED_32B = 1  # [N, 48] float32 — flattened
+    PACKED_16B = 2  # [N, 48] float16 — flattened + quantized to fp16
+
+
+SH_COMPRESSION_MAP = {
+    "none": SHCompressionMode.NONE,
+    "32b": SHCompressionMode.PACKED_32B,
+    "16b": SHCompressionMode.PACKED_16B,
+}
+SH_COMPRESSION_MODE_VALUES = frozenset(SHCompressionMode)
+
+__all__ = [
+    "SHCompressionMode",
+    "SH_COMPRESSION_MAP",
+    "SH_COMPRESSION_MODE_VALUES",
+]

--- a/libs/scene/test_package_imports.py
+++ b/libs/scene/test_package_imports.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCENE_ROOT = Path(__file__).resolve().parent
+
+
+def test_top_level_import_does_not_load_functional_or_native_backend():
+    code = """
+import sys
+import tempfile
+from pathlib import Path
+
+scene_root = Path(%r)
+import_root = Path(tempfile.mkdtemp())
+(import_root / "gsplat_scene").symlink_to(scene_root, target_is_directory=True)
+sys.path.insert(0, str(import_root))
+
+import gsplat_scene
+
+unexpected = {
+    "gsplat_scene.functional",
+    "gsplat_scene.kernels._backend",
+    "gsplat_scene_cuda",
+}
+loaded = sorted(name for name in unexpected if name in sys.modules)
+if loaded:
+    raise AssertionError(f"unexpected modules loaded: {loaded}")
+if "functional" in gsplat_scene.__dict__:
+    raise AssertionError("gsplat_scene.functional was eagerly attached")
+assert gsplat_scene.Scene.__name__ == "Scene"
+assert gsplat_scene.GaussianScene.__name__ == "GaussianScene"
+assert gsplat_scene.GaussianInferenceScene.__name__ == "GaussianInferenceScene"
+""" % str(
+        SCENE_ROOT
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_functional_import_does_not_load_native_backend():
+    code = """
+import sys
+import tempfile
+from pathlib import Path
+
+scene_root = Path(%r)
+import_root = Path(tempfile.mkdtemp())
+(import_root / "gsplat_scene").symlink_to(scene_root, target_is_directory=True)
+sys.path.insert(0, str(import_root))
+
+import gsplat_scene.functional
+
+unexpected = {
+    "gsplat_scene.kernels._backend",
+    "gsplat_scene_cuda",
+}
+loaded = sorted(name for name in unexpected if name in sys.modules)
+if loaded:
+    raise AssertionError(f"importing gsplat_scene.functional eagerly loaded: {loaded}")
+""" % str(
+        SCENE_ROOT
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_scene_pyproject_includes_cuda_jit_sources():
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        tomllib = pytest.importorskip("tomli")
+
+    pyproject = tomllib.loads((SCENE_ROOT / "pyproject.toml").read_text())
+    package_data = pyproject["tool"]["setuptools"]["package-data"]["gsplat_scene"]
+
+    required_sources = [
+        "kernels/cuda/ext.cpp",
+        "kernels/cuda/csrc/gaussian_scene_pack.cpp",
+        "kernels/cuda/csrc/gaussian_scene_pack.cuh",
+    ]
+    for source in required_sources:
+        assert any(
+            fnmatch.fnmatchcase(source, pattern) for pattern in package_data
+        ), f"{source} is not matched by package-data"


### PR DESCRIPTION
## Summary

Adds an inference-only Gaussian scene representation for packed render-time storage.
`GaussianInferenceScene` can be built from a training `GaussianScene` or from
already-activated tensors, detaches inputs from autograd, validates activation and
layout contracts, and stores compact tensors for inference consumers.

This also adds the scene packing path through `gsplat_scene.functional` and the
scene CUDA extension, producing planar means, packed quaternion/scale/opacity
data, and RGB/SH color layouts with optional SH3 compression.

```text
GaussianScene / activated tensors
  means, quats, scales, opacities, colors
                |
                v
  Python validation + detach boundary
                |
                v
  pack_gaussian_inference_scene
      Python API -> kernels wrapper -> C++/CUDA
                |
                +--> means_planar  [3, N]    fp32
                +--> qso_packed    [N, 8]    fp16
                +--> colors_packed RGB / SH / packed SH3
                |
                v
        GaussianInferenceScene
  inference-only packed tensors + component metadata
```

## Details

- Adds `GaussianInferenceScene` with `from_gaussian_scene`,
  `from_gaussian_tensors`, `put`, `get`, `release`, component indexing,
  distributed rejection, activation checks, fp16 clamp warnings, and SH
  compression metadata.
- Adds `pack_gaussian_inference_scene` as the public functional API and native
  CUDA-backed packing implementation.
- Supports RGB, SH0-SH3, and SH3 compression modes: `none`, `32b`, and `16b`.
- Updates scene package exports, docs, package data, and import behavior so
  top-level `gsplat_scene` imports do not eagerly load the native backend.