### PR TITLE
[NV] Adding Gaussian Inference Scene renderer and benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ gsplat is an open-source library for CUDA accelerated rasterization of gaussians
 
 ## News
 
+[May 2026] **Inference Rendering (HiGS)** -- An experimental inference-only rendering path based on HiGS (Hierarchical 3D Gaussian Splatting) is now available under the `experimental` package. The inference path uses macro-tile fused rasterization with fp16 scene packing for low-latency rendering of pre-trained Gaussian scenes. See the [HiGS project page](https://research.nvidia.com/labs/sil/projects/higs/) and the "Inference Rendering" section below.
+
 [Jan 2026] [PPISP](https://research.nvidia.com/labs/sil/projects/ppisp/) is integrated as an alternative way of bilateral grid to compensate the training views.
 
 [May 2025] Arbitrary batching (over multiple scenes and multiple viewpoints) is supported now!! Checkout [here](docs/batch.md) for more details! Kudos to [Junchen Liu](https://junchenliu77.github.io/).
@@ -68,6 +70,16 @@ the examples (requires installing some extrra dependencies via `pip install -r e
 - [Render a large scene in real-time.](https://docs.gsplat.studio/main/examples/large_scale.html)
 - [Train on an NCore v4 capture.](https://docs.gsplat.studio/main/examples/ncore.html)
 
+
+## Inference Rendering
+
+gsplat includes an experimental inference-only rendering path based on HiGS (Hierarchical 3D Gaussian Splatting) in the standalone `experimental` package, designed for low-latency rendering of pre-trained Gaussian scenes where training gradients are not needed. The inference path packs scene data into compact fp16 layouts and uses a macro-tile fused rasterization pipeline for fast single-camera rendering.
+
+```python
+from experimental import render_scene, GaussianInferenceScene
+```
+
+The `simple_viewer.py` example supports the Inference path via the `--use_gaussian_render_inference_scene` flag. A standalone benchmark comparing Inference rendering against the default `rasterization()` path is available at `examples/benchmarks/gaussian_render_inference_scene/`. For more details, [see project page](https://research.nvidia.com/labs/sil/projects/higs/).
 
 ## Development and Contribution
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,23 @@ gsplat is an open-source library for CUDA accelerated rasterization of gaussians
 
 ## News
 
-[Jan 2026] [PPISP](https://research.nvidia.com/labs/sil/projects/ppisp/) is integrated as an alternative way of bilateral grid to compensate the training views.
+### Unreleased
 
-[May 2025] Arbitrary batching (over multiple scenes and multiple viewpoints) is supported now!! Checkout [here](docs/batch.md) for more details! Kudos to [Junchen Liu](https://junchenliu77.github.io/).
+Changes on `main` since the [v1.5.3](https://github.com/nerfstudio-project/gsplat/releases/tag/v1.5.3) tag (not yet on PyPI).
 
-[May 2025] [Jonathan Stephens](https://x.com/jonstephens85) makes a great [tutorial video](https://www.youtube.com/watch?v=ACPTiP98Pf8) for Windows users on how to install gsplat and get start with 3DGUT.
+- [May 2026] Native CUDA **MCMC perturb** (`inject_noise`) speeds up the noise-injection step used in MCMC-style Gaussian optimization.
+- [Apr 2026] **AccuTile** adds a conservative ellipse-based tile–Gaussian intersection test on the 3DGS path for tighter work scheduling before rasterization ([PR #927](https://github.com/nerfstudio-project/gsplat/pull/927)).
+- [Apr 2026] **NCore v4** capture support, including richer camera models and point-cloud loading via `PointCloudsSourceProtocol`. See the [NCore example](https://docs.gsplat.studio/main/examples/ncore.html).
+- [Mar 2026] **LiDAR** rasterization for 3D Gaussian splatting: spinning-lidar camera models, `eval3d` rendering, depth / hit-distance modes, and related tooling (optional SciPy via `pip install "gsplat[lidar]"`).
+- [Mar 2026] **TorchScript-oriented** deployment: camera models and distortions are also available through PyTorch **custom operators** and **custom classes**, not only Python callables.
+- [Mar 2026] **3DGUT** extensions: [external distortion](https://github.com/nerfstudio-project/gsplat/pull/886) (e.g. windshield-style rigs), optional **per-ray** inputs with gradients, optional **ray-normal** outputs, and refactored render modes / extra signals (see [3DGUT notes](docs/3dgut.md)).
+- [Jan 2026] [PPISP](https://research.nvidia.com/labs/sil/projects/ppisp/) is integrated as an alternative way of bilateral grid to compensate the training views.
 
-[April 2025] [NVIDIA 3DGUT](https://research.nvidia.com/labs/toronto-ai/3DGUT/) is now integrated in gsplat! Checkout [here](docs/3dgut.md) for more details. [[NVIDIA Tech Blog]](https://developer.nvidia.com/blog/revolutionizing-neural-reconstruction-and-rendering-in-gsplat-with-3dgut/) [[NVIDIA Sweepstakes]](https://www.nvidia.com/en-us/research/3dgut-sweepstakes/)
+### v1.5.3
+
+- [May 2025] Arbitrary batching (over multiple scenes and multiple viewpoints) is supported now!! Checkout [here](docs/batch.md) for more details! Kudos to [Junchen Liu](https://junchenliu77.github.io/).
+- [May 2025] [Jonathan Stephens](https://x.com/jonstephens85) makes a great [tutorial video](https://www.youtube.com/watch?v=ACPTiP98Pf8) for Windows users on how to install gsplat and get start with 3DGUT.
+- [April 2025] [NVIDIA 3DGUT](https://research.nvidia.com/labs/toronto-ai/3DGUT/) is now integrated in gsplat! Checkout [here](docs/3dgut.md) for more details. [[NVIDIA Tech Blog]](https://developer.nvidia.com/blog/revolutionizing-neural-reconstruction-and-rendering-in-gsplat-with-3dgut/) [[NVIDIA Sweepstakes]](https://www.nvidia.com/en-us/research/3dgut-sweepstakes/)
 
 ## Installation
 

--- a/examples/benchmarks/gaussian_render_inference_scene/README.md
+++ b/examples/benchmarks/gaussian_render_inference_scene/README.md
@@ -1,0 +1,23 @@
+# Inference Rendering Benchmarks
+
+This directory contains benchmarks for the inference rendering path, which uses
+packed quaternion, scale, and opacity (QSO) scene representation. The benchmark
+measures GPU latency and optionally compares image quality against the default
+gsplat `rasterization()` renderer.
+
+## Python Benchmark
+
+Run from the repository root:
+
+```bash
+python examples/benchmarks/gaussian_render_inference_scene/gaussian_render_inference_scene_bench.py
+```
+
+By default, the benchmark uses a synthetic scene. To use a trained model, pass
+`--ply-path <path_to_point_cloud.ply>`. Pretrained scenes can be downloaded
+with `python examples/datasets/download_dataset.py`.
+
+Pass `--reference-tile-size 16` to enable the reference `rasterization()` path
+and print speedup and image-quality (PSNR / LPIPS) comparisons.
+
+Run with `--help` for the full list of options.

--- a/examples/benchmarks/gaussian_render_inference_scene/gaussian_render_inference_scene_bench.py
+++ b/examples/benchmarks/gaussian_render_inference_scene/gaussian_render_inference_scene_bench.py
@@ -1,0 +1,1060 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark script for the Inference Gaussian rasterization path.
+
+Measures GPU latency (via CUDA events) for the stateful Inference renderer:
+
+1. **Stateful renderer** -- ``GaussianInferenceRenderer``
+   Scene is packed once, a persistent renderer is created once, and each
+   frame is rendered via ``renderer.render()``.  The renderer caches GPU
+   buffers across frames.
+
+Optionally, pass ``--reference-tile-size`` to benchmark the reference
+``gsplat.rasterization()`` path and print speedup/image-quality comparisons.
+
+This is a standalone script (NOT a pytest test). Run it directly::
+
+    python examples/benchmarks/gaussian_render_inference_scene/gaussian_render_inference_scene_bench.py
+    python examples/benchmarks/gaussian_render_inference_scene/gaussian_render_inference_scene_bench.py --num-gaussians 1000000 --num-frames 200
+    python examples/benchmarks/gaussian_render_inference_scene/gaussian_render_inference_scene_bench.py --inference-tile-size 8 --reference-tile-size 16
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import torch
+import torch.nn.functional as F
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Benchmark the Inference rasterization path.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--num-gaussians",
+        type=int,
+        default=500_000,
+        help="Number of Gaussians in the synthetic scene.",
+    )
+    p.add_argument("--width", type=int, default=1920, help="Image width in pixels.")
+    p.add_argument("--height", type=int, default=1080, help="Image height in pixels.")
+    p.add_argument(
+        "--num-frames",
+        type=int,
+        default=100,
+        help="Number of timed frames per benchmark.",
+    )
+    p.add_argument(
+        "--warmup-frames",
+        type=int,
+        default=10,
+        help="Number of warmup frames (not timed) before each benchmark.",
+    )
+    p.add_argument(
+        "--sh-degree",
+        type=int,
+        default=3,
+        help="SH degree (0-3). Use -1 for pre-activated RGB.",
+    )
+    p.add_argument(
+        "--inference-tile-size",
+        type=int,
+        default=8,
+        choices=[8, 16],
+        help="Tile size for Inference rasterization kernels.",
+    )
+    p.add_argument(
+        "--reference-tile-size",
+        type=int,
+        default=None,
+        choices=[4, 16],
+        help=(
+            "Tile size for the gsplat reference rasterization path. When omitted, "
+            "the reference benchmark, speedup, and image-quality comparisons are skipped."
+        ),
+    )
+    p.add_argument(
+        "--tile-size",
+        type=int,
+        default=None,
+        help=(
+            "Deprecated compatibility alias for --inference-tile-size. "
+            "Use --reference-tile-size separately to enable the reference path."
+        ),
+    )
+    p.add_argument(
+        "--device",
+        type=str,
+        default="cuda:0",
+        help="CUDA device to use.",
+    )
+    p.add_argument(
+        "--ply-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to a trained 3DGS PLY file. When set, the bench loads the "
+            "scene via gsplat.exporter.load_ply_to_splats instead of "
+            "generating synthetic Gaussians. --num-gaussians is ignored and "
+            "--sh-degree is inferred from the PLY contents."
+        ),
+    )
+    p.add_argument(
+        "--save-image",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Render one frame with the inference path and save it as a PNG.",
+    )
+    p.add_argument(
+        "--quality-frames",
+        type=int,
+        default=1,
+        help=(
+            "Number of frames used for Inference-vs-reference PSNR/LPIPS comparison. "
+            "Only used when --reference-tile-size is provided. Set to 0 to skip "
+            "image-quality metrics."
+        ),
+    )
+    p.add_argument(
+        "--lpips-net",
+        type=str,
+        default="alex",
+        choices=["alex", "vgg"],
+        help="LPIPS backbone used for Inference-vs-reference image-quality comparison.",
+    )
+    args = p.parse_args()
+    if args.tile_size is not None:
+        if args.tile_size not in (8, 16):
+            p.error(
+                "--tile-size can only be 8 or 16. Use --reference-tile-size "
+                "separately to enable the reference path."
+            )
+        args.inference_tile_size = args.tile_size
+    if args.quality_frames < 0:
+        p.error("--quality-frames must be non-negative.")
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Synthetic scene and camera helpers
+# ---------------------------------------------------------------------------
+
+
+def make_gaussians(
+    N: int,
+    device: torch.device,
+    sh_degree: Optional[int],
+) -> tuple:
+    """Create random Gaussians placed in front of the camera."""
+    torch.manual_seed(42)
+    means = torch.randn(N, 3, device=device)
+    # Spread Gaussians in a 10-unit cube in front of the camera (z in [2, 12])
+    means[:, 0] *= 5.0
+    means[:, 1] *= 5.0
+    means[:, 2] = means[:, 2].abs() * 5.0 + 2.0
+
+    quats = torch.randn(N, 4, device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+
+    scales = torch.exp(torch.rand(N, 3, device=device) * 0.1 - 2.0)
+
+    opacities = torch.sigmoid(torch.rand(N, device=device) * 2.0 - 1.0)
+
+    if sh_degree is not None and sh_degree >= 0:
+        K_sh = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K_sh, 3, device=device) * 0.1
+    else:
+        colors = torch.sigmoid(torch.randn(N, 3, device=device))
+
+    return means, quats, scales, opacities, colors
+
+
+def make_gaussians_from_ply(
+    path: str,
+    device: torch.device,
+) -> tuple:
+    """Load Gaussians from a trained 3DGS PLY file.
+
+    Returns the same (means, quats, scales, opacities, colors) tuple as
+    :func:`make_gaussians`. ``colors`` is built from the PLY's sh0 (DC) and
+    shN (higher-order) coefficients with shape ``(N, K, 3)`` where
+    ``K = (sh_degree+1)**2``. The inferred SH degree is returned alongside.
+    """
+    from gsplat.exporter import load_ply_to_splats
+
+    splats = load_ply_to_splats(path)
+    # Concatenate SH on CPU to avoid tripling GPU memory (sh0 + shN + colors).
+    colors_cpu = torch.cat([splats["sh0"], splats["shN"]], dim=1)  # (N, K, 3)
+    inferred_sh_degree = int(round(colors_cpu.shape[1] ** 0.5)) - 1
+    means = splats["means"].to(device)
+    quats = F.normalize(splats["quats"].to(device), dim=-1)
+    # PLY stores log-scales and logit-opacities; activate them.
+    scales = torch.exp(splats["scales"]).to(device)
+    opacities = torch.sigmoid(splats["opacities"]).to(device)
+    del splats
+    colors = colors_cpu.to(device)
+    del colors_cpu
+    return means, quats, scales, opacities, colors, inferred_sh_degree
+
+
+def make_intrinsics(width: int, height: int, device: torch.device) -> torch.Tensor:
+    """Simple pinhole intrinsics with ~50-degree horizontal FOV."""
+    focal = width / (2.0 * math.tan(math.radians(25)))
+    K = torch.tensor(
+        [
+            [focal, 0.0, width / 2.0],
+            [0.0, focal, height / 2.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    return K
+
+
+def make_orbit_viewmats(
+    num_frames: int,
+    device: torch.device,
+    radius: float = 7.0,
+    height: float = 0.0,
+    look_at: tuple = (0.0, 0.0, 5.0),
+) -> List[torch.Tensor]:
+    """Generate a circular orbit camera trajectory.
+
+    Returns a list of [4, 4] world-to-camera matrices.
+    """
+    viewmats = []
+    for i in range(num_frames):
+        angle = 2.0 * math.pi * i / num_frames
+        cx = radius * math.cos(angle) + look_at[0]
+        cy = height + look_at[1]
+        cz = radius * math.sin(angle) + look_at[2]
+        cam_pos = torch.tensor([cx, cy, cz], dtype=torch.float32)
+
+        # Look-at direction
+        target = torch.tensor(look_at, dtype=torch.float32)
+        forward = target - cam_pos
+        forward = forward / forward.norm()
+
+        # World up
+        up = torch.tensor([0.0, -1.0, 0.0], dtype=torch.float32)
+
+        right = torch.linalg.cross(forward, up)
+        right = right / right.norm()
+        up = torch.linalg.cross(right, forward)
+
+        # Build rotation (rows = right, -up, forward for OpenGL-style)
+        R = torch.stack([right, -up, forward], dim=0)
+        t = -R @ cam_pos
+
+        viewmat = torch.eye(4, dtype=torch.float32, device=device)
+        viewmat[:3, :3] = R.to(device)
+        viewmat[:3, 3] = t.to(device)
+        viewmats.append(viewmat)
+    return viewmats
+
+
+# ---------------------------------------------------------------------------
+# Timing helpers
+# ---------------------------------------------------------------------------
+
+
+class CudaTimer:
+    """GPU timer using CUDA events for accurate kernel timing."""
+
+    def __init__(self, device: torch.device):
+        self.device = device
+        self._start = torch.cuda.Event(enable_timing=True)
+        self._end = torch.cuda.Event(enable_timing=True)
+
+    def start(self) -> None:
+        self._start.record()
+
+    def stop(self) -> float:
+        """Stop timer and return elapsed time in milliseconds."""
+        self._end.record()
+        torch.cuda.synchronize(self.device)
+        return self._start.elapsed_time(self._end)
+
+
+def summarize_times(times_ms: List[float], label: str, num_frames: int) -> None:
+    """Print a formatted summary of per-frame GPU times."""
+    if not times_ms:
+        print(f"  [{label}]  No timing data collected.\n")
+        return
+    t = torch.tensor(times_ms)
+    mean = t.mean().item()
+    median = t.median().item()
+    mn = t.min().item()
+    mx = t.max().item()
+    std = t.std().item() if len(t) > 1 else 0.0
+    p5 = t.quantile(0.05).item() if len(t) >= 20 else mn
+    p95 = t.quantile(0.95).item() if len(t) >= 20 else mx
+    fps = 1000.0 / median if median > 0 else 0.0
+
+    print(f"  [{label}]")
+    print(f"    Frames : {num_frames}")
+    print(f"    Mean   : {mean:8.3f} ms")
+    print(f"    Median : {median:8.3f} ms")
+    print(f"    Min    : {mn:8.3f} ms")
+    print(f"    Max    : {mx:8.3f} ms")
+    print(f"    StdDev : {std:8.3f} ms")
+    print(f"    P5     : {p5:8.3f} ms")
+    print(f"    P95    : {p95:8.3f} ms")
+    print(f"    FPS    : {fps:8.1f}  (from median)")
+    print()
+
+
+def print_gpu_memory(device: torch.device) -> None:
+    """Print peak GPU memory statistics."""
+    allocated = torch.cuda.max_memory_allocated(device) / (1024**2)
+    reserved = torch.cuda.max_memory_reserved(device) / (1024**2)
+    print(f"  Peak allocated : {allocated:8.1f} MiB")
+    print(f"  Peak reserved  : {reserved:8.1f} MiB")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Image-quality helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_psnr(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Compute PSNR between two images after clamping to [0, 1]."""
+    a = a.float().clamp(0.0, 1.0)
+    b = b.float().clamp(0.0, 1.0)
+    mse = ((a - b) ** 2).mean().item()
+    if mse == 0.0:
+        return float("inf")
+    return 10.0 * math.log10(1.0 / mse)
+
+
+def to_lpips_nchw(image: torch.Tensor) -> torch.Tensor:
+    """Convert [1, H, W, 3] or [H, W, 3] image tensors to LPIPS NCHW input."""
+    image = image.float().clamp(0.0, 1.0)
+    if image.ndim == 3:
+        image = image.unsqueeze(0)
+    return image.permute(0, 3, 1, 2).contiguous()
+
+
+def make_lpips_metric(net_type: str, device: torch.device):
+    """Create the torchmetrics LPIPS metric if the optional dependency is available."""
+    try:
+        from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
+    except Exception as exc:
+        print(f"    LPIPS skipped: torchmetrics LPIPS unavailable ({exc}).")
+        return None
+
+    try:
+        return LearnedPerceptualImagePatchSimilarity(
+            net_type=net_type,
+            normalize=True,
+        ).to(device)
+    except Exception as exc:
+        print(f"    LPIPS skipped: failed to initialize {net_type!r} network ({exc}).")
+        return None
+
+
+def compare_render_quality(
+    means,
+    quats,
+    scales,
+    opacities,
+    colors,
+    viewmats,
+    K,
+    width,
+    height,
+    sh_degree,
+    inference_tile_size,
+    reference_tile_size,
+    quality_frames,
+    lpips_net,
+    device,
+) -> Optional[dict]:
+    """Compare Inference functional output against the reference rasterizer."""
+    if quality_frames == 0:
+        print("  SKIPPED -- --quality-frames=0.\n")
+        return None
+
+    from experimental import GaussianInferenceScene, rasterize_gaussian_inference_scene
+    from gsplat import rasterization
+
+    sh_deg_arg = sh_degree if (sh_degree is not None and sh_degree >= 0) else None
+    Ks = K.unsqueeze(0)
+    lpips_metric = make_lpips_metric(lpips_net, device)
+
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=sh_deg_arg,
+        sh_compression="none",
+        id="quality",
+    )
+
+    psnrs = []
+    lpips_values = []
+
+    with torch.inference_mode():
+        for i in range(quality_frames):
+            vm = viewmats[i % len(viewmats)]
+            inference_ret = rasterize_gaussian_inference_scene(
+                scene,
+                viewmat=vm,
+                K=K,
+                width=width,
+                height=height,
+                tile_size=inference_tile_size,
+            )
+            reference_colors, _, _ = rasterization(
+                means=means,
+                quats=quats,
+                scales=scales,
+                opacities=opacities,
+                colors=colors,
+                viewmats=vm.unsqueeze(0),
+                Ks=Ks,
+                width=width,
+                height=height,
+                render_mode="RGB",
+                packed=False,
+                sh_degree=sh_deg_arg,
+                tile_size=reference_tile_size,
+            )
+
+            inference_frame = inference_ret.frame
+            reference_frame = reference_colors
+            psnrs.append(compute_psnr(reference_frame, inference_frame))
+
+            if lpips_metric is not None:
+                try:
+                    lpips_values.append(
+                        lpips_metric(
+                            to_lpips_nchw(inference_frame),
+                            to_lpips_nchw(reference_frame),
+                        ).item()
+                    )
+                except Exception as exc:
+                    print(f"    LPIPS skipped: metric evaluation failed ({exc}).")
+                    lpips_metric = None
+                    lpips_values = []
+
+    torch.cuda.synchronize(device)
+
+    psnr_tensor = torch.tensor(psnrs)
+    mean_psnr = psnr_tensor.mean().item()
+    min_psnr = psnr_tensor.min().item()
+    max_psnr = psnr_tensor.max().item()
+
+    print(f"    Frames compared : {quality_frames}")
+    print(f"    PSNR mean       : {mean_psnr:8.3f} dB")
+    print(f"    PSNR min/max    : {min_psnr:8.3f} / {max_psnr:8.3f} dB")
+
+    result = {
+        "psnr_mean": mean_psnr,
+        "psnr_min": min_psnr,
+        "psnr_max": max_psnr,
+        "lpips_mean": None,
+    }
+
+    if lpips_values:
+        lpips_tensor = torch.tensor(lpips_values)
+        mean_lpips = lpips_tensor.mean().item()
+        min_lpips = lpips_tensor.min().item()
+        max_lpips = lpips_tensor.max().item()
+        print(f"    LPIPS ({lpips_net})  : {mean_lpips:8.5f}")
+        print(f"    LPIPS min/max  : {min_lpips:8.5f} / {max_lpips:8.5f}")
+        result["lpips_mean"] = mean_lpips
+        result["lpips_min"] = min_lpips
+        result["lpips_max"] = max_lpips
+
+    print()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Benchmark routines
+# ---------------------------------------------------------------------------
+
+
+def bench_stateful(
+    means,
+    quats,
+    scales,
+    opacities,
+    colors,
+    viewmats,
+    K,
+    width,
+    height,
+    sh_degree,
+    tile_size,
+    warmup,
+    num_frames,
+    device,
+) -> tuple:
+    """Benchmark GaussianInferenceRenderer (scene packed once, renderer created once, render per frame).
+
+    Returns:
+        (times, memory_info) where *memory_info* is a dict with keys:
+        ``alloc_before``, ``alloc_after``, ``per_frame_allocs``,
+        ``per_frame_delta``. All allocation values are in bytes.
+    """
+    from experimental import GaussianInferenceScene, GaussianInferenceRenderer
+
+    sh_deg_arg = sh_degree if (sh_degree is not None and sh_degree >= 0) else None
+
+    # Build scene (timed)
+    pack_timer = CudaTimer(device)
+    pack_timer.start()
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=sh_deg_arg,
+        sh_compression="none",
+        id="bench_stateful",
+    )
+    pack_time = pack_timer.stop()
+    print(
+        f"    Scene packing  : {pack_time:8.3f} ms  "
+        f"({scene.num_gaussians} Gaussians)"
+    )
+
+    # Create renderer (timed separately)
+    renderer_timer = CudaTimer(device)
+    renderer_timer.start()
+    renderer = GaussianInferenceRenderer(scene, tile_size=tile_size)
+    renderer_time = renderer_timer.stop()
+    print(f"    Renderer setup : {renderer_time:8.3f} ms")
+
+    timer = CudaTimer(device)
+
+    # Warmup
+    with torch.inference_mode():
+        for i in range(warmup):
+            vm = viewmats[i % len(viewmats)]
+            renderer.render(
+                viewmat=vm,
+                K=K,
+                width=width,
+                height=height,
+            )
+    torch.cuda.synchronize(device)
+
+    alloc_before = torch.cuda.memory_allocated(device)
+
+    # Timed
+    times = []
+    per_frame_allocs = []
+    with torch.inference_mode():
+        for i in range(num_frames):
+            vm = viewmats[(warmup + i) % len(viewmats)]
+            timer.start()
+            renderer.render(
+                viewmat=vm,
+                K=K,
+                width=width,
+                height=height,
+            )
+            elapsed = timer.stop()
+            times.append(elapsed)
+            per_frame_allocs.append(torch.cuda.memory_allocated(device))
+
+    alloc_after = torch.cuda.memory_allocated(device)
+    per_frame_delta = (
+        per_frame_allocs[-1] - per_frame_allocs[0] if per_frame_allocs else 0
+    )
+
+    memory_info = {
+        "alloc_before": alloc_before,
+        "alloc_after": alloc_after,
+        "per_frame_allocs": per_frame_allocs,
+        "per_frame_delta": per_frame_delta,
+    }
+    return times, memory_info
+
+
+def bench_reference(
+    means,
+    quats,
+    scales,
+    opacities,
+    colors,
+    viewmats,
+    K,
+    width,
+    height,
+    sh_degree,
+    tile_size,
+    warmup,
+    num_frames,
+    device,
+) -> Optional[List[float]]:
+    """Benchmark the training rasterization() path under torch.no_grad()."""
+    from gsplat import rasterization
+
+    timer = CudaTimer(device)
+    sh_deg_arg = sh_degree if (sh_degree is not None and sh_degree >= 0) else None
+    Ks = K.unsqueeze(0)
+
+    # Warmup
+    for i in range(warmup):
+        vm = viewmats[i % len(viewmats)].unsqueeze(0)
+        with torch.no_grad():
+            rasterization(
+                means=means,
+                quats=quats,
+                scales=scales,
+                opacities=opacities,
+                colors=colors,
+                viewmats=vm,
+                Ks=Ks,
+                width=width,
+                height=height,
+                render_mode="RGB",
+                packed=False,
+                sh_degree=sh_deg_arg,
+                tile_size=tile_size,
+            )
+    torch.cuda.synchronize(device)
+
+    # Timed
+    times = []
+    for i in range(num_frames):
+        vm = viewmats[(warmup + i) % len(viewmats)].unsqueeze(0)
+        timer.start()
+        with torch.no_grad():
+            rasterization(
+                means=means,
+                quats=quats,
+                scales=scales,
+                opacities=opacities,
+                colors=colors,
+                viewmats=vm,
+                Ks=Ks,
+                width=width,
+                height=height,
+                render_mode="RGB",
+                packed=False,
+                sh_degree=sh_deg_arg,
+                tile_size=tile_size,
+            )
+        elapsed = timer.stop()
+        times.append(elapsed)
+
+    return times
+
+
+# ---------------------------------------------------------------------------
+# Host-sync detection
+# ---------------------------------------------------------------------------
+
+
+def measure_host_sync_overhead(device: torch.device) -> float:
+    """Measure the cost of a bare torch.cuda.synchronize() call (ms)."""
+    import time
+
+    # Warm up the sync path
+    for _ in range(50):
+        torch.cuda.synchronize(device)
+
+    N = 200
+    start = time.perf_counter()
+    for _ in range(N):
+        torch.cuda.synchronize(device)
+    end = time.perf_counter()
+    return (end - start) / N * 1000.0  # ms
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not torch.cuda.is_available():
+        print("ERROR: CUDA is not available. This benchmark requires a GPU.")
+        sys.exit(1)
+
+    device = torch.device(args.device)
+
+    # Import gsplat and probe capabilities
+    import gsplat
+
+    has_3dgs_flag = gsplat.has_3dgs()
+
+    sh_degree = args.sh_degree if args.sh_degree >= 0 else None
+    run_reference = args.reference_tile_size is not None
+
+    # Header
+    print("=" * 70)
+    print("  gsplat Inference benchmark")
+    print("=" * 70)
+    print()
+    print(f"  Device           : {torch.cuda.get_device_name(device)}")
+    print(f"  gsplat version   : {gsplat.__version__}")
+    print(f"  Num Gaussians    : {args.num_gaussians:,}")
+    print(f"  Resolution       : {args.width} x {args.height}")
+    print(
+        f"  SH degree        : {args.sh_degree} "
+        f"({'RGB' if sh_degree is None else f'SH K={(sh_degree+1)**2}'})"
+    )
+    print(f"  Inference tile size    : {args.inference_tile_size}")
+    if run_reference:
+        print(f"  Reference tile   : {args.reference_tile_size}")
+    else:
+        print("  Reference path   : disabled")
+    print(f"  Warmup frames    : {args.warmup_frames}")
+    print(f"  Timed frames     : {args.num_frames}")
+    if run_reference:
+        print(f"  Quality frames   : {args.quality_frames}")
+        print(f"  LPIPS net        : {args.lpips_net}")
+    print()
+    print(f"  has_3dgs()                    : {has_3dgs_flag}")
+    print()
+
+    if args.ply_path is not None:
+        print(f"Loading PLY scene {args.ply_path!r} ... ", end="", flush=True)
+        (
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            ply_sh_degree,
+        ) = make_gaussians_from_ply(args.ply_path, device)
+        sh_degree = ply_sh_degree if ply_sh_degree >= 0 else None
+        print(f"done ({means.size(0):,} Gaussians, SH degree {ply_sh_degree}).")
+        scene_center = means.median(dim=0).values.cpu()
+        radius = 2.0
+    else:
+        print("Generating synthetic scene ... ", end="", flush=True)
+        means, quats, scales, opacities, colors = make_gaussians(
+            args.num_gaussians,
+            device,
+            sh_degree,
+        )
+        print("done.")
+        scene_center = torch.tensor([0.0, 0.0, 5.0])
+        radius = 7.0
+
+    # Generate camera intrinsics and orbit trajectory
+    K = make_intrinsics(args.width, args.height, device)
+    quality_frames_needed = args.quality_frames if run_reference else 0
+    total_frames_needed = max(
+        1,
+        args.warmup_frames + args.num_frames,
+        quality_frames_needed,
+    )
+    viewmats = make_orbit_viewmats(
+        total_frames_needed,
+        device,
+        radius=radius,
+        look_at=tuple(scene_center.tolist()),
+    )
+    print(f"Generated {total_frames_needed} camera poses (circular orbit).")
+    print()
+
+    # ------------------------------------------------------------------
+    # Optional: save a single rendered frame for visual sanity check
+    # ------------------------------------------------------------------
+    if args.save_image is not None:
+        from PIL import Image
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        sh_deg_arg = sh_degree if (sh_degree is not None and sh_degree >= 0) else None
+
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=sh_deg_arg,
+            sh_compression="none",
+            id="preview",
+        )
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene,
+                viewmat=viewmats[0],
+                K=K,
+                width=args.width,
+                height=args.height,
+                tile_size=args.inference_tile_size,
+            )
+        img = (ret.frame[0].clamp(0.0, 1.0) * 255).to(torch.uint8).cpu()
+        Image.fromarray(img.numpy()).save(args.save_image)
+        print(f"Saved Inference preview to {args.save_image!r}")
+
+        if run_reference and has_3dgs_flag:
+            from gsplat import rasterization
+
+            vm = viewmats[0].unsqueeze(0)
+            Ks = K.unsqueeze(0)
+            with torch.no_grad():
+                render_colors, _, _ = rasterization(
+                    means=means,
+                    quats=quats,
+                    scales=scales,
+                    opacities=opacities,
+                    colors=colors,
+                    viewmats=vm,
+                    Ks=Ks,
+                    width=args.width,
+                    height=args.height,
+                    render_mode="RGB",
+                    packed=False,
+                    sh_degree=sh_deg_arg,
+                    tile_size=args.reference_tile_size,
+                )
+            img = (render_colors[0].clamp(0.0, 1.0) * 255).to(torch.uint8).cpu()
+            from pathlib import Path
+
+            p = Path(args.save_image)
+            ref_path = str(p.with_stem(p.stem + "_ref"))
+            Image.fromarray(img.numpy()).save(ref_path)
+            print(f"Saved reference preview to {ref_path!r}")
+        elif run_reference:
+            print("WARNING: --save-image reference preview requires 3DGS; skipping.")
+
+        print()
+
+    # Common args tuples for benchmark calls. Tile sizes are path-specific
+    # because Inference supports {8, 16} while the 3DGS reference path supports {4, 16}.
+    inference_bench_args = (
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        viewmats,
+        K,
+        args.width,
+        args.height,
+        sh_degree,
+        args.inference_tile_size,
+        args.warmup_frames,
+        args.num_frames,
+        device,
+    )
+
+    # ------------------------------------------------------------------
+    # 1. Stateful renderer benchmark (GaussianInferenceRenderer)
+    # ------------------------------------------------------------------
+    print("-" * 70)
+    print("  1. Stateful renderer  (GaussianInferenceRenderer)")
+    print("-" * 70)
+    times_stateful = None
+    stateful_memory_info = None
+    torch.cuda.reset_peak_memory_stats(device)
+    try:
+        times_stateful, stateful_memory_info = bench_stateful(*inference_bench_args)
+        summarize_times(times_stateful, "Stateful", args.num_frames)
+        # Print workspace-reuse memory diagnostics
+        alloc_before = stateful_memory_info["alloc_before"]
+        alloc_after = stateful_memory_info["alloc_after"]
+        delta = stateful_memory_info["per_frame_delta"]
+        grew = alloc_after > alloc_before
+        print(f"    Alloc before timed loop : {alloc_before / (1024**2):8.1f} MiB")
+        print(f"    Alloc after  timed loop : {alloc_after / (1024**2):8.1f} MiB")
+        print(f"    Allocation grew         : {'YES' if grew else 'no'}")
+        print(f"    Per-frame delta (first->last) : {delta / 1024:+.1f} KiB")
+        print()
+    except Exception as exc:
+        print(f"  FAILED -- {exc}\n")
+    print_gpu_memory(device)
+
+    # ------------------------------------------------------------------
+    # 2. Reference path benchmark
+    # ------------------------------------------------------------------
+    times_ref = None
+    if run_reference:
+        reference_bench_args = (
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            viewmats,
+            K,
+            args.width,
+            args.height,
+            sh_degree,
+            args.reference_tile_size,
+            args.warmup_frames,
+            args.num_frames,
+            device,
+        )
+        print("-" * 70)
+        print("  2. Reference path  (rasterization + no_grad)")
+        print("-" * 70)
+    if run_reference and has_3dgs_flag:
+        torch.cuda.reset_peak_memory_stats(device)
+        try:
+            times_ref = bench_reference(*reference_bench_args)
+            summarize_times(times_ref, "Reference", args.num_frames)
+        except Exception as exc:
+            print(f"  FAILED -- {exc}\n")
+            times_ref = None
+        print_gpu_memory(device)
+    elif run_reference:
+        print("  SKIPPED -- 3DGS not built.\n")
+
+    # ------------------------------------------------------------------
+    # 3. Image-quality comparison
+    # ------------------------------------------------------------------
+    quality_result = None
+    if run_reference:
+        print("-" * 70)
+        print("  3. Image quality  (Inference vs reference)")
+        print("-" * 70)
+    if run_reference and has_3dgs_flag:
+        torch.cuda.reset_peak_memory_stats(device)
+        try:
+            quality_result = compare_render_quality(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                viewmats,
+                K,
+                args.width,
+                args.height,
+                sh_degree,
+                args.inference_tile_size,
+                args.reference_tile_size,
+                args.quality_frames,
+                args.lpips_net,
+                device,
+            )
+        except Exception as exc:
+            print(f"  FAILED -- {exc}\n")
+            quality_result = None
+        print_gpu_memory(device)
+    elif run_reference:
+        print("  SKIPPED -- 3DGS not built.\n")
+
+    # ------------------------------------------------------------------
+    # 4. Host synchronization overhead
+    # ------------------------------------------------------------------
+    print("-" * 70)
+    print("  4. Host synchronization overhead")
+    print("-" * 70)
+    sync_ms = measure_host_sync_overhead(device)
+    print(f"    Mean sync cost : {sync_ms:8.4f} ms  (200 iterations)")
+    print()
+
+    # ------------------------------------------------------------------
+    # GPU memory summary (aggregate)
+    # ------------------------------------------------------------------
+    print("-" * 70)
+    print("  GPU Memory (peak across all benchmarks)")
+    print("-" * 70)
+    print_gpu_memory(device)
+
+    # ------------------------------------------------------------------
+    # Comparison table
+    # ------------------------------------------------------------------
+    print("=" * 70)
+    print("  Summary comparison")
+    print("=" * 70)
+    print()
+    header = (
+        f"  {'Path':<30s}  {'Mean':>8s}  {'Median':>8s}  {'Min':>8s}"
+        f"  {'Max':>8s}  {'StdDev':>8s}  {'P5':>8s}  {'P95':>8s}  {'FPS':>8s}"
+    )
+    print(header)
+    print("  " + "-" * (len(header.strip())))
+
+    na = "N/A"
+
+    def _row(label: str, times: Optional[List[float]]) -> None:
+        if times is None:
+            print(
+                f"  {label:<30s}  {na:>8s}  {na:>8s}  {na:>8s}"
+                f"  {na:>8s}  {na:>8s}  {na:>8s}  {na:>8s}  {na:>8s}"
+            )
+            return
+        t = torch.tensor(times)
+        mean = t.mean().item()
+        median = t.median().item()
+        mn = t.min().item()
+        mx = t.max().item()
+        std = t.std().item() if len(t) > 1 else 0.0
+        p5 = t.quantile(0.05).item() if len(t) >= 20 else mn
+        p95 = t.quantile(0.95).item() if len(t) >= 20 else mx
+        fps = 1000.0 / median if median > 0 else 0.0
+        print(
+            f"  {label:<30s}  {mean:8.3f}  {median:8.3f}  {mn:8.3f}"
+            f"  {mx:8.3f}  {std:8.3f}  {p5:8.3f}  {p95:8.3f}  {fps:8.1f}"
+        )
+
+    _row("Stateful (InferenceRenderer)", times_stateful)
+    if run_reference:
+        _row("Reference (rasterization)", times_ref)
+
+    # Speedup calculations
+    if run_reference and times_ref is not None:
+        ref_median = torch.tensor(times_ref).median().item()
+        print()
+        if times_stateful is not None:
+            stat_median = torch.tensor(times_stateful).median().item()
+            speedup = ref_median / stat_median if stat_median > 0 else float("inf")
+            print(f"  Stateful    vs Reference speedup : {speedup:.2f}x")
+
+    if quality_result is not None:
+        print()
+        print(f"  Inference vs Reference PSNR  : {quality_result['psnr_mean']:.3f} dB")
+        if quality_result["lpips_mean"] is not None:
+            print(
+                f"  Inference vs Reference LPIPS : "
+                f"{quality_result['lpips_mean']:.5f} ({args.lpips_net})"
+            )
+
+    print()
+    print("=" * 70)
+    print("  Benchmark complete.")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gsplat_viewer.py
+++ b/examples/gsplat_viewer.py
@@ -59,7 +59,9 @@ class GsplatViewer(Viewer):
         render_fn: Callable,
         output_dir: Path,
         mode: Literal["rendering", "training"] = "rendering",
+        render_modes: tuple = ("rgb", "depth(accumulated)", "depth(expected)", "alpha"),
     ):
+        self._render_modes = render_modes
         super().__init__(server, render_fn, output_dir, mode)
         server.gui.set_panel_label("gsplat viewer")
 
@@ -160,7 +162,7 @@ class GsplatViewer(Viewer):
 
                 render_mode_dropdown = server.gui.add_dropdown(
                     "Render Mode",
-                    ("rgb", "depth(accumulated)", "depth(expected)", "alpha"),
+                    self._render_modes,
                     initial_value=self.render_tab_state.render_mode,
                     hint="Render mode to use.",
                 )

--- a/examples/simple_viewer.py
+++ b/examples/simple_viewer.py
@@ -16,7 +16,11 @@
 import argparse
 import math
 import os
+import sys
 import time
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import imageio
 import numpy as np
@@ -27,7 +31,10 @@ import viser
 from pathlib import Path
 from gsplat._helper import load_test_data
 from gsplat.distributed import cli
+from gsplat.exporter import load_ply_to_splats
 from gsplat.rendering import rasterization
+from libs.scene import GaussianScene
+import experimental
 
 from nerfview import CameraState, RenderTabState, apply_float_colormap
 from gsplat_viewer import GsplatViewer, GsplatRenderTabState
@@ -37,7 +44,29 @@ def main(local_rank: int, world_rank, world_size: int, args):
     torch.manual_seed(42)
     device = torch.device("cuda", local_rank)
 
-    if args.ckpt is None:
+    if args.ply is not None:
+        splats_dict = load_ply_to_splats(args.ply)
+        means = splats_dict["means"].to(device)
+        quats = F.normalize(splats_dict["quats"].to(device), p=2, dim=-1)
+        scales_raw = splats_dict["scales"].to(device)
+        opacities_raw = splats_dict["opacities"].to(device)
+        sh0_t = splats_dict["sh0"].to(device)
+        shN_t = splats_dict["shN"].to(device)
+        colors = torch.cat([sh0_t, shN_t], dim=-2)
+        sh_degree = int(math.sqrt(colors.shape[-2]) - 1)
+        print("Number of Gaussians:", len(means))
+
+        splats = torch.nn.ParameterDict(
+            {
+                "means": torch.nn.Parameter(means, requires_grad=False),
+                "quats": torch.nn.Parameter(quats, requires_grad=False),
+                "scales": torch.nn.Parameter(scales_raw, requires_grad=False),
+                "opacities": torch.nn.Parameter(opacities_raw, requires_grad=False),
+                "colors": torch.nn.Parameter(colors, requires_grad=False),
+            }
+        )
+        gaussian_scene = GaussianScene.from_splats(splats, id="viewer_scene")
+    elif args.ckpt is None:
         (
             means,
             quats,
@@ -52,15 +81,10 @@ def main(local_rank: int, world_rank, world_size: int, args):
 
         assert world_size <= 2
         means = means[world_rank::world_size].contiguous()
-        means.requires_grad = True
         quats = quats[world_rank::world_size].contiguous()
-        quats.requires_grad = True
         scales = scales[world_rank::world_size].contiguous()
-        scales.requires_grad = True
         opacities = opacities[world_rank::world_size].contiguous()
-        opacities.requires_grad = True
         colors = colors[world_rank::world_size].contiguous()
-        colors.requires_grad = True
 
         viewmats = viewmats[world_rank::world_size][:1].contiguous()
         Ks = Ks[world_rank::world_size][:1].contiguous()
@@ -70,8 +94,8 @@ def main(local_rank: int, world_rank, world_size: int, args):
         N = len(means)
         print("rank", world_rank, "Number of Gaussians:", N, "Number of Cameras:", C)
 
-        # batched render
-        for _ in tqdm.trange(1):
+        # batched render (skipped for inference render: no backward, no RGB+D)
+        for _ in tqdm.trange(0 if args.use_gaussian_render_inference_scene else 1):
             render_colors, render_alphas, meta = rasterization(
                 means,  # [N, 3]
                 quats,  # [N, 4]
@@ -86,56 +110,94 @@ def main(local_rank: int, world_rank, world_size: int, args):
                 packed=False,
                 distributed=world_size > 1,
             )
-        C = render_colors.shape[0]
-        assert render_colors.shape == (C, height, width, 4)
-        assert render_alphas.shape == (C, height, width, 1)
-        render_colors.sum().backward()
+        if not args.use_gaussian_render_inference_scene:
+            C = render_colors.shape[0]
+            assert render_colors.shape == (C, height, width, 4)
+            assert render_alphas.shape == (C, height, width, 1)
 
-        render_rgbs = render_colors[..., 0:3]
-        render_depths = render_colors[..., 3:4]
-        render_depths = render_depths / render_depths.max()
+            render_rgbs = render_colors[..., 0:3]
+            render_depths = render_colors[..., 3:4]
+            render_depths = render_depths / render_depths.max()
 
-        # dump batch images
-        os.makedirs(args.output_dir, exist_ok=True)
-        canvas = (
-            torch.cat(
-                [
-                    render_rgbs.reshape(C * height, width, 3),
-                    render_depths.reshape(C * height, width, 1).expand(-1, -1, 3),
-                    render_alphas.reshape(C * height, width, 1).expand(-1, -1, 3),
-                ],
-                dim=1,
+            # dump batch images
+            os.makedirs(args.output_dir, exist_ok=True)
+            canvas = (
+                torch.cat(
+                    [
+                        render_rgbs.reshape(C * height, width, 3),
+                        render_depths.reshape(C * height, width, 1).expand(-1, -1, 3),
+                        render_alphas.reshape(C * height, width, 1).expand(-1, -1, 3),
+                    ],
+                    dim=1,
+                )
+                .detach()
+                .cpu()
+                .numpy()
             )
-            .detach()
-            .cpu()
-            .numpy()
+            imageio.imsave(
+                f"{args.output_dir}/render_rank{world_rank}.png",
+                (canvas * 255).astype(np.uint8),
+            )
+
+        # Build GaussianScene for viewer callback (needs raw/log-space tensors)
+        splats = torch.nn.ParameterDict(
+            {
+                "means": torch.nn.Parameter(means.detach(), requires_grad=False),
+                "quats": torch.nn.Parameter(quats.detach(), requires_grad=False),
+                "scales": torch.nn.Parameter(
+                    scales.detach().log(), requires_grad=False
+                ),
+                "opacities": torch.nn.Parameter(
+                    torch.logit(opacities.detach().clamp(1e-6, 1 - 1e-6)),
+                    requires_grad=False,
+                ),
+                "colors": torch.nn.Parameter(colors.detach(), requires_grad=False),
+            }
         )
-        imageio.imsave(
-            f"{args.output_dir}/render_rank{world_rank}.png",
-            (canvas * 255).astype(np.uint8),
-        )
+        gaussian_scene = GaussianScene.from_splats(splats, id="viewer_scene")
     else:
-        means, quats, scales, opacities, sh0, shN = [], [], [], [], [], []
+        means, quats_list, scales_raw, opacities_raw, sh0, shN = [], [], [], [], [], []
         for ckpt_path in args.ckpt:
             ckpt = torch.load(ckpt_path, map_location=device)["splats"]
             means.append(ckpt["means"])
-            quats.append(F.normalize(ckpt["quats"], p=2, dim=-1))
-            scales.append(torch.exp(ckpt["scales"]))
-            opacities.append(torch.sigmoid(ckpt["opacities"]))
+            quats_list.append(F.normalize(ckpt["quats"], p=2, dim=-1))
+            scales_raw.append(ckpt["scales"])  # raw log-space
+            opacities_raw.append(ckpt["opacities"])  # raw logit-space
             sh0.append(ckpt["sh0"])
             shN.append(ckpt["shN"])
         means = torch.cat(means, dim=0)
-        quats = torch.cat(quats, dim=0)
-        scales = torch.cat(scales, dim=0)
-        opacities = torch.cat(opacities, dim=0)
+        quats = torch.cat(quats_list, dim=0)
+        scales_raw = torch.cat(scales_raw, dim=0)
+        opacities_raw = torch.cat(opacities_raw, dim=0)
         sh0 = torch.cat(sh0, dim=0)
         shN = torch.cat(shN, dim=0)
         colors = torch.cat([sh0, shN], dim=-2)
         sh_degree = int(math.sqrt(colors.shape[-2]) - 1)
         print("Number of Gaussians:", len(means))
 
+        splats = torch.nn.ParameterDict(
+            {
+                "means": torch.nn.Parameter(means, requires_grad=False),
+                "quats": torch.nn.Parameter(quats, requires_grad=False),
+                "scales": torch.nn.Parameter(scales_raw, requires_grad=False),
+                "opacities": torch.nn.Parameter(opacities_raw, requires_grad=False),
+                "colors": torch.nn.Parameter(colors, requires_grad=False),
+            }
+        )
+        gaussian_scene = GaussianScene.from_splats(splats, id="viewer_scene")
+
+    # Build Inference scene if requested (after both loading paths)
+    inference_scene = None
+    inference_renderer = None
+    if args.use_gaussian_render_inference_scene:
+        inference_scene = experimental.GaussianInferenceScene.from_gaussian_scene(
+            gaussian_scene, id="viewer_scene", sh_compression="32b"
+        )
+        inference_renderer = experimental.GaussianInferenceRenderer(
+            inference_scene
+        )
+
     # register and open viewer
-    @torch.no_grad()
     def viewer_render_fn(camera_state: CameraState, render_tab_state: RenderTabState):
         assert isinstance(render_tab_state, GsplatRenderTabState)
         if render_tab_state.preview_render:
@@ -148,53 +210,87 @@ def main(local_rank: int, world_rank, world_size: int, args):
         K = camera_state.get_K((width, height))
         c2w = torch.from_numpy(c2w).float().to(device)
         K = torch.from_numpy(K).float().to(device)
-        viewmat = c2w.inverse()
+        viewmat = c2w.inverse().contiguous()
 
-        RENDER_MODE_MAP = {
-            "rgb": "RGB",
-            "depth(accumulated)": "D",
-            "depth(expected)": "ED",
-            "alpha": "RGB",
-        }
+        if args.use_gaussian_render_inference_scene:
+            bg_raw = render_tab_state.backgrounds
+            bg = torch.tensor(bg_raw, device=device) / 255.0
+            render_kwargs = dict(
+                viewmat=viewmat,
+                K=K,
+                width=width,
+                height=height,
+                near_plane=render_tab_state.near_plane,
+                far_plane=render_tab_state.far_plane,
+                radius_clip=render_tab_state.radius_clip,
+                eps2d=render_tab_state.eps2d,
+                background=bg,
+            )
+        else:
+            RENDER_MODE_MAP = {
+                "rgb": "RGB",
+                "depth(accumulated)": "D",
+                "depth(expected)": "ED",
+                "alpha": "RGB",
+            }
+            splats = gaussian_scene.splats
+            render_kwargs = dict(
+                viewmats=viewmat[None],
+                Ks=K[None],
+                width=width,
+                height=height,
+                sh_degree=(
+                    min(render_tab_state.max_sh_degree, sh_degree)
+                    if sh_degree is not None
+                    else None
+                ),
+                near_plane=render_tab_state.near_plane,
+                far_plane=render_tab_state.far_plane,
+                radius_clip=render_tab_state.radius_clip,
+                eps2d=render_tab_state.eps2d,
+                backgrounds=torch.tensor([render_tab_state.backgrounds], device=device)
+                / 255.0,
+                render_mode=RENDER_MODE_MAP[render_tab_state.render_mode],
+                rasterize_mode=render_tab_state.rasterize_mode,
+                camera_model=render_tab_state.camera_model,
+                packed=False,
+                with_ut=args.with_ut,
+                with_eval3d=args.with_eval3d,
+            )
 
-        render_colors, render_alphas, info = rasterization(
-            means,  # [N, 3]
-            quats,  # [N, 4]
-            scales,  # [N, 3]
-            opacities,  # [N]
-            colors,  # [N, S, 3]
-            viewmat[None],  # [1, 4, 4]
-            K[None],  # [1, 3, 3]
-            width,
-            height,
-            sh_degree=(
-                min(render_tab_state.max_sh_degree, sh_degree)
-                if sh_degree is not None
-                else None
-            ),
-            near_plane=render_tab_state.near_plane,
-            far_plane=render_tab_state.far_plane,
-            radius_clip=render_tab_state.radius_clip,
-            eps2d=render_tab_state.eps2d,
-            backgrounds=torch.tensor([render_tab_state.backgrounds], device=device)
-            / 255.0,
-            render_mode=RENDER_MODE_MAP[render_tab_state.render_mode],
-            rasterize_mode=render_tab_state.rasterize_mode,
-            camera_model=render_tab_state.camera_model,
-            packed=False,
-            with_ut=args.with_ut,
-            with_eval3d=args.with_eval3d,
-        )
-        render_tab_state.total_gs_count = len(means)
-        render_tab_state.rendered_gs_count = (info["radii"] > 0).all(-1).sum().item()
+        with torch.inference_mode():
+            if args.use_gaussian_render_inference_scene:
+                ret = inference_renderer.render(**render_kwargs)
+            else:
+                render_colors_out, render_alphas_out, render_info = rasterization(
+                    splats["means"],
+                    splats["quats"],
+                    splats["scales"].exp(),
+                    splats["opacities"].sigmoid(),
+                    splats.get("colors", splats.get("sh0")),
+                    **render_kwargs,
+                )
+
+        if args.use_gaussian_render_inference_scene:
+            render_tab_state.total_gs_count = inference_scene.num_gaussians
+            render_tab_state.rendered_gs_count = 0
+            # Stateful Inference returns native half4 RGBT; the viewer displays RGB.
+            renders = ret.frame.squeeze(0)[..., :3].float().clamp(0, 1).cpu().numpy()
+            return renders
+
+        # Vanilla branch post-processing (using direct rasterization outputs)
+        render_tab_state.total_gs_count = gaussian_scene.splats["means"].shape[0]
+        radii = render_info.get("radii")
+        if radii is not None:
+            render_tab_state.rendered_gs_count = (radii > 0).all(-1).sum().item()
+        else:
+            render_tab_state.rendered_gs_count = 0
 
         if render_tab_state.render_mode == "rgb":
-            # colors represented with sh are not guranteed to be in [0, 1]
-            render_colors = render_colors[0, ..., 0:3].clamp(0, 1)
+            render_colors = render_colors_out[0, ..., 0:3].clamp(0, 1)
             renders = render_colors.cpu().numpy()
         elif render_tab_state.render_mode in ["depth(accumulated)", "depth(expected)"]:
-            # normalize depth to [0, 1]
-            depth = render_colors[0, ..., 0:1]
+            depth = render_colors_out[0, ..., 0:1]
             if render_tab_state.normalize_nearfar:
                 near_plane = render_tab_state.near_plane
                 far_plane = render_tab_state.far_plane
@@ -211,19 +307,22 @@ def main(local_rank: int, world_rank, world_size: int, args):
                 .numpy()
             )
         elif render_tab_state.render_mode == "alpha":
-            alpha = render_alphas[0, ..., 0:1]
+            alpha = render_alphas_out[0, ..., 0:1]
             renders = (
                 apply_float_colormap(alpha, render_tab_state.colormap).cpu().numpy()
             )
         return renders
 
     server = viser.ViserServer(port=args.port, verbose=False)
-    _ = GsplatViewer(
+    viewer_kwargs = dict(
         server=server,
         render_fn=viewer_render_fn,
         output_dir=Path(args.output_dir),
         mode="rendering",
     )
+    if args.use_gaussian_render_inference_scene:
+        viewer_kwargs["render_modes"] = ("rgb",)
+    _ = GsplatViewer(**viewer_kwargs)
     print("Viewer running... Ctrl+C to exit.")
     time.sleep(100000)
 
@@ -235,7 +334,7 @@ if __name__ == "__main__":
         --ckpt results/garden/ckpts/ckpt_6999_rank0.pt \
         --output_dir results/garden/ \
         --port 8082
-    
+
     CUDA_VISIBLE_DEVICES=9 python -m simple_viewer \
         --output_dir results/garden/ \
         --port 8082
@@ -250,6 +349,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ckpt", type=str, nargs="+", default=None, help="path to the .pt file"
     )
+    parser.add_argument("--ply", type=str, default=None, help="path to a 3DGS PLY file")
     parser.add_argument(
         "--port", type=int, default=8080, help="port for the viewer server"
     )
@@ -257,6 +357,11 @@ if __name__ == "__main__":
         "--with_ut", action="store_true", help="use uncentered transform"
     )
     parser.add_argument("--with_eval3d", action="store_true", help="use eval 3D")
+    parser.add_argument(
+        "--use_gaussian_render_inference_scene",
+        action="store_true",
+        help="use the Inference (non-differentiable) rasterization path",
+    )
     args = parser.parse_args()
     assert args.scene_grid % 2 == 1, "scene_grid must be odd"
 

--- a/examples/simple_viewer.py
+++ b/examples/simple_viewer.py
@@ -193,9 +193,7 @@ def main(local_rank: int, world_rank, world_size: int, args):
         inference_scene = experimental.GaussianInferenceScene.from_gaussian_scene(
             gaussian_scene, id="viewer_scene", sh_compression="32b"
         )
-        inference_renderer = experimental.GaussianInferenceRenderer(
-            inference_scene
-        )
+        inference_renderer = experimental.GaussianInferenceRenderer(inference_scene)
 
     # register and open viewer
     def viewer_render_fn(camera_state: CameraState, render_tab_state: RenderTabState):

--- a/experimental/__init__.py
+++ b/experimental/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = [
+    "GaussianInferenceRenderer",
+    "GaussianInferenceScene",
+    "RenderReturn",
+    "rasterize_gaussian_inference_scene",
+    "render_scene",
+]
+
+
+def __getattr__(name):
+    if name == "GaussianInferenceScene":
+        from libs.scene import GaussianInferenceScene
+
+        return GaussianInferenceScene
+    if name == "GaussianInferenceRenderer":
+        from .render.components import GaussianInferenceRenderer
+
+        return GaussianInferenceRenderer
+    if name in {"RenderReturn", "rasterize_gaussian_inference_scene", "render_scene"}:
+        from . import render
+
+        return getattr(render, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/render/__init__.py
+++ b/experimental/render/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = [
+    "GaussianInferenceRenderer",
+    "RenderReturn",
+    "rasterize_gaussian_inference_scene",
+    "render_scene",
+]
+
+
+def __getattr__(name):
+    if name == "GaussianInferenceRenderer":
+        from .components import GaussianInferenceRenderer
+
+        return GaussianInferenceRenderer
+    if name == "RenderReturn":
+        from .types import RenderReturn
+
+        return RenderReturn
+    if name == "rasterize_gaussian_inference_scene":
+        from .functional.gaussian_inference import rasterize_gaussian_inference_scene
+
+        return rasterize_gaussian_inference_scene
+    if name == "render_scene":
+        from .functional.render_scene import render_scene
+
+        return render_scene
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/render/_common.py
+++ b/experimental/render/_common.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Shared helpers for experimental render wrappers."""
+
+from __future__ import annotations
+
+import torch
+
+
+def check_inference_grad_mode() -> None:
+    """Raise if autograd is enabled and inference mode is off."""
+    if torch.is_grad_enabled() and not torch.is_inference_mode_enabled():
+        raise RuntimeError(
+            "rasterize_gaussian_inference_scene requires "
+            "torch.inference_mode() or torch.no_grad()"
+        )
+
+
+__all__ = ["check_inference_grad_mode"]

--- a/experimental/render/components/__init__.py
+++ b/experimental/render/components/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = ["GaussianInferenceRenderer"]
+
+
+def __getattr__(name):
+    if name == "GaussianInferenceRenderer":
+        from .gaussian_inference_renderer import GaussianInferenceRenderer
+
+        return GaussianInferenceRenderer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/render/components/gaussian_inference_renderer.py
+++ b/experimental/render/components/gaussian_inference_renderer.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Stateful Gaussian Inference renderer component."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+from torch import Tensor
+
+from libs.scene import GaussianInferenceScene
+
+from experimental.render._common import check_inference_grad_mode
+from experimental.render.kernels.gaussian_inference_ops import (
+    create_native_gaussian_inference_renderer,
+)
+from experimental.render.types import RenderReturn
+
+
+# ---------------------------------------------------------------------------
+# Unsupported-feature set for the stateful renderer (same as the stateless
+# path, minus the ones that are simply not parameters there like
+# render_mode / camera_model, plus a few extras).
+# ---------------------------------------------------------------------------
+
+_RENDERER_UNSUPPORTED_KWARGS = frozenset(
+    {
+        "with_ut",
+        "with_eval3d",
+        "absgrad",
+        "sparse_grad",
+        "distributed",
+        "packed",
+        "segmented",
+        "return_normals",
+        "covars",
+        "rays",
+        "radial_coeffs",
+        "tangential_coeffs",
+        "thin_prism_coeffs",
+        "ftheta_coeffs",
+        "lidar_coeffs",
+        "external_distortion_coeffs",
+        "rolling_shutter",
+        "viewmats_rs",
+        "extra_signals",
+        "extra_signals_sh_degree",
+        "rasterize_mode",
+        "channel_chunk",
+        "global_z_order",
+        "ut_params",
+        "colors",
+        "render_mode",
+        "camera_model",
+        "backgrounds",
+        "sh_compression_mode",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# GaussianInferenceRenderer  (stateful, persistent buffer reuse)
+# ---------------------------------------------------------------------------
+
+
+class GaussianInferenceRenderer:
+    """Stateful Inference renderer that caches per-scene and per-frame GPU buffers.
+
+    Wraps the C++ ``GaussianInferenceRenderer`` for persistent buffer reuse across frames.
+    Unlike the stateless :func:`rasterize_gaussian_inference_scene`, this class
+        pre-allocates projection, visibility, color, and intersection buffers
+        in the native renderer.  The native half4 output buffer is owned by
+        Python and passed as an ``out`` tensor so rasterization writes directly
+        into it.
+
+    Usage::
+
+        scene = GaussianInferenceScene(...)
+        with GaussianInferenceRenderer(scene) as renderer:
+            result = renderer.render(
+                viewmat=viewmat, K=K, width=1920, height=1080,
+            )
+            # result.frame is [1, H, W, 4] float16 RGBT
+
+    Parameters
+    ----------
+    scene : GaussianInferenceScene
+        Packed scene to render.  Must not be empty.
+    tile_size : int, optional
+        Default tile size for rasterisation (8 or 16).  Can be overridden
+        per-frame via :meth:`render`.  Default is 8.
+    """
+
+    def __init__(self, scene: Any, *, tile_size: int = 8) -> None:
+        if not isinstance(scene, GaussianInferenceScene):
+            raise TypeError(
+                f"GaussianInferenceRenderer requires a GaussianInferenceScene; "
+                f"got {type(scene).__name__}"
+            )
+
+        if scene.is_empty():
+            raise ValueError(
+                "GaussianInferenceScene has been released and contains no packed "
+                "tensors. Did you forget to rebuild the snapshot?"
+            )
+
+        if tile_size not in (8, 16):
+            raise ValueError(f"tile_size must be 8 or 16; got {tile_size}")
+
+        # -- Create native renderer ----------------------------------------
+        self._native = create_native_gaussian_inference_renderer(
+            scene.means_planar,
+            scene.qso_packed,
+            scene.colors_packed,
+            scene.sh_degree,
+            scene.sh_compression_mode,
+        )
+        self._scene = scene
+        self._tile_size = tile_size
+        self._frame_buffer: Optional[Tensor] = None
+        self._frame_buffer_shape: Optional[tuple[int, int, int, int]] = None
+
+    # ------------------------------------------------------------------
+    # render
+    # ------------------------------------------------------------------
+
+    def render(
+        self,
+        *,
+        viewmat: Optional[Tensor] = None,
+        viewmats: Optional[Tensor] = None,
+        K: Optional[Tensor] = None,
+        Ks: Optional[Tensor] = None,
+        width: int,
+        height: int,
+        tile_size: Optional[int] = None,
+        near_plane: float = 0.01,
+        far_plane: float = 1e10,
+        radius_clip: float = 0.0,
+        eps2d: float = 0.3,
+        background: Optional[Tensor] = None,
+        sh_degree: Optional[int] = None,
+        out: Optional[RenderReturn] = None,
+        **kwargs: Any,
+    ) -> RenderReturn:
+        """Render a single frame.
+
+        Parameters
+        ----------
+        viewmat, viewmats : Tensor
+            Camera extrinsics.  Pass exactly one; if *viewmats* is given it
+            must have leading dim 1.
+        K, Ks : Tensor
+            Camera intrinsics.  Pass exactly one; if *Ks* is given it must
+            have leading dim 1.
+        width, height : int
+            Output resolution in pixels.
+        tile_size : int, optional
+            Override the default tile size set at construction time.
+        near_plane, far_plane : float
+            Clipping planes.
+        radius_clip : float
+            Gaussians with projected radius below this are culled.
+        eps2d : float
+            Covariance regularisation epsilon.
+        background : Tensor, optional
+            Background color ``[3]`` float32.
+        sh_degree : int, optional
+            Per-frame SH degree (clamped to scene max in C++).  Defaults to
+            the scene's SH degree.
+        out : RenderReturn, optional
+            Pre-allocated half4 output buffer to write into.
+
+        Returns
+        -------
+        RenderReturn
+            ``.frame`` is ``[1, H, W, 4]`` float16 with channels
+            ``{R, G, B, T}``, where ``T`` is transmittance.  Callers that need
+            alpha should compute ``1 - frame[..., 3:4]``.
+        """
+        if self._native is None or self._native.is_released():
+            raise RuntimeError(
+                "GaussianInferenceRenderer has been released; cannot render"
+            )
+
+        # -- Scene mutation guard ------------------------------------------
+        if self._scene.num_gaussians != self._native.num_gaussians():
+            raise RuntimeError(
+                f"Scene was mutated after renderer creation "
+                f"(scene has {self._scene.num_gaussians} Gaussians, "
+                f"renderer was built for {self._native.num_gaussians()}). "
+                f"Create a new GaussianInferenceRenderer after modifying the scene."
+            )
+
+        # -- Reject unsupported kwargs ------------------------------------
+        for key in kwargs:
+            if key in _RENDERER_UNSUPPORTED_KWARGS:
+                raise TypeError(
+                    f"GaussianInferenceRenderer.render() does not support {key}"
+                )
+            else:
+                raise TypeError(
+                    f"GaussianInferenceRenderer.render() got unexpected keyword "
+                    f"argument '{key}'"
+                )
+
+        # -- Grad-mode gate ------------------------------------------------
+        check_inference_grad_mode()
+
+        # -- Normalize cameras ---------------------------------------------
+        viewmat_t = self._normalize_viewmat(viewmat, viewmats)
+        K_t = self._normalize_K(K, Ks)
+
+        # -- tile_size -----------------------------------------------------
+        effective_tile_size = tile_size if tile_size is not None else self._tile_size
+        if effective_tile_size not in (8, 16):
+            raise ValueError(f"tile_size must be 8 or 16; got {effective_tile_size}")
+
+        # -- sh_degree -----------------------------------------------------
+        effective_sh_degree = (
+            sh_degree if sh_degree is not None else self._scene.sh_degree
+        )
+
+        # -- Validate out buffer -------------------------------------------
+        if out is not None:
+            self._validate_half4_out_buffer(out, height, width, viewmat_t.device)
+
+        # -- Select half4 output framebuffer --------------------------------
+        if out is not None:
+            out_rgbt = out.frame  # [1, H, W, 4]
+        else:
+            out_rgbt = self._get_frame_buffer(height, width, viewmat_t.device)
+
+        # -- Call C++ renderer ---------------------------------------------
+        rgbt = self._native.render(
+            self._scene.means_planar,
+            self._scene.qso_packed,
+            self._scene.colors_packed,
+            viewmat_t,
+            K_t,
+            width,
+            height,
+            effective_tile_size,
+            near_plane,
+            far_plane,
+            radius_clip,
+            eps2d,
+            effective_sh_degree,
+            self._scene.sh_compression_mode,
+            background,
+            out_rgbt,
+        )
+
+        # -- Package result ------------------------------------------------
+        metadata = {"format": "RGBT", "channels": "RGBT"}
+        if out is None:
+            return RenderReturn(
+                frame=rgbt,  # [1, H, W, 4]
+                metadata=metadata,
+            )
+        else:
+            out.metadata.clear()
+            out.metadata.update(metadata)
+            return out
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def release(self) -> None:
+        """Release all GPU buffers held by the native renderer."""
+        if self._native is not None and not self._native.is_released():
+            self._native.release()
+        self._native = None
+        self._frame_buffer = None
+        self._frame_buffer_shape = None
+
+    @property
+    def is_released(self) -> bool:
+        """True if the renderer has been released."""
+        return self._native is None or self._native.is_released()
+
+    @property
+    def num_gaussians(self) -> int:
+        """Number of Gaussians in the scene, or 0 if released."""
+        if self._native is not None and not self._native.is_released():
+            return self._native.num_gaussians()
+        return 0
+
+    def __del__(self) -> None:
+        try:
+            self.release()
+        except Exception:
+            pass
+
+    def __enter__(self) -> "GaussianInferenceRenderer":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_viewmat(
+        viewmat: Optional[Tensor],
+        viewmats: Optional[Tensor],
+    ) -> Tensor:
+        """Return a single [4, 4] viewmat tensor."""
+        if viewmat is not None and viewmats is not None:
+            raise RuntimeError("pass exactly one of viewmat or viewmats, not both")
+        if viewmat is None and viewmats is None:
+            raise RuntimeError("pass exactly one of viewmat or viewmats")
+
+        if viewmats is not None:
+            if viewmats.shape[0] > 1:
+                raise RuntimeError(
+                    f"Inference branch supports single camera (leading dim == 1); "
+                    f"got viewmats with leading dim {viewmats.shape[0]}"
+                )
+            return viewmats[0]
+        return viewmat  # type: ignore[return-value]
+
+    @staticmethod
+    def _normalize_K(
+        K: Optional[Tensor],
+        Ks: Optional[Tensor],
+    ) -> Tensor:
+        """Return a single [3, 3] intrinsics tensor."""
+        if K is not None and Ks is not None:
+            raise RuntimeError("pass exactly one of K or Ks, not both")
+        if K is None and Ks is None:
+            raise RuntimeError("pass exactly one of K or Ks")
+
+        if Ks is not None:
+            if Ks.shape[0] > 1:
+                raise RuntimeError(
+                    f"Inference branch supports single camera (leading dim == 1); "
+                    f"got Ks with leading dim {Ks.shape[0]}"
+                )
+            return Ks[0]
+        return K  # type: ignore[return-value]
+
+    @staticmethod
+    def _validate_half4_out_buffer(
+        out: RenderReturn,
+        height: int,
+        width: int,
+        device: torch.device,
+    ) -> None:
+        """Validate the stateful renderer's native half4 ``out=`` buffer."""
+        frame = out.frame
+        ok = (
+            frame.shape == (1, height, width, 4)
+            and frame.dtype == torch.float16
+            and frame.device == device
+            and frame.is_contiguous()
+        )
+        if not ok:
+            raise RuntimeError(
+                "out.frame expected shape "
+                f"[1, {height}, {width}, 4], dtype torch.float16, "
+                f"device {device}, contiguous; got shape {list(frame.shape)}, "
+                f"dtype {frame.dtype}, device {frame.device}, "
+                f"contiguous={frame.is_contiguous()}"
+            )
+        if frame.requires_grad:
+            raise RuntimeError("out=... buffer must not be grad-tracked")
+
+    def _get_frame_buffer(
+        self,
+        height: int,
+        width: int,
+        device: torch.device,
+    ) -> Tensor:
+        """Return the Python-owned default framebuffer for this resolution."""
+        shape = (1, height, width, 4)
+        if (
+            self._frame_buffer is None
+            or self._frame_buffer_shape != shape
+            or self._frame_buffer.device != device
+        ):
+            self._frame_buffer = torch.empty(
+                shape,
+                device=device,
+                dtype=torch.float16,
+            )
+            self._frame_buffer_shape = shape
+        return self._frame_buffer
+
+
+__all__ = ["GaussianInferenceRenderer"]

--- a/experimental/render/components/test_gaussian_inference_renderer.py
+++ b/experimental/render/components/test_gaussian_inference_renderer.py
@@ -1,0 +1,474 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for :class:`GaussianInferenceRenderer` (stateful Inference renderer).
+
+Covers construction, native half4 RGBT rendering correctness, lifecycle
+management (release, context manager), resolution changes, output-buffer
+reuse, viewmat/K normalisation, and parity with the stateless
+:func:`rasterize_gaussian_inference_scene`.
+"""
+
+import math
+
+import pytest
+import torch
+
+# Skip entire module if CUDA is unavailable.
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+DEVICE = torch.device("cuda:0")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_test_scene(sh_degree=3, sh_compression="none"):
+    """Create a small synthetic GaussianInferenceScene for testing."""
+    N = 1000
+    torch.manual_seed(42)
+    means = torch.randn(N, 3, device=DEVICE)
+    means[:, 2] = means[:, 2].abs() + 2.0
+    quats = torch.randn(N, 4, device=DEVICE)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = torch.exp(torch.rand(N, 3, device=DEVICE) * 0.1 - 2.0)
+    opacities = torch.sigmoid(torch.rand(N, device=DEVICE))
+    K_sh = (sh_degree + 1) ** 2 if sh_degree is not None and sh_degree >= 0 else 0
+    if K_sh > 0:
+        colors = torch.randn(N, K_sh, 3, device=DEVICE) * 0.1
+    else:
+        colors = torch.sigmoid(torch.randn(N, 3, device=DEVICE))
+
+    from experimental import GaussianInferenceScene
+
+    return GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=sh_degree if sh_degree is not None and sh_degree >= 0 else None,
+        sh_compression=sh_compression,
+        id="test_scene",
+    )
+
+
+def make_camera(width=256, height=256):
+    """Create a simple pinhole camera looking down +z."""
+    focal = width / (2.0 * math.tan(math.radians(25)))
+    K = torch.tensor(
+        [
+            [focal, 0, width / 2.0],
+            [0, focal, height / 2.0],
+            [0, 0, 1],
+        ],
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    viewmat = torch.eye(4, dtype=torch.float32, device=DEVICE)
+    viewmat[2, 3] = -5.0  # camera looking at z=5
+    return viewmat, K
+
+
+# ---------------------------------------------------------------------------
+# Construction tests
+# ---------------------------------------------------------------------------
+
+
+def test_construction():
+    """Create a renderer and verify num_gaussians and is_released."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    renderer = GaussianInferenceRenderer(scene)
+    try:
+        assert renderer.num_gaussians == 1000
+        assert not renderer.is_released
+    finally:
+        renderer.release()
+
+
+# ---------------------------------------------------------------------------
+# Basic rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_basic():
+    """Render a single frame; verify output shapes and dtype."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 256, 256
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            ret = renderer.render(viewmat=viewmat, K=K, width=W, height=H)
+
+    assert ret.frame.shape == (1, H, W, 4)
+    assert ret.frame.dtype == torch.float16
+    assert ret.metadata["format"] == "RGBT"
+    assert ret.metadata["channels"] == "RGBT"
+
+
+# ---------------------------------------------------------------------------
+# Repeated rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_repeated():
+    """Render 5 frames with slightly different viewmats; all must succeed."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            frame_ptr = None
+            for i in range(5):
+                vm = viewmat.clone()
+                vm[0, 3] += 0.1 * i  # slight translation each frame
+                ret = renderer.render(viewmat=vm, K=K, width=W, height=H)
+                assert ret.frame.shape == (1, H, W, 4)
+                assert ret.frame.isfinite().all()
+                if frame_ptr is None:
+                    frame_ptr = ret.frame.data_ptr()
+                assert ret.frame.data_ptr() == frame_ptr
+
+
+def test_render_repeated_stable():
+    """Rendering the same viewmat twice must produce identical output."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            ret1 = renderer.render(viewmat=viewmat, K=K, width=W, height=H)
+            ret2 = renderer.render(viewmat=viewmat, K=K, width=W, height=H)
+
+    assert torch.equal(ret1.frame, ret2.frame)
+
+
+# ---------------------------------------------------------------------------
+# Resolution change
+# ---------------------------------------------------------------------------
+
+
+def test_resize():
+    """Render at three different resolutions; verify shapes match each time."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    viewmat, K_256 = make_camera(256, 256)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            for w, h in [(256, 256), (512, 512), (128, 128)]:
+                _, K = make_camera(w, h)
+                ret = renderer.render(viewmat=viewmat, K=K, width=w, height=h)
+                assert ret.frame.shape == (
+                    1,
+                    h,
+                    w,
+                    4,
+                ), f"Expected (1, {h}, {w}, 4), got {ret.frame.shape}"
+
+
+# ---------------------------------------------------------------------------
+# Consistency with stateless path
+# ---------------------------------------------------------------------------
+
+
+def test_output_consistency_with_stateless():
+    """Stateful and stateless renderers must produce identical output."""
+    from experimental import (
+        GaussianInferenceRenderer,
+        rasterize_gaussian_inference_scene,
+    )
+
+    scene = make_test_scene()
+    W, H = 256, 256
+    viewmat, K = make_camera(W, H)
+
+    with torch.inference_mode():
+        stateless_ret = rasterize_gaussian_inference_scene(
+            scene,
+            viewmat=viewmat,
+            K=K,
+            width=W,
+            height=H,
+        )
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            stateful_ret = renderer.render(
+                viewmat=viewmat,
+                K=K,
+                width=W,
+                height=H,
+            )
+
+    stateful_rgb = stateful_ret.frame[..., :3].float()
+    stateful_alpha = 1.0 - stateful_ret.frame[..., 3:4].float()
+
+    torch.testing.assert_close(
+        stateful_rgb,
+        stateless_ret.frame,
+        atol=1e-5,
+        rtol=1e-4,
+        msg="Stateful vs stateless frame mismatch",
+    )
+    torch.testing.assert_close(
+        stateful_alpha,
+        stateless_ret.metadata["alpha"],
+        atol=1e-5,
+        rtol=1e-4,
+        msg="Stateful vs stateless alpha mismatch",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output buffer reuse
+# ---------------------------------------------------------------------------
+
+
+def test_out_buffer_reuse():
+    """Pre-allocated out buffers keep the same data_ptr across renders."""
+    from experimental import GaussianInferenceRenderer, RenderReturn
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    buf = RenderReturn(
+        frame=torch.empty(1, H, W, 4, device=DEVICE, dtype=torch.float16),
+        metadata={},
+    )
+    frame_ptr = buf.frame.data_ptr()
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            for _ in range(2):
+                ret = renderer.render(
+                    viewmat=viewmat,
+                    K=K,
+                    width=W,
+                    height=H,
+                    out=buf,
+                )
+                assert ret is buf
+                assert buf.frame.data_ptr() == frame_ptr
+                assert buf.metadata["format"] == "RGBT"
+
+
+# ---------------------------------------------------------------------------
+# viewmats / Ks normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_viewmats_ks_normalization():
+    """Passing viewmats=[1,4,4] and Ks=[1,3,3] must produce same result as viewmat/K."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            ret_single = renderer.render(
+                viewmat=viewmat,
+                K=K,
+                width=W,
+                height=H,
+            )
+            ret_batch = renderer.render(
+                viewmats=viewmat.unsqueeze(0),
+                Ks=K.unsqueeze(0),
+                width=W,
+                height=H,
+            )
+
+    torch.testing.assert_close(
+        ret_single.frame,
+        ret_batch.frame,
+        atol=0,
+        rtol=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: release
+# ---------------------------------------------------------------------------
+
+
+def test_release():
+    """After release(), is_released is True and render raises RuntimeError."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    renderer = GaussianInferenceRenderer(scene)
+    renderer.release()
+
+    assert renderer.is_released
+
+    with torch.inference_mode():
+        with pytest.raises(RuntimeError, match="has been released"):
+            renderer.render(viewmat=viewmat, K=K, width=W, height=H)
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager():
+    """The context manager auto-releases the renderer on exit."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        assert not renderer.is_released
+        with torch.inference_mode():
+            ret = renderer.render(viewmat=viewmat, K=K, width=W, height=H)
+        assert ret.frame.shape == (1, H, W, 4)
+
+    assert renderer.is_released
+
+
+# ---------------------------------------------------------------------------
+# Construction errors
+# ---------------------------------------------------------------------------
+
+
+def test_construction_empty_scene_raises():
+    """Constructing from a released (empty) scene raises ValueError."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    scene.release()
+    assert scene.is_empty()
+
+    with pytest.raises(ValueError, match="has been released"):
+        GaussianInferenceRenderer(scene)
+
+
+def test_construction_wrong_type_raises():
+    """Constructing with a non-scene object raises TypeError."""
+    from experimental import GaussianInferenceRenderer
+
+    with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+        GaussianInferenceRenderer("not_a_scene")
+
+
+# ---------------------------------------------------------------------------
+# SH degree override
+# ---------------------------------------------------------------------------
+
+
+def test_sh_degree_override():
+    """Rendering with sh_degree=0 (lower than scene's 3) must not crash."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene(sh_degree=3)
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            ret = renderer.render(
+                viewmat=viewmat,
+                K=K,
+                width=W,
+                height=H,
+                sh_degree=0,
+            )
+
+    assert ret.frame.shape == (1, H, W, 4)
+    assert ret.frame.isfinite().all()
+
+
+def test_sh_compression_mode_override_rejected():
+    """SH compression is fixed by the scene used to construct the renderer."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene(sh_degree=3, sh_compression="32b")
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            with pytest.raises(TypeError, match="does not support sh_compression_mode"):
+                renderer.render(
+                    viewmat=viewmat,
+                    K=K,
+                    width=W,
+                    height=H,
+                    sh_compression_mode=0,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Background colour
+# ---------------------------------------------------------------------------
+
+
+def test_background():
+    """A red background should tint transparent regions red."""
+    from experimental import GaussianInferenceRenderer
+
+    scene = make_test_scene()
+    W, H = 128, 128
+    viewmat, K = make_camera(W, H)
+    bg = torch.tensor([1.0, 0.0, 0.0], dtype=torch.float32, device=DEVICE)
+
+    with GaussianInferenceRenderer(scene) as renderer:
+        with torch.inference_mode():
+            ret = renderer.render(
+                viewmat=viewmat,
+                K=K,
+                width=W,
+                height=H,
+                background=bg,
+            )
+
+    alpha = 1.0 - ret.frame[..., 3:4].float()  # [1, H, W, 1]
+    # Find pixels where alpha < 0.5 (transparent regions)
+    transparent_mask = alpha[0, :, :, 0] < 0.5
+    if transparent_mask.any():
+        # In transparent regions the red channel should dominate
+        transparent_pixels = ret.frame[0, ..., :3].float()[transparent_mask]  # [K, 3]
+        red_channel = transparent_pixels[:, 0]
+        green_channel = transparent_pixels[:, 1]
+        blue_channel = transparent_pixels[:, 2]
+        assert (
+            red_channel.mean() > green_channel.mean()
+        ), "Red background not visible in transparent regions"
+        assert (
+            red_channel.mean() > blue_channel.mean()
+        ), "Red background not visible in transparent regions"

--- a/experimental/render/functional/__init__.py
+++ b/experimental/render/functional/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = ["RenderReturn", "rasterize_gaussian_inference_scene", "render_scene"]
+
+
+def __getattr__(name):
+    if name == "RenderReturn":
+        from experimental.render.types import RenderReturn
+
+        return RenderReturn
+    if name == "rasterize_gaussian_inference_scene":
+        from .gaussian_inference import rasterize_gaussian_inference_scene
+
+        return rasterize_gaussian_inference_scene
+    if name == "render_scene":
+        from .render_scene import render_scene
+
+        return render_scene
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/experimental/render/functional/gaussian_inference.py
+++ b/experimental/render/functional/gaussian_inference.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Stateless Gaussian Inference render API."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+from torch import Tensor
+
+from libs.scene import GaussianInferenceScene
+
+from experimental.render._common import check_inference_grad_mode
+from experimental.render.kernels.gaussian_inference_ops import (
+    gaussian_render_inference_only,
+)
+from experimental.render.types import RenderReturn
+
+
+# Known unsupported features for the Inference branch (each raises TypeError).
+_INFERENCE_UNSUPPORTED_FEATURES = frozenset(
+    {
+        "with_ut",
+        "with_eval3d",
+        "absgrad",
+        "sparse_grad",
+        "distributed",
+        "packed",
+        "segmented",
+        "return_normals",
+        "covars",
+        "rays",
+        "radial_coeffs",
+        "tangential_coeffs",
+        "thin_prism_coeffs",
+        "ftheta_coeffs",
+        "lidar_coeffs",
+        "external_distortion_coeffs",
+        "rolling_shutter",
+        "viewmats_rs",
+        "extra_signals",
+        "extra_signals_sh_degree",
+        "rasterize_mode",
+        "channel_chunk",
+        "global_z_order",
+        "ut_params",
+        "colors",
+    }
+)
+
+# Accepted kwargs for the Inference branch.
+_INFERENCE_ACCEPTED_KWARGS = frozenset(
+    {
+        "viewmat",
+        "viewmats",
+        "K",
+        "Ks",
+        "width",
+        "height",
+        "tile_size",
+        "near_plane",
+        "far_plane",
+        "radius_clip",
+        "eps2d",
+        "background",
+        "render_mode",
+        "camera_model",
+    }
+)
+
+
+def _check_grad_mode() -> None:
+    check_inference_grad_mode()
+
+
+def _validate_device_consistency(
+    scene: GaussianInferenceScene,
+    request: dict[str, Any],
+    out: Optional[RenderReturn],
+) -> None:
+    """Ensure all request tensors live on the same CUDA device as the scene."""
+    scene_device = scene.means_planar.device
+    for name in ("viewmat", "viewmats", "K", "Ks", "background"):
+        val = request.get(name)
+        if val is not None and isinstance(val, Tensor) and val.device != scene_device:
+            raise ValueError(
+                f"{name} is on {val.device} but scene is on {scene_device}; "
+                f"all tensors must be on the same device"
+            )
+    if out is not None and out.frame.device != scene_device:
+        raise ValueError(
+            f"out buffer is on {out.frame.device} but scene is on "
+            f"{scene_device}; all tensors must be on the same device"
+        )
+
+
+def _validate_inference_request(request: dict[str, Any]) -> dict[str, Any]:
+    """Validate and extract inference kwargs from ``**request``.
+
+    Returns a normalised dict ready for downstream consumption.
+    """
+    # -- Reject sh_degree / sh_compression_mode overrides ----------------
+    for key in ("sh_degree", "sh_compression_mode"):
+        if key in request:
+            raise TypeError(
+                "sh_degree/sh_compression_mode are read from scene; "
+                "cannot be overridden via request kwargs"
+            )
+
+    # -- Reject ``backgrounds`` (plural) ---------------------------------
+    if "backgrounds" in request:
+        raise TypeError(
+            "rasterize_gaussian_inference_scene got unexpected keyword argument "
+            "'backgrounds'"
+        )
+
+    # -- Reject known-unsupported features -------------------------------
+    for key in _INFERENCE_UNSUPPORTED_FEATURES:
+        if key in request:
+            raise TypeError(f"Inference branch does not support {key}")
+
+    # -- Reject truly unknown kwargs -------------------------------------
+    for key in request:
+        if key not in _INFERENCE_ACCEPTED_KWARGS:
+            raise TypeError(
+                f"rasterize_gaussian_inference_scene got unexpected keyword "
+                f"argument '{key}'"
+            )
+
+    # -- Constrained values -----------------------------------------------
+    render_mode = request.get("render_mode", "RGB")
+    if render_mode != "RGB":
+        raise TypeError(
+            f"Inference branch supports render_mode='RGB' only; got '{render_mode}'"
+        )
+
+    camera_model = request.get("camera_model", "pinhole")
+    if camera_model != "pinhole":
+        raise TypeError(
+            f"Inference branch supports camera_model='pinhole' only; "
+            f"got '{camera_model}'"
+        )
+
+    tile_size = request.get("tile_size", 8)
+    if tile_size not in (8, 16):
+        raise TypeError(
+            f"Inference branch supports tile_size in {{8, 16}}; got {tile_size}"
+        )
+
+    # -- Build normalised result -----------------------------------------
+    return {
+        "viewmat": request.get("viewmat"),
+        "viewmats": request.get("viewmats"),
+        "K": request.get("K"),
+        "Ks": request.get("Ks"),
+        "width": request.get("width"),
+        "height": request.get("height"),
+        "tile_size": tile_size,
+        "near_plane": request.get("near_plane", 0.01),
+        "far_plane": request.get("far_plane", 1e10),
+        "radius_clip": request.get("radius_clip", 0.0),
+        "eps2d": request.get("eps2d", 0.3),
+        "background": request.get("background"),
+    }
+
+
+def _normalize_cameras(
+    kwargs: dict[str, Any],
+) -> tuple[Tensor, Tensor, dict[str, Any]]:
+    """Normalize viewmat/K from request kwargs.
+
+    Returns ``(viewmat, K, cleaned_kwargs)`` where ``cleaned_kwargs`` no
+    longer contains viewmat/viewmats/K/Ks.
+    """
+    viewmat_val = kwargs.get("viewmat")
+    viewmats_val = kwargs.get("viewmats")
+    K_val = kwargs.get("K")
+    Ks_val = kwargs.get("Ks")
+
+    # -- viewmat / viewmats -----------------------------------------------
+    if viewmat_val is not None and viewmats_val is not None:
+        raise RuntimeError("pass exactly one of viewmat or viewmats, not both")
+    if viewmat_val is None and viewmats_val is None:
+        raise RuntimeError("pass exactly one of viewmat or viewmats")
+
+    if viewmats_val is not None:
+        if viewmats_val.shape[0] > 1:
+            raise RuntimeError(
+                f"Inference branch supports single camera (leading dim == 1); "
+                f"got viewmats with leading dim {viewmats_val.shape[0]}"
+            )
+        viewmat = viewmats_val[0]
+    else:
+        viewmat = viewmat_val
+
+    # -- K / Ks -----------------------------------------------------------
+    if K_val is not None and Ks_val is not None:
+        raise RuntimeError("pass exactly one of K or Ks, not both")
+    if K_val is None and Ks_val is None:
+        raise RuntimeError("pass exactly one of K or Ks")
+
+    if Ks_val is not None:
+        if Ks_val.shape[0] > 1:
+            raise RuntimeError(
+                f"Inference branch supports single camera (leading dim == 1); "
+                f"got Ks with leading dim {Ks_val.shape[0]}"
+            )
+        K = Ks_val[0]
+    else:
+        K = K_val
+
+    # Build a cleaned copy without the camera keys
+    cleaned = {
+        k: v for k, v in kwargs.items() if k not in ("viewmat", "viewmats", "K", "Ks")
+    }
+    return viewmat, K, cleaned
+
+
+def _validate_out_buffer(
+    out: RenderReturn,
+    height: int,
+    width: int,
+    device: torch.device,
+) -> None:
+    """Validate the ``out=`` buffer contract."""
+    # -- frame -----------------------------------------------------------
+    _validate_single_buffer(
+        out.frame,
+        name="out.frame",
+        expected_shape=(1, height, width, 3),
+        device=device,
+    )
+    if out.frame.requires_grad:
+        raise RuntimeError("out=... buffer must not be grad-tracked")
+
+    # -- optional alpha in metadata --------------------------------------
+    alpha = out.metadata.get("alpha")
+    if alpha is not None:
+        _validate_single_buffer(
+            alpha,
+            name="out.metadata['alpha']",
+            expected_shape=(1, height, width, 1),
+            device=device,
+        )
+        if alpha.requires_grad:
+            raise RuntimeError("out=... buffer must not be grad-tracked")
+
+
+def _validate_single_buffer(
+    t: Tensor,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+    device: torch.device,
+) -> None:
+    """Validate shape, dtype, device, contiguity for a single buffer tensor."""
+    ok = (
+        t.shape == expected_shape
+        and t.dtype == torch.float32
+        and t.device == device
+        and t.is_contiguous()
+    )
+    if not ok:
+        raise RuntimeError(
+            f"{name} expected shape {list(expected_shape)}, "
+            f"dtype torch.float32, device {device}, contiguous; "
+            f"got shape {list(t.shape)}, dtype {t.dtype}, "
+            f"device {t.device}, contiguous={t.is_contiguous()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# rasterize_gaussian_inference_scene  (direct inference entry point)
+# ---------------------------------------------------------------------------
+
+
+def rasterize_gaussian_inference_scene(
+    scene: GaussianInferenceScene,
+    *,
+    out: Optional[RenderReturn] = None,
+    **request: Any,
+) -> RenderReturn:
+    """Render a ``GaussianInferenceScene`` via the fused Inference rasterisation op.
+
+    This is the direct, low-level entry point.  For a polymorphic API that
+    also handles ``GaussianScene``, use :func:`render_scene`.
+    """
+    # 1. Type check
+    if not isinstance(scene, GaussianInferenceScene):
+        raise TypeError(
+            f"rasterize_gaussian_inference_scene requires a GaussianInferenceScene; "
+            f"got {type(scene).__name__}"
+        )
+
+    # 2. Empty-scene guard
+    if scene.is_empty():
+        raise ValueError(
+            "GaussianInferenceScene has been released and contains no packed "
+            "tensors. Did you forget to rebuild the snapshot?"
+        )
+
+    # 3. Grad-mode gate
+    _check_grad_mode()
+
+    # 3b. Device consistency
+    _validate_device_consistency(scene, request, out)
+
+    # 4. Request-subset validation
+    validated = _validate_inference_request(request)
+
+    # 5. Camera normalisation
+    viewmat, K, rest = _normalize_cameras(validated)
+
+    height = rest["height"]
+    width = rest["width"]
+    if not isinstance(height, int) or height <= 0:
+        raise ValueError(f"height must be a positive integer, got {height!r}")
+    if not isinstance(width, int) or width <= 0:
+        raise ValueError(f"width must be a positive integer, got {width!r}")
+
+    # 6. Buffer validation
+    if out is not None:
+        _validate_out_buffer(out, height, width, viewmat.device)
+
+    # 7. Build out_renders / out_alphas views
+    out_renders: Optional[Tensor] = None
+    out_alphas: Optional[Tensor] = None
+    saved_alpha: Optional[Tensor] = None
+    if out is not None:
+        out_renders = out.frame[0]  # [H, W, 3]
+        alpha_buf = out.metadata.get("alpha")
+        if alpha_buf is not None:
+            saved_alpha = alpha_buf
+            out_alphas = alpha_buf[0]  # [H, W, 1]
+
+    # 8. Call accelerated backend (stateless one-shot path)
+    renders, alphas = gaussian_render_inference_only(
+        scene.means_planar,
+        scene.qso_packed,
+        scene.colors_packed,
+        viewmat,
+        K,
+        width,
+        height,
+        scene.sh_degree,
+        rest["tile_size"],
+        rest["near_plane"],
+        rest["far_plane"],
+        rest["radius_clip"],
+        rest["eps2d"],
+        scene.sh_compression_mode,
+        rest["background"],
+        out_renders=out_renders,
+        out_alphas=out_alphas,
+    )
+
+    # 9. Package result
+    if out is None:
+        return RenderReturn(
+            frame=renders[None],  # [1, H, W, 3]
+            metadata={"alpha": alphas[None]},  # [1, H, W, 1]
+        )
+    else:
+        out.metadata.clear()
+        if saved_alpha is not None:
+            out.metadata["alpha"] = saved_alpha
+        else:
+            out.metadata["alpha"] = alphas[None]
+        return out
+
+
+__all__ = ["rasterize_gaussian_inference_scene"]

--- a/experimental/render/functional/render_scene.py
+++ b/experimental/render/functional/render_scene.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render dispatcher for the ``experimental`` package.
+
+Dispatches to the Inference rasteriser for ``GaussianInferenceScene``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from libs.scene import GaussianInferenceScene
+
+from experimental.render.functional.gaussian_inference import (
+    rasterize_gaussian_inference_scene,
+)
+from experimental.render.types import RenderReturn
+
+
+def render_scene(
+    scene,
+    *,
+    out: Optional[RenderReturn] = None,
+    **request: Any,
+) -> RenderReturn:
+    """Render a ``GaussianInferenceScene``.
+
+    Raises:
+        TypeError: If *scene* is not a :class:`GaussianInferenceScene`.
+    """
+    if not isinstance(scene, GaussianInferenceScene):
+        raise TypeError(
+            f"render_scene requires a GaussianInferenceScene; "
+            f"got {type(scene).__name__}"
+        )
+
+    ret = rasterize_gaussian_inference_scene(scene, out=out, **request)
+    ret.metadata["render_path"] = "inference"
+    return ret

--- a/experimental/render/functional/test_gaussian_inference.py
+++ b/experimental/render/functional/test_gaussian_inference.py
@@ -1,0 +1,1001 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Gaussian Inference rasterization path (gsplat.experimental).
+
+Migrated from tests/test_render_only.py during Phase 4b of the Inference Render
+Path Unification plan.  All tests use the ``gsplat.experimental`` surface
+(``GaussianInferenceScene``, ``rasterize_gaussian_inference_scene``, ``render_scene``,
+``RenderReturn``).
+"""
+
+import pytest
+import torch
+
+device = torch.device("cuda:0")
+
+_skip_no_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="No CUDA device"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gaussians(N, device, sh_degree=None):
+    """Create random Gaussian parameters for testing.
+
+    Returns *activated* tensors:
+    - scales: positive (already exp'd)
+    - opacities: in [0.1, 0.9] (already sigmoid'd)
+    """
+    torch.manual_seed(42)
+    means = torch.randn(N, 3, device=device)
+    # Place gaussians in front of camera (positive z)
+    means[:, 2] = means[:, 2].abs() + 2.0
+    quats = torch.randn(N, 4, device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = torch.rand(N, 3, device=device) * 0.1 + 0.01  # activated (positive)
+    opacities = torch.rand(N, device=device) * 0.8 + 0.1  # activated [0.1, 0.9]
+
+    if sh_degree is not None:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K, 3, device=device) * 0.1
+    else:
+        colors = torch.sigmoid(torch.randn(N, 3, device=device))
+
+    return means, quats, scales, opacities, colors
+
+
+def _make_camera(device, width=128, height=96):
+    """Create a simple pinhole camera looking down +z."""
+    focal = 128.0
+    K = torch.tensor(
+        [
+            [focal, 0.0, width / 2.0],
+            [0.0, focal, height / 2.0],
+            [0.0, 0.0, 1.0],
+        ],
+        device=device,
+    )
+    viewmat = torch.eye(4, device=device)
+    return viewmat, K, width, height
+
+
+def _build_inference_scene(N, device, sh_degree=None, sh_compression="none"):
+    """Build a GaussianInferenceScene from random Gaussians."""
+    from experimental import GaussianInferenceScene
+
+    means, quats, scales, opacities, colors = _make_gaussians(N, device, sh_degree)
+    scene = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        sh_degree=sh_degree,
+        sh_compression=sh_compression,
+        id="test",
+    )
+    return scene
+
+
+# ---------------------------------------------------------------------------
+# Negative-import tests (legacy symbols removed)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyImportsRemoved:
+    def test_render_only_rasterization_removed(self):
+        with pytest.raises(ImportError):
+            from gsplat import render_only_rasterization  # noqa: F401
+
+    def test_RenderOnlyRasterizer_removed(self):
+        with pytest.raises(ImportError):
+            from gsplat import RenderOnlyRasterizer  # noqa: F401
+
+    def test_has_render_only_removed(self):
+        with pytest.raises(ImportError):
+            from gsplat import has_render_only  # noqa: F401
+
+    def test_has_render_only_viewer_path_removed(self):
+        with pytest.raises(ImportError):
+            from gsplat import has_render_only_viewer_path  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Input validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    pytestmark = [_skip_no_cuda]
+
+    def test_cpu_tensors_rejected(self):
+        """CPU tensors should be rejected by from_gaussian_tensors."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(10, "cpu")
+        # The C++ pack op should reject CPU tensors
+        with pytest.raises((RuntimeError, ValueError)):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=None,
+                sh_compression="none",
+                id="test",
+            )
+
+    def test_negative_scales_rejected(self):
+        """Negative scales should be rejected by from_gaussian_tensors."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(10, device)
+        scales_bad = scales.clone()
+        scales_bad[0, 0] = -1.0
+        with pytest.raises(ValueError, match="non-positive"):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales_bad,
+                opacities,
+                colors,
+                sh_degree=None,
+                sh_compression="none",
+                id="test",
+            )
+
+    def test_opacities_out_of_range_rejected(self):
+        """Opacities outside [0, 1] should be rejected."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(10, device)
+        opacities_bad = opacities.clone()
+        opacities_bad[0] = 1.5
+        with pytest.raises(ValueError, match="opacities outside"):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities_bad,
+                colors,
+                sh_degree=None,
+                sh_compression="none",
+                id="test",
+            )
+
+    def test_invalid_tile_size_rejected(self):
+        """Tile size other than 8 or 16 is rejected."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(10, device)
+        viewmat, K, w, h = _make_camera(device)
+        with torch.inference_mode():
+            with pytest.raises(TypeError, match="tile_size"):
+                rasterize_gaussian_inference_scene(
+                    scene,
+                    viewmat=viewmat,
+                    K=K,
+                    width=w,
+                    height=h,
+                    tile_size=4,
+                )
+
+    def test_wrong_means_shape_rejected(self):
+        """Means with wrong shape should be rejected."""
+        from experimental import GaussianInferenceScene
+
+        means = torch.randn(10, 4, device=device)  # wrong: should be [N, 3]
+        _, quats, scales, opacities, colors = _make_gaussians(10, device)
+        with pytest.raises((ValueError, RuntimeError)):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=None,
+                sh_compression="none",
+                id="test",
+            )
+
+    def test_sh_degree_mismatch_rejected(self):
+        """SH degree that doesn't match colors shape should be rejected."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(10, device)
+        # Pre-activated RGB colors but sh_degree=3 -> should fail
+        with pytest.raises((ValueError, RuntimeError)):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=3,
+                sh_compression="none",
+                id="test",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Correctness tests
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectness:
+    pytestmark = [_skip_no_cuda]
+
+    def test_single_gaussian_rgb(self):
+        """Single Gaussian produces non-zero output near its projected center."""
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        # Explicitly place the Gaussian at the origin in XY (projects to image
+        # center) to avoid random seed-dependent culling when N=1.
+        means = torch.tensor([[0.0, 0.0, 2.0]], device=device)
+        quats = torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device)
+        scales = torch.tensor([[0.2, 0.2, 0.2]], device=device)
+        opacities = torch.tensor([0.8], device=device)
+        colors = torch.tensor([[0.9, 0.2, 0.5]], device=device)
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.metadata["alpha"].shape == (1, h, w, 1)
+        assert ret.frame.device.type == "cuda"
+        # At least some pixels should be non-zero
+        assert ret.frame.sum() > 0
+
+    def test_multiple_gaussians_rgb(self):
+        """Multiple Gaussians render correctly."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(100, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.metadata["alpha"].shape == (1, h, w, 1)
+
+    def test_behind_camera_culling(self):
+        """Gaussians behind the camera should not contribute to the image."""
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        means, quats, scales, opacities, colors = _make_gaussians(10, device)
+        # Place all gaussians behind camera (negative z)
+        means[:, 2] = -5.0
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+        viewmat, K, w, h = _make_camera(device)
+        bg = torch.tensor([1.0, 1.0, 1.0], device=device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h, background=bg
+            )
+
+        # Should be all background
+        torch.testing.assert_close(
+            ret.frame[0],
+            bg.expand(h, w, 3),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_output_no_grad(self):
+        """Outputs should not have requires_grad."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(10, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        assert not ret.frame.requires_grad
+        assert not ret.metadata["alpha"].requires_grad
+
+    def test_with_background(self):
+        """Background color is applied where alpha < 1."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(5, device)
+        viewmat, K, w, h = _make_camera(device)
+        bg = torch.tensor([0.2, 0.4, 0.6], device=device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h, background=bg
+            )
+
+        assert ret.frame.shape == (1, h, w, 3)
+
+    @pytest.mark.parametrize("tile_size", [8, 16])
+    def test_tile_sizes(self, tile_size):
+        """Both supported tile sizes produce valid output."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene,
+                viewmat=viewmat,
+                K=K,
+                width=w,
+                height=h,
+                tile_size=tile_size,
+            )
+
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+
+
+# ---------------------------------------------------------------------------
+# Reference comparison tests
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceComparison:
+    pytestmark = [_skip_no_cuda]
+
+    def _has_3dgs(self):
+        import gsplat
+
+        return gsplat.has_3dgs()
+
+    def test_matches_rasterization_rgb(self):
+        """render_scene Inference output should closely match rasterization() for RGB."""
+        if not self._has_3dgs():
+            pytest.skip("3DGS not built")
+
+        from experimental import render_scene, GaussianInferenceScene
+        import gsplat
+
+        N = 50
+        means, quats, scales, opacities, colors = _make_gaussians(N, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        # Build Inference scene
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+        # Render with Inference path
+        with torch.inference_mode():
+            ret_inference = render_scene(scene, viewmat=viewmat, K=K, width=w, height=h)
+
+        # Render with standard rasterization path
+        viewmats = viewmat.unsqueeze(0)
+        Ks = K.unsqueeze(0)
+        with torch.no_grad():
+            render_ref, alphas_ref, meta_ref = gsplat.rasterization(
+                means=means,
+                quats=quats,
+                scales=scales,
+                opacities=opacities,
+                colors=colors,
+                viewmats=viewmats,
+                Ks=Ks,
+                width=w,
+                height=h,
+                render_mode="RGB",
+                packed=False,
+                sh_degree=None,
+            )
+
+        # Inference uses fp16-packed intermediates, so allow fp16-level slack.
+        torch.testing.assert_close(
+            ret_inference.frame,
+            render_ref,
+            atol=5e-3,
+            rtol=1e-2,
+        )
+
+    def test_matches_rasterization_sh(self):
+        """render_scene Inference with SH should be close to rasterization() with SH."""
+        if not self._has_3dgs():
+            pytest.skip("3DGS not built")
+
+        from experimental import render_scene, GaussianInferenceScene
+        import gsplat
+
+        N = 50
+        sh_degree = 3
+        means, quats, scales, opacities, colors = _make_gaussians(
+            N,
+            device,
+            sh_degree=sh_degree,
+        )
+        viewmat, K, w, h = _make_camera(device)
+
+        # Build Inference scene
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=sh_degree,
+            sh_compression="none",
+            id="test",
+        )
+
+        # Render with Inference path
+        with torch.inference_mode():
+            ret_inference = render_scene(scene, viewmat=viewmat, K=K, width=w, height=h)
+
+        # Render with standard rasterization path
+        viewmats = viewmat.unsqueeze(0)
+        Ks = K.unsqueeze(0)
+        with torch.no_grad():
+            render_ref, alphas_ref, meta_ref = gsplat.rasterization(
+                means=means,
+                quats=quats,
+                scales=scales,
+                opacities=opacities,
+                colors=colors,
+                viewmats=viewmats,
+                Ks=Ks,
+                width=w,
+                height=h,
+                render_mode="RGB",
+                packed=False,
+                sh_degree=sh_degree,
+            )
+
+        # Inference uses fp16-packed intermediates, allow fp16-level slack.
+        torch.testing.assert_close(
+            ret_inference.frame,
+            render_ref,
+            atol=5e-3,
+            rtol=1e-2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# GaussianInferenceScene lifecycle tests (migrated from TestRenderOnlyRasterizer)
+# ---------------------------------------------------------------------------
+
+
+class TestGaussianInferenceSceneLifecycle:
+    pytestmark = [_skip_no_cuda]
+
+    def test_basic_render(self):
+        """GaussianInferenceScene + rasterize_gaussian_inference_scene produces valid output."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.metadata["alpha"].shape == (1, h, w, 1)
+
+    def test_multiple_renders(self):
+        """Can render multiple camera poses with the same scene."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device)
+        _, K, w, h = _make_camera(device)
+
+        viewmat1 = torch.eye(4, device=device)
+        viewmat2 = torch.eye(4, device=device)
+        viewmat2[2, 3] = -1.0  # shift camera back
+
+        with torch.inference_mode():
+            ret1 = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat1, K=K, width=w, height=h
+            )
+            ret2 = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat2, K=K, width=w, height=h
+            )
+
+        assert ret1.frame.shape == (1, h, w, 3)
+        assert ret2.frame.shape == (1, h, w, 3)
+        # Different viewpoints should produce different images
+        assert not torch.allclose(ret1.frame, ret2.frame)
+
+    def test_rebuild_scene(self):
+        """Rebuilding a scene with different data produces different renders."""
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        means1, quats1, scales1, opacities1, colors1 = _make_gaussians(50, device)
+        torch.manual_seed(123)
+        means2, quats2, scales2, opacities2, colors2 = _make_gaussians(30, device)
+
+        viewmat, K, w, h = _make_camera(device)
+
+        scene1 = GaussianInferenceScene.from_gaussian_tensors(
+            means1,
+            quats1,
+            scales1,
+            opacities1,
+            colors1,
+            sh_degree=None,
+            sh_compression="none",
+            id="test1",
+        )
+        scene2 = GaussianInferenceScene.from_gaussian_tensors(
+            means2,
+            quats2,
+            scales2,
+            opacities2,
+            colors2,
+            sh_degree=None,
+            sh_compression="none",
+            id="test2",
+        )
+
+        with torch.inference_mode():
+            ret1 = rasterize_gaussian_inference_scene(
+                scene1, viewmat=viewmat, K=K, width=w, height=h
+            )
+            ret2 = rasterize_gaussian_inference_scene(
+                scene2, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        # Different scene data should produce different renders
+        assert ret1.frame.shape == ret2.frame.shape
+
+    def test_release_and_rebuild(self):
+        """Releasing a scene and rebuilding works correctly."""
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        means, quats, scales, opacities, colors = _make_gaussians(50, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+
+        with torch.inference_mode():
+            ret_before = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        scene.release()
+        assert scene.is_empty()
+
+        # Rebuild
+        scene2 = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test2",
+        )
+        with torch.inference_mode():
+            ret_after = rasterize_gaussian_inference_scene(
+                scene2, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        torch.testing.assert_close(ret_before.frame, ret_after.frame, atol=0, rtol=0)
+
+    def test_render_on_released_scene_raises(self):
+        """Rendering a released scene raises ValueError."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(10, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        scene.release()
+        assert scene.is_empty()
+
+        with torch.inference_mode():
+            with pytest.raises(ValueError, match="has been released"):
+                rasterize_gaussian_inference_scene(
+                    scene, viewmat=viewmat, K=K, width=w, height=h
+                )
+
+    def test_snapshot_isolation(self):
+        """Inference scene owns its packed buffer; mutating original tensors has no effect."""
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        means, quats, scales, opacities, colors = _make_gaussians(200, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="snap",
+        )
+
+        with torch.inference_mode():
+            ret1 = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+            frame1 = ret1.frame.clone()
+
+            # Shift the original tensors by a large amount.
+            means.add_(10.0)
+
+            # The packed buffer is independent — render must be unchanged.
+            ret2 = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+            torch.testing.assert_close(ret2.frame, frame1, atol=0, rtol=0)
+
+            # A scene rebuilt from the mutated tensors should differ.
+            scene2 = GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=None,
+                sh_compression="none",
+                id="snap2",
+            )
+            ret3 = rasterize_gaussian_inference_scene(
+                scene2, viewmat=viewmat, K=K, width=w, height=h
+            )
+            assert not torch.allclose(
+                ret3.frame, frame1, atol=1e-3
+            ), "Rebuilt snapshot should differ after means shifted by 10"
+
+
+# ---------------------------------------------------------------------------
+# Source parity tests (Phase 8) -- kept as-is
+# ---------------------------------------------------------------------------
+
+
+class TestSourceParity:
+    """Verify that imported viewer source files match the manifest."""
+
+    pytestmark = [_skip_no_cuda]
+
+    def test_imported_files_present(self):
+        """All expected imported files exist."""
+        import os
+
+        imported_dir = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "kernels",
+            "cuda",
+            "csrc",
+            "gaussian_inference",
+        )
+        expected_files = [
+            "Constants.h",
+            "IntersectCommon.cu",
+            "IntersectCommon.h",
+            "IntersectMTConfig.h",
+            "IntersectMTFused.cu",
+            "IntersectMTFused.h",
+            "MacroTileIntersect.cu",
+            "MacroTileIntersect.h",
+            "MacroTileRasterize.cu",
+            "MacroTileRasterize.h",
+            "Projection.cu",
+            "Projection.h",
+            "InferenceTypes.h",
+            "SegmentedSort.cu",
+            "SegmentedSort.h",
+            "SHCommon.h",
+            "SHCompression.cu",
+            "SHCompression.h",
+            "SphericalHarmonics.cu",
+            "SphericalHarmonics.h",
+            "Utils.h",
+        ]
+        for f in expected_files:
+            path = os.path.join(imported_dir, f)
+            assert os.path.isfile(path), f"Missing imported file: {f}"
+
+
+# ---------------------------------------------------------------------------
+# Viewer-specific correctness tests (migrated from TestViewerPath)
+# ---------------------------------------------------------------------------
+
+
+class TestViewerPath:
+    """Tests that verify the viewer path via direct op calls."""
+
+    pytestmark = [_skip_no_cuda]
+
+    def test_viewer_op_callable(self):
+        """The viewer Torch op can be called directly via gaussian_render_inference_only."""
+        from experimental.render.kernels._backend import _C  # noqa: F401
+
+        scene = _build_inference_scene(10, device)
+        viewmat, K, w, h = _make_camera(device)
+
+        renders, alphas = torch.ops.experimental.gaussian_render_inference_only(
+            scene.means_planar,
+            scene.qso_packed,
+            scene.colors_packed,
+            viewmat,
+            K,
+            w,
+            h,
+            scene.sh_degree,
+            16,
+            0.01,
+            1e10,
+            0.0,
+            0.3,
+            scene.sh_compression_mode,
+            None,
+        )
+        assert renders.shape == (h, w, 3)
+        assert alphas.shape == (h, w, 1)
+
+    def test_sh_degree_3_fused(self):
+        """Degree-3 SH (K=16) triggers the fused projection+SH path."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device, sh_degree=3)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+        assert ret.frame.sum() > 0
+
+    def test_sh_degree_1_separate(self):
+        """Degree-1 SH (K=4) triggers the separate projection+SH path."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device, sh_degree=1)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+
+    def test_off_screen_gaussians(self):
+        """Gaussians far off-screen produce only background."""
+        from experimental import (
+            GaussianInferenceScene,
+            rasterize_gaussian_inference_scene,
+        )
+
+        N = 20
+        means = torch.zeros(N, 3, device=device)
+        means[:, 0] = 1000.0  # way off to the right
+        means[:, 2] = 5.0  # in front of camera
+        quats = torch.zeros(N, 4, device=device)
+        quats[:, 0] = 1.0  # identity rotation
+        scales = torch.full((N, 3), 0.01, device=device)
+        opacities = torch.full((N,), 0.5, device=device)  # activated [0, 1]
+        colors = torch.ones(N, 3, device=device)
+
+        scene = GaussianInferenceScene.from_gaussian_tensors(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            sh_degree=None,
+            sh_compression="none",
+            id="test",
+        )
+        viewmat, K, w, h = _make_camera(device)
+        bg = torch.tensor([0.5, 0.5, 0.5], device=device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h, background=bg
+            )
+
+        # Should be all background since gaussians are off-screen
+        torch.testing.assert_close(
+            ret.frame[0], bg.expand(h, w, 3), atol=1e-3, rtol=1e-3
+        )
+
+    def test_stateful_sh_degree_3(self):
+        """GaussianInferenceScene with SH degree 3 renders correctly."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device, sh_degree=3)
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+
+
+# ---------------------------------------------------------------------------
+# SH Compression tests (Phase 7)
+# ---------------------------------------------------------------------------
+
+
+class TestSHCompression:
+    pytestmark = [_skip_no_cuda]
+
+    def test_raw_sh_degree3(self):
+        """Raw degree-3 SH still works (no compression)."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device, sh_degree=3, sh_compression="none")
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+
+    def test_compressed_32b(self):
+        """Compressed 32B degree-3 SH renders."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device, sh_degree=3, sh_compression="32b")
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+        assert ret.frame.sum() > 0
+
+    def test_compressed_16b(self):
+        """Compressed 16B degree-3 SH renders."""
+        from experimental import rasterize_gaussian_inference_scene
+
+        scene = _build_inference_scene(50, device, sh_degree=3, sh_compression="16b")
+        viewmat, K, w, h = _make_camera(device)
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(
+                scene, viewmat=viewmat, K=K, width=w, height=h
+            )
+        assert ret.frame.shape == (1, h, w, 3)
+        assert ret.frame.isfinite().all()
+
+    def test_compression_rejects_non_degree3(self):
+        """Compression rejects non-degree-3 SH at scene construction time."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(
+            50, device, sh_degree=1
+        )
+        with pytest.raises(ValueError):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=1,
+                sh_compression="32b",
+                id="test",
+            )
+
+    def test_compression_rejects_rgb(self):
+        """Compression rejects pre-activated RGB at scene construction time."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(50, device)
+        with pytest.raises(ValueError):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=None,
+                sh_compression="32b",
+                id="test",
+            )
+
+    def test_invalid_compression_mode(self):
+        """Invalid compression mode string is rejected."""
+        from experimental import GaussianInferenceScene
+
+        means, quats, scales, opacities, colors = _make_gaussians(
+            50, device, sh_degree=3
+        )
+        with pytest.raises(ValueError, match="sh_compression"):
+            GaussianInferenceScene.from_gaussian_tensors(
+                means,
+                quats,
+                scales,
+                opacities,
+                colors,
+                sh_degree=3,
+                sh_compression="invalid",
+                id="test",
+            )

--- a/experimental/render/functional/test_render_scene.py
+++ b/experimental/render/functional/test_render_scene.py
@@ -1,0 +1,913 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``gsplat.experimental`` render surface.
+
+Covers ``RenderReturn``, ``rasterize_gaussian_inference_scene``, and ``render_scene``:
+grad-mode gating, camera normalisation, out= buffer contract, request
+validation, dispatch tagging, and cross-path parity.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+from unittest.mock import patch
+
+_CUDA = torch.cuda.is_available()
+skipif_no_cuda = pytest.mark.skipif(not _CUDA, reason="CUDA required")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+W, H = 256, 256
+
+
+def _make_test_gaussians(N=100, sh_degree=None, device="cuda"):
+    """Create random Gaussians in *log/logit* space for GaussianScene."""
+    means = torch.randn(N, 3, device=device)
+    quats = torch.randn(N, 4, device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = torch.rand(N, 3, device=device) * 0.1 + 0.01  # log-space
+    opacities = torch.randn(N, device=device)  # logit-space
+    if sh_degree is not None:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K, 3, device=device) * 0.1
+    else:
+        colors = torch.rand(N, 3, device=device)
+    return means, quats, scales, opacities, colors
+
+
+def _make_camera(device="cuda"):
+    viewmat = torch.eye(4, device=device, dtype=torch.float32)
+    viewmat[2, 3] = 5.0
+    K = torch.tensor(
+        [[500.0, 0, 128.0], [0, 500.0, 128.0], [0, 0, 1]],
+        device=device,
+        dtype=torch.float32,
+    )
+    return viewmat, K
+
+
+def _make_gaussian_scene(
+    N=100,
+    sh_degree=None,
+    device="cuda",
+    *,
+    requires_grad=False,
+):
+    """Build a GaussianScene with raw (log/logit-space) splats."""
+    from libs.scene import GaussianScene
+
+    means, quats, scales, opacities, colors = _make_test_gaussians(N, sh_degree, device)
+    splats = nn.ParameterDict(
+        {
+            "means": nn.Parameter(means, requires_grad=requires_grad),
+            "quats": nn.Parameter(quats, requires_grad=requires_grad),
+            "scales": nn.Parameter(scales, requires_grad=requires_grad),
+            "opacities": nn.Parameter(opacities, requires_grad=requires_grad),
+            "colors": nn.Parameter(colors, requires_grad=requires_grad),
+        }
+    )
+    return GaussianScene.from_splats(splats, id="test")
+
+
+def _make_inference_scene(
+    N=100, sh_degree=None, sh_compression="none", device="cuda", *, requires_grad=False
+):
+    """Build a GaussianInferenceScene from a GaussianScene."""
+    from experimental import GaussianInferenceScene
+
+    gs = _make_gaussian_scene(N, sh_degree, device, requires_grad=requires_grad)
+    return GaussianInferenceScene.from_gaussian_scene(
+        gs, id="test", sh_compression=sh_compression
+    )
+
+
+def _common_request(device="cuda"):
+    """Return the minimal valid Inference request dict."""
+    viewmat, K = _make_camera(device)
+    return dict(viewmat=viewmat, K=K, width=W, height=H)
+
+
+# ======================================================================
+# 1. Vanilla-branch passthrough parity
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_vanilla_passthrough_raises_typeerror():
+    """render_scene(gaussian_scene, ...) raises TypeError (vanilla path removed)."""
+    from experimental import render_scene
+
+    gs = _make_gaussian_scene(N=200)
+    viewmat, K = _make_camera()
+    viewmats = viewmat[None]
+    Ks = K[None]
+    req = dict(viewmats=viewmats, Ks=Ks, width=W, height=H)
+
+    with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+        render_scene(gs, **req)
+
+
+# ======================================================================
+# 2. Info-key collision (alpha / render_path overwrite)
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_info_key_collision_gaussian_scene_raises():
+    """render_scene rejects GaussianScene (vanilla path removed)."""
+    from experimental import render_scene
+
+    gs = _make_gaussian_scene(N=50)
+    viewmat, K = _make_camera()
+    req = dict(viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+
+    with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+        render_scene(gs, **req)
+
+
+# ======================================================================
+# 3. Inference branch dispatch + tag
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_inference_dispatch_and_tag():
+    """render_scene(inference_scene, ...) returns RenderReturn with correct tag and shapes."""
+    from experimental import render_scene, RenderReturn
+
+    inference = _make_inference_scene(N=200)
+    req = _common_request()
+
+    with torch.inference_mode():
+        ret = render_scene(inference, **req)
+
+    assert isinstance(ret, RenderReturn)
+    assert ret.metadata["render_path"] == "inference"
+    assert ret.frame.shape == (1, H, W, 3)
+    assert ret.metadata["alpha"].shape == (1, H, W, 1)
+
+
+# ======================================================================
+# 4. Grad-mode gate
+# ======================================================================
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+class TestGradModeGate:
+    """Grad-mode gate over both entry points."""
+
+    def _get_fn(self, entry):
+        import experimental as exp
+
+        return getattr(exp, entry)
+
+    def test_inference_mode_pass(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        req = _common_request()
+        with torch.inference_mode():
+            ret = fn(inference, **req)
+        assert ret.frame.shape[0] == 1
+
+    def test_no_grad_pass(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        req = _common_request()
+        with torch.no_grad():
+            ret = fn(inference, **req)
+        assert ret.frame.shape[0] == 1
+
+    def test_bare_grad_raises(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        req = _common_request()
+        # Spy on op to verify it is NOT called
+        with patch.object(
+            torch.ops.experimental, "gaussian_render_inference_only", wraps=None
+        ) as mock_op:
+            with pytest.raises(RuntimeError, match="requires torch.inference_mode"):
+                fn(inference, **req)
+            mock_op.assert_not_called()
+
+
+# ======================================================================
+# 5. Direct op layer unguarded
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_direct_op_unguarded():
+    """Direct torch.ops.experimental.gaussian_render_inference_only runs with grad enabled."""
+    from experimental.render.kernels._backend import _C  # noqa: F401
+
+    inference = _make_inference_scene(N=50)
+    viewmat, K = _make_camera()
+
+    # no_grad / inference_mode not required for the raw op
+    renders, alphas = torch.ops.experimental.gaussian_render_inference_only(
+        inference.means_planar,
+        inference.qso_packed,
+        inference.colors_packed,
+        viewmat,
+        K,
+        W,
+        H,
+        inference.sh_degree,
+        16,
+        0.01,
+        1e10,
+        0.0,
+        0.3,
+        inference.sh_compression_mode,
+        None,
+    )
+    assert renders.shape == (H, W, 3)
+    assert alphas.shape == (H, W, 1)
+    assert renders.grad_fn is None
+    assert alphas.grad_fn is None
+
+
+# ======================================================================
+# 6. Inference request-subset validation, both entry points
+# ======================================================================
+
+
+_UNSUPPORTED_FEATURES = [
+    "with_ut",
+    "with_eval3d",
+    "absgrad",
+    "sparse_grad",
+    "distributed",
+    "packed",
+    "segmented",
+    "return_normals",
+    "covars",
+    "rays",
+    "radial_coeffs",
+    "tangential_coeffs",
+    "thin_prism_coeffs",
+    "ftheta_coeffs",
+    "lidar_coeffs",
+    "external_distortion_coeffs",
+    "rolling_shutter",
+    "viewmats_rs",
+    "extra_signals",
+    "extra_signals_sh_degree",
+    "rasterize_mode",
+    "channel_chunk",
+    "global_z_order",
+    "ut_params",
+    "colors",
+]
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize("feature", _UNSUPPORTED_FEATURES)
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_unsupported_feature_raises(feature, entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req[feature] = True
+
+    with torch.inference_mode():
+        with pytest.raises(
+            TypeError, match=f"Inference branch does not support {feature}"
+        ):
+            fn(inference, **req)
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_render_mode_non_rgb_raises(entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req["render_mode"] = "D"
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="render_mode='RGB' only"):
+            fn(inference, **req)
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_camera_model_non_pinhole_raises(entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req["camera_model"] = "ortho"
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="camera_model='pinhole' only"):
+            fn(inference, **req)
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_tile_size_invalid_raises(entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req["tile_size"] = 32
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="tile_size in {8, 16}"):
+            fn(inference, **req)
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_sh_degree_override_raises(entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req["sh_degree"] = 3
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="sh_degree/sh_compression_mode"):
+            fn(inference, **req)
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_unknown_kwarg_raises(entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req["bogus_arg"] = 42
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="unexpected keyword argument 'bogus_arg'"):
+            fn(inference, **req)
+
+
+# ======================================================================
+# 7. Camera-shape normalization, both entry points
+# ======================================================================
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+class TestCameraNormalization:
+    def _get_fn(self, entry):
+        import experimental as exp
+
+        return getattr(exp, entry)
+
+    def test_viewmats_1x4x4_normalised(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        viewmat, K = _make_camera()
+        req = dict(viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+        with torch.inference_mode():
+            ret = fn(inference, **req)
+        assert ret.frame.shape == (1, H, W, 3)
+
+    def test_viewmats_2x4x4_rejected(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        viewmat, K = _make_camera()
+        req = dict(
+            viewmats=viewmat[None].expand(2, -1, -1).contiguous(),
+            Ks=K[None],
+            width=W,
+            height=H,
+        )
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="leading dim"):
+                fn(inference, **req)
+
+    def test_both_viewmat_viewmats_rejected(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        viewmat, K = _make_camera()
+        req = dict(viewmat=viewmat, viewmats=viewmat[None], K=K, width=W, height=H)
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="not both"):
+                fn(inference, **req)
+
+    def test_neither_viewmat_viewmats_rejected(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=50)
+        _, K = _make_camera()
+        req = dict(K=K, width=W, height=H)
+        with torch.inference_mode():
+            with pytest.raises(
+                RuntimeError, match="exactly one of viewmat or viewmats"
+            ):
+                fn(inference, **req)
+
+
+# ======================================================================
+# 8. backgrounds plural rejected
+# ======================================================================
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+def test_backgrounds_plural_rejected(entry):
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=10)
+    req = _common_request()
+    req["backgrounds"] = torch.zeros(1, 3, device="cuda")
+
+    with torch.inference_mode():
+        with pytest.raises(
+            TypeError, match="unexpected keyword argument 'backgrounds'"
+        ):
+            fn(inference, **req)
+
+
+# ======================================================================
+# 9. Non-GaussianInferenceScene to direct entry point
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_non_inference_scene_to_direct_raises():
+    from experimental import rasterize_gaussian_inference_scene
+
+    gs = _make_gaussian_scene(N=10)
+    req = _common_request()
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+            rasterize_gaussian_inference_scene(gs, **req)
+
+
+@skipif_no_cuda
+def test_non_inference_scene_string_raises():
+    from experimental import rasterize_gaussian_inference_scene
+
+    req = _common_request()
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+            rasterize_gaussian_inference_scene("not_a_scene", **req)
+
+
+# ======================================================================
+# 10. Render on empty/released Inference scene
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_render_empty_scene_raises():
+    from experimental import rasterize_gaussian_inference_scene
+
+    inference = _make_inference_scene(N=50)
+    inference.release()
+    req = _common_request()
+
+    with torch.inference_mode():
+        with patch.object(
+            torch.ops.experimental, "gaussian_render_inference_only"
+        ) as mock_op:
+            with pytest.raises(ValueError, match="has been released"):
+                rasterize_gaussian_inference_scene(inference, **req)
+            mock_op.assert_not_called()
+
+
+@skipif_no_cuda
+def test_render_empty_scene_via_render_scene():
+    from experimental import render_scene
+
+    inference = _make_inference_scene(N=50)
+    inference.release()
+    req = _common_request()
+
+    with torch.inference_mode():
+        with patch.object(
+            torch.ops.experimental, "gaussian_render_inference_only"
+        ) as mock_op:
+            with pytest.raises(ValueError, match="has been released"):
+                render_scene(inference, **req)
+            mock_op.assert_not_called()
+
+
+# ======================================================================
+# 11. Unsupported Scene subclass
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_unsupported_scene_type():
+    from experimental import render_scene
+
+    class FakeScene:
+        pass
+
+    req = _common_request()
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+            render_scene(FakeScene(), **req)
+
+
+# ======================================================================
+# 12. out= buffer contract suite
+# ======================================================================
+
+
+@skipif_no_cuda
+class TestOutBufferContract:
+    """Comprehensive out= buffer tests."""
+
+    def test_numerical_match(self):
+        """out= produces same numbers as freshly-allocated path."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=200)
+        req = _common_request()
+
+        with torch.inference_mode():
+            fresh = rasterize_gaussian_inference_scene(inference, **req)
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={
+                "alpha": torch.empty(1, H, W, 1, device="cuda", dtype=torch.float32)
+            },
+        )
+
+        with torch.inference_mode():
+            reused = rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+        torch.testing.assert_close(reused.frame, fresh.frame, atol=0, rtol=0)
+        torch.testing.assert_close(
+            reused.metadata["alpha"],
+            fresh.metadata["alpha"],
+            atol=0,
+            rtol=0,
+        )
+
+    def test_identity_guarantee(self):
+        """Returned object *is* the same ``out`` instance across N=3 calls with data_ptr stability."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=50)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={
+                "alpha": torch.empty(1, H, W, 1, device="cuda", dtype=torch.float32)
+            },
+        )
+        frame_ptr = buf.frame.data_ptr()
+
+        with torch.inference_mode():
+            alpha_ptr = None
+            for i in range(3):
+                ret = rasterize_gaussian_inference_scene(inference, out=buf, **req)
+                assert ret is buf
+                assert buf.frame.data_ptr() == frame_ptr
+                if i > 0:
+                    # alpha data_ptr stable after first call
+                    assert buf.metadata["alpha"].data_ptr() == alpha_ptr
+                alpha_ptr = buf.metadata["alpha"].data_ptr()
+
+    def test_metadata_refresh(self):
+        """Old metadata keys are cleared when out= is provided."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=50)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={
+                "stale_key": "should_vanish",
+                "alpha": torch.empty(1, H, W, 1, device="cuda", dtype=torch.float32),
+            },
+        )
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+        assert "stale_key" not in ret.metadata
+        assert "alpha" in ret.metadata
+
+    def test_lazy_alpha_alloc(self):
+        """When out= has no alpha in metadata, alpha is newly allocated."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=50)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={},
+        )
+
+        with torch.inference_mode():
+            ret = rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+        assert "alpha" in ret.metadata
+        assert ret.metadata["alpha"].shape == (1, H, W, 1)
+
+    def test_shape_mismatch_raises(self):
+        """Wrong frame shape raises RuntimeError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H + 1, W, 3, device="cuda", dtype=torch.float32),
+            metadata={},
+        )
+
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="out.frame expected shape"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_dtype_mismatch_raises(self):
+        """Wrong frame dtype raises RuntimeError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float16),
+            metadata={},
+        )
+
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="out.frame expected shape"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_device_mismatch_raises(self):
+        """CPU frame with CUDA viewmat raises ValueError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, dtype=torch.float32),  # CPU
+            metadata={},
+        )
+
+        with torch.inference_mode():
+            with pytest.raises(ValueError, match="out buffer is on .* but scene is on"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_non_contiguous_raises(self):
+        """Non-contiguous frame raises RuntimeError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        # Create non-contiguous by transposing
+        frame = torch.empty(1, 3, H, W, device="cuda", dtype=torch.float32).permute(
+            0, 2, 3, 1
+        )
+        assert not frame.is_contiguous()
+
+        buf = RenderReturn(frame=frame, metadata={})
+
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="out.frame expected shape"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_grad_tracked_buffer_raises(self):
+        """Frame with requires_grad raises RuntimeError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(
+                1, H, W, 3, device="cuda", dtype=torch.float32
+            ).requires_grad_(True),
+            metadata={},
+        )
+
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="must not be grad-tracked"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_grad_tracked_alpha_raises(self):
+        """Alpha with requires_grad raises RuntimeError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={
+                "alpha": torch.empty(
+                    1, H, W, 1, device="cuda", dtype=torch.float32
+                ).requires_grad_(True)
+            },
+        )
+
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="must not be grad-tracked"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_vanilla_rejects_out(self):
+        """render_scene with GaussianScene and out= raises TypeError."""
+        from experimental import render_scene, RenderReturn
+
+        gs = _make_gaussian_scene(N=10)
+        viewmat, K = _make_camera()
+        req = dict(viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={},
+        )
+
+        with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+            render_scene(gs, out=buf, **req)
+
+    def test_alpha_shape_mismatch_raises(self):
+        """Wrong alpha shape in metadata raises RuntimeError."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        buf = RenderReturn(
+            frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+            metadata={
+                "alpha": torch.empty(
+                    1, H, W, 3, device="cuda", dtype=torch.float32
+                )  # wrong last dim
+            },
+        )
+
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError, match="out.metadata\\['alpha'\\]"):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    def test_metadata_unchanged_on_failure(self):
+        """Metadata is not corrupted when validation fails before the op runs."""
+        from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+        inference = _make_inference_scene(N=10)
+        req = _common_request()
+
+        sentinel = object()
+        original_alpha = torch.empty(1, H, W, 1, device="cuda", dtype=torch.float32)
+        original_metadata = {"sentinel": sentinel, "alpha": original_alpha}
+
+        # Shape mismatch failure (H+1 instead of H)
+        buf = RenderReturn(
+            frame=torch.empty(1, H + 1, W, 3, device="cuda", dtype=torch.float32),
+            metadata=dict(original_metadata),
+        )
+        with torch.inference_mode():
+            with pytest.raises(RuntimeError):
+                rasterize_gaussian_inference_scene(inference, out=buf, **req)
+        assert buf.metadata.get("sentinel") is sentinel
+        assert "alpha" in buf.metadata
+
+
+# ======================================================================
+# 13. Cross-path render parity
+# ======================================================================
+
+_CROSS_PARITY_CASES = [
+    # (sh_degree, sh_compression)
+    (None, "none"),
+    (0, "none"),
+    (1, "none"),
+    (2, "none"),
+    (3, "none"),
+    (3, "32b"),
+    (3, "16b"),
+]
+
+
+def _compute_psnr(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Compute PSNR between two images (assuming [0,1]-ish range)."""
+    mse = ((a.float() - b.float()) ** 2).mean().item()
+    if mse == 0:
+        return float("inf")
+    # Use max of 1.0 as peak for clamp_min(0) images
+    peak = max(a.abs().max().item(), b.abs().max().item(), 1.0)
+    import math
+
+    return 10 * math.log10(peak**2 / mse)
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize("sh_degree,sh_compression", _CROSS_PARITY_CASES)
+def test_cross_path_parity(sh_degree, sh_compression):
+    """Inference and vanilla (direct rasterization) paths produce reasonably close results (PSNR > 30 dB)."""
+    from experimental import render_scene
+    from gsplat.rendering import rasterization
+
+    torch.manual_seed(42)
+    N = 500
+    gs = _make_gaussian_scene(N=N, sh_degree=sh_degree)
+
+    # Inference scene from the same GaussianScene
+    from experimental import GaussianInferenceScene
+
+    inference = GaussianInferenceScene.from_gaussian_scene(
+        gs, id="test_inference", sh_compression=sh_compression
+    )
+
+    viewmat, K = _make_camera()
+
+    # Vanilla path via direct rasterization (render_scene no longer accepts GaussianScene)
+    splats = gs.splats
+    vanilla_req = dict(viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+    if sh_degree is not None:
+        vanilla_req["sh_degree"] = sh_degree
+    with torch.no_grad():
+        vanilla_renders, vanilla_alphas, _info = rasterization(
+            splats["means"],
+            splats["quats"],
+            splats["scales"].exp(),
+            splats["opacities"].sigmoid(),
+            splats.get("colors", splats.get("sh0")),
+            **vanilla_req,
+        )
+
+    # Inference path
+    inference_req = dict(viewmat=viewmat, K=K, width=W, height=H)
+    with torch.inference_mode():
+        inference_ret = render_scene(inference, **inference_req)
+
+    # Verify inference render_path tag
+    assert inference_ret.metadata["render_path"] == "inference"
+
+    # Compare: vanilla produces [1, H, W, 3], inference produces [1, H, W, 3]
+    psnr = _compute_psnr(vanilla_renders, inference_ret.frame)
+    assert psnr > 30.0, (
+        f"PSNR {psnr:.1f} dB below 30 dB threshold for "
+        f"sh_degree={sh_degree}, sh_compression={sh_compression}"
+    )
+
+    # Alpha comparison
+    alpha_diff = (vanilla_alphas - inference_ret.metadata["alpha"]).abs()
+    assert alpha_diff.max().item() < 0.1, (
+        f"Alpha max diff {alpha_diff.max().item()} for "
+        f"sh_degree={sh_degree}, sh_compression={sh_compression}"
+    )

--- a/experimental/render/kernels/__init__.py
+++ b/experimental/render/kernels/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Backend implementation layer for experimental render operators."""
+
+__all__: list[str] = []

--- a/experimental/render/kernels/_backend.py
+++ b/experimental/render/kernels/_backend.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from subprocess import DEVNULL, call
+import torch
+import torch.utils.cpp_extension as jit
+from .cuda.build import build_and_load_experimental_gaussian_render_inference_scene
+
+try:
+    from rich.console import Console
+
+    _console = Console()
+except ImportError:
+    _console = None
+
+
+def cuda_toolkit_available():
+    """
+    Check more robustly if the CUDA toolkit is available.
+    1. Attempt to locate ``CUDA_HOME`` using PyTorch's internal method.
+    2. Check if nvcc is present in that location.
+    """
+    cuda_home = jit._find_cuda_home()
+    if not cuda_home:
+        return False
+
+    nvcc_path = os.path.join(cuda_home, "bin", "nvcc")
+    if not os.path.isfile(nvcc_path):
+        try:
+            call(["nvcc"], stdout=DEVNULL, stderr=DEVNULL)
+            return True
+        except FileNotFoundError:
+            return False
+    return True
+
+
+_C = None
+
+
+def _warn(message):
+    """Print an inference backend warning through rich when it is available."""
+    if _console is not None:
+        _console.print(f"[yellow]{message}[/yellow]")
+    else:
+        print(message)
+
+
+def _inference_op_registered():
+    """Return whether loading the extension registered the Inference torch op."""
+    return hasattr(torch.ops.experimental, "gaussian_render_inference_only")
+
+
+try:
+    # Try to import the compiled module first, matching gsplat.cuda._backend.
+    # The module intentionally lives outside cuda.csrc so in-tree source
+    # checkouts fall through to JIT instead of importing the source directory as
+    # a namespace package.
+    from experimental.render.kernels import csrc as _C
+except ImportError:
+    # Fall back to JIT compilation.
+    if cuda_toolkit_available():
+        try:
+            _C = build_and_load_experimental_gaussian_render_inference_scene()
+        except Exception as _build_err:
+            _warn(
+                "experimental: Inference JIT build failed "
+                f"({_build_err}). Inference render will be disabled."
+            )
+    else:
+        _warn("experimental: No CUDA toolkit found. Inference render will be disabled.")
+
+if _C is not None and not _inference_op_registered():
+    _warn(
+        "experimental: Inference CUDA extension loaded but did not register "
+        "torch.ops.experimental.gaussian_render_inference_only. "
+        "Inference render will be disabled."
+    )
+    _C = None
+
+__all__ = ["_C"]

--- a/experimental/render/kernels/cuda/__init__.py
+++ b/experimental/render/kernels/cuda/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/experimental/render/kernels/cuda/build.py
+++ b/experimental/render/kernels/cuda/build.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build parameters for the experimental Inference render CUDA extension."""
+
+import os
+import sys
+import platform
+import json
+import shutil
+import time
+from contextlib import nullcontext, contextmanager
+from types import SimpleNamespace
+
+from torch.utils.cpp_extension import CUDA_HOME
+
+try:
+    import torch.utils.cpp_extension as jit
+except ImportError as e:
+    if "pkg_resources" in str(e):
+        raise ImportError(
+            "torch.utils.cpp_extension failed to import because 'pkg_resources' "
+            "is no longer available in setuptools >= 82. "
+            "Fix: pip install 'setuptools<82'"
+        ) from e
+    raise
+
+try:
+    from rich.console import Console
+
+    _console = Console()
+except ImportError:
+    _console = None
+
+# Directory of this build.py file (experimental/render/kernels/cuda/)
+PATH = os.path.dirname(os.path.abspath(__file__))
+
+# Compute the path to gsplat/cuda/include/ relative to this file's location.
+# Layout: <repo_root>/experimental/render/kernels/cuda/build.py
+#         <repo_root>/gsplat/cuda/include/
+_REPO_ROOT = os.path.normpath(os.path.join(PATH, "..", "..", "..", ".."))
+_GSPLAT_INCLUDE = os.path.join(_REPO_ROOT, "gsplat", "cuda", "include")
+_GSPLAT_CSRC = os.path.join(_REPO_ROOT, "gsplat", "cuda", "csrc")
+
+DEBUG = os.getenv("DEBUG", "0") == "1"
+FAST_MATH = os.getenv("FAST_MATH", "1") == "1"
+WITH_SYMBOLS = os.getenv("WITH_SYMBOLS", "1" if DEBUG else "0") == "1"
+NVCC_FLAGS = os.getenv("NVCC_FLAGS", "")
+MAX_JOBS = os.getenv("MAX_JOBS")
+NINJA_STATUS = os.getenv("NINJA_STATUS")
+VERBOSE = os.getenv("VERBOSE", "0") == "1"
+
+
+def get_build_parameters():
+    name = "experimental_gaussian_render_inference_scene_cuda"
+    current_dir = PATH
+
+    gaussian_render_inference_dir = os.path.join(
+        current_dir, "csrc", "gaussian_inference"
+    )
+    # Include paths -----------------------------------
+    extra_include_paths = [
+        _GSPLAT_INCLUDE,
+        _GSPLAT_CSRC,  # for Config.h (included as #include "Config.h")
+        gaussian_render_inference_dir,
+        os.path.join(_GSPLAT_CSRC, "third_party", "glm"),
+    ]
+
+    # Fix for CUDA 12+ in conda environment
+    if CUDA_HOME and os.path.isdir(os.path.join(CUDA_HOME, "targets")):
+        for arch in os.listdir(os.path.join(CUDA_HOME, "targets")):
+            if os.path.isdir(p := os.path.join(CUDA_HOME, "targets", arch, "include")):
+                extra_include_paths.append(p)
+                if os.path.isdir(
+                    p := os.path.join(CUDA_HOME, "targets", arch, "include", "cccl")
+                ):
+                    extra_include_paths.append(p)
+
+    # Source files ------------------------------------
+    sources = [os.path.join(current_dir, "ext.cpp")]
+    if os.path.isdir(gaussian_render_inference_dir):
+        sources.append(
+            os.path.join(
+                gaussian_render_inference_dir, "GaussianRenderInferenceScene.cu"
+            )
+        )
+    if os.path.isdir(gaussian_render_inference_dir):
+        sources += [
+            os.path.join(gaussian_render_inference_dir, f)
+            for f in [
+                "IntersectCommon.cu",
+                "IntersectMTFused.cu",
+                "MacroTileIntersect.cu",
+                "MacroTileRasterize.cu",
+                "Projection.cu",
+                "SegmentedSort.cu",
+                "SHCompression.cu",
+                "SphericalHarmonics.cu",
+            ]
+        ]
+
+    # Compiler flags ----------------------------------
+    extra_cflags = []
+    extra_cuda_cflags = []
+    extra_ldflags = []
+
+    if sys.platform == "win32":
+        extra_cflags += ["/std:c++20", "/Zc:preprocessor", "-DWIN32_LEAN_AND_MEAN"]
+        extra_cuda_cflags += [
+            "-std=c++20",
+            "-allow-unsupported-compiler",
+            "-Xcompiler",
+            "/Zc:preprocessor",
+            "-DWIN32_LEAN_AND_MEAN",
+        ]
+    else:
+        extra_cflags = ["-std=c++20"]
+
+    if sys.platform == "darwin" and platform.machine() == "arm64":
+        extra_cflags += ["-arch", "arm64"]
+        extra_ldflags += ["-arch", "arm64"]
+
+    extra_cuda_cflags += ["--forward-unknown-opts"]
+
+    if DEBUG:
+        extra_cflags += ["-g", "-O0"]
+        if sys.platform != "win32":
+            extra_cflags += ["-Wall"]
+            extra_cuda_cflags += [
+                "-Xcompiler=-Werror",
+                "--Werror",
+                "all-warnings",
+            ]
+        else:
+            extra_cflags += ["/Zi", "/Od"]
+            extra_cuda_cflags += ["-Od"]
+    else:
+        if sys.platform != "win32":
+            extra_cflags += ["-O3", "-DNDEBUG"]
+        else:
+            extra_cflags += ["/O2", "-DNDEBUG"]
+            extra_cuda_cflags += ["-O2", "-DNDEBUG"]
+
+    extra_cuda_cflags += ["-use_fast_math"] if FAST_MATH else []
+
+    extra_cuda_cflags += ["-diag-suppress", "20012,186"]
+    if not os.name == "nt":
+        extra_cflags += ["-Wno-attributes"]
+        extra_cflags += ["-Wno-unknown-pragmas"]
+
+    extra_ldflags += [] if WITH_SYMBOLS or sys.platform == "win32" else ["-s"]
+
+    if WITH_SYMBOLS:
+        extra_cuda_cflags += ["-lineinfo"]
+
+    import torch
+
+    if torch.version.hip:
+        extra_cflags += ["-DUSE_ROCM", "-U__HIP_NO_HALF_CONVERSIONS__"]
+    else:
+        extra_cuda_cflags += ["--expt-relaxed-constexpr"]
+
+    parinfo = torch.__config__.parallel_info()
+    if (
+        "backend: OpenMP" in parinfo
+        and "OpenMP not found" not in parinfo
+        and sys.platform != "darwin"
+    ):
+        extra_cflags += ["-DAT_PARALLEL_OPENMP"]
+        if sys.platform == "win32":
+            extra_cflags += ["/openmp"]
+            extra_cuda_cflags += ["-Xcompiler", "/openmp"]
+        else:
+            extra_cflags += ["-fopenmp"]
+        if sys.platform == "win32":
+            extra_cuda_cflags += ["-DAT_PARALLEL_OPENMP"]
+    else:
+        print("Compiling without OpenMP...")
+
+    if sys.platform != "win32":
+        extra_cuda_cflags += extra_cflags
+
+    if DEBUG and sys.platform != "win32":
+        extra_cflags += ["-Werror"]
+
+    extra_cuda_cflags += [] if NVCC_FLAGS == "" else NVCC_FLAGS.split(" ")
+
+    return SimpleNamespace(
+        name=name,
+        extra_include_paths=extra_include_paths,
+        sources=sources,
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cuda_cflags,
+        extra_ldflags=extra_ldflags,
+    )
+
+
+def build_and_load_experimental_gaussian_render_inference_scene():
+    build_params = get_build_parameters()
+
+    if not hasattr(jit, "_get_build_directory"):
+        raise RuntimeError(
+            "torch.utils.cpp_extension.jit._get_build_directory is missing — "
+            "PyTorch upgrade broke a private API. Update "
+            "experimental/render/kernels/cuda/build.py."
+        )
+
+    build_dir = jit._get_build_directory(build_params.name, verbose=False)
+
+    try:
+        os.remove(os.path.join(build_dir, "lock"))
+    except OSError:
+        pass
+
+    saved_build_params_fname = os.path.join(build_dir, "build_params.json")
+    build_params_changed = False
+    try:
+        if os.path.exists(saved_build_params_fname):
+            with open(saved_build_params_fname, "r") as f:
+                saved = SimpleNamespace(**json.load(f))
+            build_params_changed = saved != build_params
+    except Exception:
+        build_params_changed = True
+
+    if build_params_changed:
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+    os.makedirs(build_dir, exist_ok=True)
+
+    with open(saved_build_params_fname, "w") as f:
+        json.dump(build_params.__dict__, f)
+
+    @contextmanager
+    def status_context():
+        tic = time.time()
+        msg = (
+            f"experimental: Setting up Inference CUDA extension with "
+            f"MAX_JOBS={MAX_JOBS if MAX_JOBS else 'max'} "
+            f"(This may take a few minutes the first time)"
+        )
+        if _console is not None:
+            ctx = _console.status(f"[bold yellow]{msg}", spinner="bouncingBall")
+        else:
+            print(msg)
+            ctx = nullcontext()
+        with ctx:
+            yield
+        toc = time.time()
+        if _console is not None:
+            _console.print(
+                f"[green]experimental: Inference CUDA extension set up in "
+                f"{toc - tic:.2f} seconds.[/green]"
+            )
+        else:
+            print(
+                f"experimental: Inference CUDA extension set up in "
+                f"{toc - tic:.2f} seconds."
+            )
+
+    module_exists = os.path.exists(
+        os.path.join(build_dir, f"{build_params.name}.so")
+    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.lib"))
+
+    with (
+        status_context() if not module_exists or build_params_changed else nullcontext()
+    ):
+        envvars_to_remove = []
+        try:
+            if not NINJA_STATUS:
+                envvars_to_remove.append("NINJA_STATUS")
+                os.environ["NINJA_STATUS"] = "[%f/%t %r %es] "
+
+            module = jit.load(
+                name=build_params.name,
+                sources=build_params.sources,
+                extra_cflags=build_params.extra_cflags,
+                extra_cuda_cflags=build_params.extra_cuda_cflags,
+                extra_include_paths=build_params.extra_include_paths,
+                extra_ldflags=build_params.extra_ldflags,
+                build_directory=build_dir,
+                verbose=VERBOSE,
+            )
+            return module
+        except OSError:
+            return jit._import_module_from_library(build_params.name, build_dir, True)
+        finally:
+            for envvar in envvars_to_remove:
+                os.environ.pop(envvar)
+
+
+__all__ = [
+    "build_and_load_experimental_gaussian_render_inference_scene",
+    "get_build_parameters",
+]

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/Constants.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/Constants.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Common.h" // ALPHA_THRESHOLD
+
+namespace higs {
+
+static constexpr float MAX_EXTEND          = 3.33f;
+static constexpr float INV_ALPHA_THRESHOLD = 1.0f / ALPHA_THRESHOLD;
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.cu
@@ -1,0 +1,508 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Config.h is resolved via extra_include_paths set to gsplat/cuda/csrc/
+#include "Config.h"
+
+#include <ATen/core/Tensor.h>
+#include <ATen/Functions.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/zeros.h>
+#include <ATen/ops/ones_like.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/cuda.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+#include "Common.h"    // CHECK_INPUT, DEVICE_GUARD, CameraModelType
+#include "GaussianRenderInferenceScene.h"
+
+// Viewer kernel headers
+#include "Projection.h"
+#include "SphericalHarmonics.h"
+#include "IntersectMTFused.h"
+#include "SHCompression.h"
+#include "InferenceTypes.h"
+
+namespace gsplat {
+namespace gaussian_render_inference_scene {
+
+static constexpr float SH_ACTIVATION_SCALE = 0.5f;
+static constexpr float SH_ACTIVATION_SHIFT = 0.0f;
+
+InferenceRenderState::~InferenceRenderState() = default;
+
+// ==========================================================================
+// create_gaussian_render_inference_scene_state
+// ==========================================================================
+std::unique_ptr<InferenceRenderState> create_gaussian_render_inference_scene_state(
+    const InferenceRenderScene& scene,
+    int64_t sh_compression_mode
+) {
+    DEVICE_GUARD(scene.means_planar);
+
+    auto state = std::make_unique<InferenceRenderState>();
+
+    state->num_gaussians = static_cast<uint32_t>(scene.means_planar.size(1));  // [3, N]
+    if (state->num_gaussians == 0) return state;
+
+    auto opts_f = at::TensorOptions().dtype(at::kFloat).device(scene.means_planar.device());
+    auto opts_h = at::TensorOptions().dtype(at::kHalf).device(scene.means_planar.device());
+    auto opts_i = at::TensorOptions().dtype(at::kInt).device(scene.means_planar.device());
+
+    // ---- Determine K from shape ----
+    if (scene.sh_degree >= 0 && scene.colors_packed.dim() == 3) {
+        state->sh_coeffs_per_channel = static_cast<uint32_t>(scene.colors_packed.size(1));
+    } else {
+        state->sh_coeffs_per_channel = 0;
+    }
+    state->maxShDegree = (state->sh_coeffs_per_channel > 0)
+        ? static_cast<uint32_t>(std::sqrt(static_cast<double>(state->sh_coeffs_per_channel))) - 1
+        : 0;
+
+    // ---- SH compression at creation time for K==16 ----
+    // sh_compression_mode: 0=NONE (skip), 1=COMPRESS_32B only, 2=COMPRESS_16B only.
+    TORCH_CHECK(
+        sh_compression_mode >= 0 && sh_compression_mode <= 2,
+        "sh_compression_mode must be 0 (NONE), 1 (COMPRESS_32B), or 2 (COMPRESS_16B); got ",
+        sh_compression_mode);
+    state->shCompressionMode = sh_compression_mode;
+    TORCH_CHECK(
+        sh_compression_mode == 0 || state->sh_coeffs_per_channel == 16,
+        "sh_compression_mode requires SH degree 3 (K==16); got K=",
+        state->sh_coeffs_per_channel);
+    if (state->sh_coeffs_per_channel == 16 && sh_compression_mode != 0) {
+        auto sh_float = scene.colors_packed.contiguous().to(at::kFloat);
+        auto opacities_float = scene.qso_packed.contiguous().narrow(1, 7, 1).squeeze(1).to(at::kFloat);
+        auto compressed = higs::launch_sh_compress(
+            sh_float, opacities_float, static_cast<SHCompressionMode>(sh_compression_mode));
+        state->shCompressed = compressed.packed;
+        state->shDecodeParams = std::make_unique<higs::SHDecodeParams>(compressed.decode_params);
+        torch::cuda::synchronize();
+    }
+
+    // ---- Pre-allocate per-frame intermediates ----
+    int64_t num_gaussians = static_cast<int64_t>(state->num_gaussians);
+    state->visible = at::zeros({(num_gaussians + 31) / 32}, opts_i);
+    state->means2d = at::empty({1, 1, num_gaussians, 2}, opts_f);
+    state->depths  = at::empty({1, 1, num_gaussians}, opts_f);
+    state->conics  = at::empty({1, 1, num_gaussians, 4}, opts_h);
+    state->colors  = at::zeros({num_gaussians, 4}, opts_h);
+
+    // ---- Pre-allocate default black background: [R, G, B, T] ----
+    state->background = at::zeros({1, 4}, opts_h);
+    state->background.select(1, 3).fill_(at::Half(1.0f));
+
+    // ---- Create intersection stage ----
+    state->isect = std::make_unique<IntersectMTFused>();
+
+    return state;
+}
+
+// ==========================================================================
+// release_gaussian_render_inference_scene_state
+// ==========================================================================
+void release_gaussian_render_inference_scene_state(InferenceRenderState& state) {
+    InferenceRenderState empty;
+    std::swap(state, empty);
+}
+
+// ==========================================================================
+// render_gaussian_inference_scene
+// ==========================================================================
+at::Tensor render_gaussian_inference_scene(
+    InferenceRenderState& state,
+    const InferenceRenderScene& scene,
+    const at::Tensor& viewmat,
+    const at::Tensor& K,
+    int64_t width, int64_t height,
+    int64_t tile_size,
+    double near_plane, double far_plane,
+    double radius_clip, double eps2d,
+    int64_t sh_degree,
+    int64_t sh_compression_mode,
+    const at::optional<at::Tensor>& background,
+    const at::optional<at::Tensor>& out_rgbt
+) {
+    // NOTE: No c10::NoGradGuard here -- the Python caller already enforces
+    // torch.inference_mode() (via check_inference_grad_mode), so adding a
+    // redundant guard would cost ~2 us per frame in thread-local toggles.
+    DEVICE_GUARD(scene.means_planar);
+
+    auto opts_h = at::TensorOptions().dtype(at::kHalf).device(scene.means_planar.device());
+
+    // ---- Validate out_rgbt if provided ----
+    if (out_rgbt.has_value()) {
+        const auto& buf = out_rgbt.value();
+        TORCH_CHECK(buf.is_cuda(), "out_rgbt must be a CUDA tensor");
+        TORCH_CHECK(buf.dtype() == at::kHalf, "out_rgbt must be float16");
+        TORCH_CHECK(buf.is_contiguous(), "out_rgbt must be contiguous");
+        TORCH_CHECK(buf.dim() == 4, "out_rgbt must be 4D");
+        TORCH_CHECK(
+            buf.size(0) == 1 && buf.size(1) == height &&
+                buf.size(2) == width && buf.size(3) == 4,
+            "out_rgbt must have shape [1, ", height, ", ", width,
+            ", 4], got [", buf.size(0), ", ", buf.size(1), ", ",
+            buf.size(2), ", ", buf.size(3), "]");
+    }
+
+    // ---- Early return for empty scene ----
+    if (state.num_gaussians == 0) {
+        at::Tensor rgbt = out_rgbt.has_value()
+            ? out_rgbt.value() : at::zeros({1, height, width, 4}, opts_h);
+        rgbt.zero_();
+        rgbt.select(3, 3).fill_(at::Half(1.0f));
+        if (background.has_value()) {
+            rgbt.narrow(3, 0, 3).copy_(
+                background.value().reshape({1, 1, 1, 3}).to(at::kHalf));
+        }
+        return rgbt;
+    }
+
+    // ---- Tile grid dimensions ----
+    uint32_t tw = (static_cast<uint32_t>(width) + static_cast<uint32_t>(tile_size) - 1)
+                  / static_cast<uint32_t>(tile_size);
+    uint32_t th = (static_cast<uint32_t>(height) + static_cast<uint32_t>(tile_size) - 1)
+                  / static_cast<uint32_t>(tile_size);
+
+    // ---- Clamp SH degree ----
+    TORCH_CHECK(
+        sh_compression_mode == state.shCompressionMode,
+        "render sh_compression_mode (", sh_compression_mode,
+        ") must match the mode used to create the inference render state (",
+        state.shCompressionMode, ")");
+    auto compression = static_cast<SHCompressionMode>(state.shCompressionMode);
+    if (state.sh_coeffs_per_channel > 0) {
+        sh_degree = std::min(sh_degree, static_cast<int64_t>(state.maxShDegree));
+    }
+
+    // ---- Get CUDA stream ----
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    // ---- Camera views for kernels; reshape is metadata-only for valid inputs. ----
+    TORCH_CHECK(viewmat.is_contiguous(), "viewmat must be contiguous");
+    TORCH_CHECK(K.is_contiguous(), "K must be contiguous");
+    auto viewmat_4d = viewmat.reshape({1, 1, 4, 4});
+    auto K_4d = K.reshape({1, 1, 3, 3});
+
+    // ---- Set background only when it changes from the cached default. ----
+    if (background.has_value()) {
+        state.background.narrow(1, 0, 3).copy_(
+            background.value().unsqueeze(0).to(at::kHalf));
+        state.backgroundIsDefault = false;
+    } else if (!state.backgroundIsDefault) {
+        state.background.zero_();
+        state.background.select(1, 3).fill_(at::Half(1.0f));
+        state.backgroundIsDefault = true;
+    }
+
+    // ---- Select output framebuffer ----
+    // Python callers normally pass a pre-allocated out tensor; the allocation
+    // fallback keeps the C++ helper usable for direct calls and the stateless
+    // compatibility wrapper.  Output is always half (fp16); callers that need
+    // float32 convert after the call.
+    at::Tensor rgbt = out_rgbt.has_value()
+        ? out_rgbt.value()
+        : at::empty({1, height, width, 4}, opts_h);
+
+    // ==================================================================
+    // Projection + SH evaluation
+    // ==================================================================
+    const auto& means = scene.means_planar;
+    const auto& qso_packed = scene.qso_packed;
+    const auto& colors_packed = scene.colors_packed;
+    const at::Tensor* raster_colors = &state.colors;
+
+    if (state.sh_coeffs_per_channel > 0 && compression != SHCompressionMode::NONE) {
+        // ---- Compressed SH — fused projection + compressed SH decode (K==16 validated at creation) ----
+        const higs::SHDecodeParams* decode_params = state.shDecodeParams.get();
+        TORCH_CHECK(
+            decode_params != nullptr,
+            "compressed SH decode parameters are missing for sh_compression_mode=",
+            state.shCompressionMode);
+
+        higs::launch_projection_sh_fused_kernel(
+            means, {}, qso_packed, viewmat_4d, K_4d,
+            static_cast<uint32_t>(width), static_cast<uint32_t>(height),
+            static_cast<float>(eps2d), static_cast<float>(near_plane),
+            static_cast<float>(far_plane), static_cast<float>(radius_clip),
+            gsplat::CameraModelType::PINHOLE,
+            static_cast<int32_t>(sh_degree), state.shCompressed, SH_ACTIVATION_SCALE, SH_ACTIVATION_SHIFT,
+            compression, decode_params,
+            state.visible, state.means2d, state.depths, state.conics, state.colors, {});
+
+    } else if (state.sh_coeffs_per_channel > 0) {
+        // ---- Uncompressed SH — fused projection + SH for any degree ----
+        // The fused kernel handles all SH degrees; only compressed mode
+        // is restricted to degree 3.
+        higs::launch_projection_sh_fused_kernel(
+            means, {}, qso_packed, viewmat_4d, K_4d,
+            static_cast<uint32_t>(width), static_cast<uint32_t>(height),
+            static_cast<float>(eps2d), static_cast<float>(near_plane),
+            static_cast<float>(far_plane), static_cast<float>(radius_clip),
+            gsplat::CameraModelType::PINHOLE,
+            static_cast<int32_t>(sh_degree), colors_packed, SH_ACTIVATION_SCALE, SH_ACTIVATION_SHIFT,
+            SHCompressionMode::NONE, nullptr,
+            state.visible, state.means2d, state.depths, state.conics, state.colors, {});
+
+    } else {
+        // ---- Pre-activated RGB: projection only + copy colors ----
+        higs::launch_projection_fwd_kernel(
+            means, {}, qso_packed, viewmat_4d, K_4d,
+            static_cast<uint32_t>(width), static_cast<uint32_t>(height),
+            static_cast<float>(eps2d), static_cast<float>(near_plane),
+            static_cast<float>(far_plane), static_cast<float>(radius_clip),
+            gsplat::CameraModelType::PINHOLE,
+            state.visible, state.means2d, state.depths, state.conics, {});
+
+        // colors_packed is already [N, 4] half {R, G, B, 0}
+        raster_colors = &colors_packed;
+    }
+
+    // ==================================================================
+    // Intersection + Rasterization (fused macro-tile path)
+    // ==================================================================
+    state.isect->execute(
+        state.means2d, state.depths, state.conics, state.visible,
+        static_cast<int32_t>(tile_size),
+        static_cast<int32_t>(tw), static_cast<int32_t>(th),
+        stream);
+
+    state.isect->rasterize(
+        state.means2d, state.conics, *raster_colors, state.background,
+        static_cast<uint32_t>(width), static_cast<uint32_t>(height),
+        rgbt);
+
+    // ==================================================================
+    // Return native half4 RGBT output
+    // ==================================================================
+    return rgbt;
+}
+
+// ==========================================================================
+// GaussianInferenceRenderer — pybind wrapper
+// ==========================================================================
+
+GaussianInferenceRenderer::~GaussianInferenceRenderer() = default;
+
+GaussianInferenceRenderer::GaussianInferenceRenderer(
+    const at::Tensor& means_planar,
+    const at::Tensor& qso_packed,
+    const at::Tensor& colors_packed,
+    int64_t sh_degree,
+    int64_t sh_compression_mode
+) {
+    // Normalize SH3 pre-packed 2-D (N, 48) tensors to 3-D (N, 16, 3) once at
+    // construction time.  The cached view is reused in render() to avoid a
+    // per-frame reshape + contiguous check.
+    int64_t N = means_planar.size(1);
+    if (sh_degree == 3 && colors_packed.dim() == 2 && colors_packed.size(1) == 48) {
+        colors_normalized_ = colors_packed.reshape({N, 16, 3}).contiguous();
+    } else {
+        colors_normalized_ = colors_packed;
+    }
+
+    InferenceRenderScene scene;
+    scene.means_planar = means_planar;
+    scene.qso_packed = qso_packed;
+    scene.colors_packed = colors_normalized_;
+    scene.sh_degree = sh_degree;
+    scene.sh_compression_mode = sh_compression_mode;
+
+    state_ = create_gaussian_render_inference_scene_state(scene, sh_compression_mode);
+}
+
+at::Tensor GaussianInferenceRenderer::render(
+    const at::Tensor& means_planar,
+    const at::Tensor& qso_packed,
+    const at::Tensor& colors_packed,
+    const at::Tensor& viewmat,
+    const at::Tensor& K,
+    int64_t width, int64_t height,
+    int64_t tile_size,
+    double near_plane, double far_plane,
+    double radius_clip, double eps2d,
+    int64_t sh_degree,
+    int64_t sh_compression_mode,
+    const at::optional<at::Tensor>& background,
+    const at::optional<at::Tensor>& out_rgbt
+) {
+    // Use the colors tensor normalized once at construction time (colors_normalized_)
+    // instead of re-normalizing every frame.  The means_planar and qso_packed are
+    // passed through as-is since they don't need reshaping.
+    InferenceRenderScene scene;
+    scene.means_planar = means_planar;
+    scene.qso_packed = qso_packed;
+    scene.colors_packed = colors_normalized_;
+    scene.sh_degree = sh_degree;
+    scene.sh_compression_mode = sh_compression_mode;
+
+    return render_gaussian_inference_scene(*state_, scene, viewmat, K,
+                      width, height, tile_size,
+                      near_plane, far_plane, radius_clip, eps2d,
+                      sh_degree, sh_compression_mode,
+                      background, out_rgbt);
+}
+
+void GaussianInferenceRenderer::release() {
+    if (state_) {
+        release_gaussian_render_inference_scene_state(*state_);
+    }
+}
+
+// ==========================================================================
+// gaussian_render_inference_only — torch.ops compatibility wrapper
+// ==========================================================================
+std::tuple<at::Tensor, at::Tensor> gaussian_render_inference_only(
+    const at::Tensor& means_planar,
+    const at::Tensor& qso_packed,
+    const at::Tensor& colors_packed,
+    const at::Tensor& viewmat,
+    const at::Tensor& K,
+    int64_t width,
+    int64_t height,
+    int64_t sh_degree,
+    int64_t tile_size,
+    double near_plane,
+    double far_plane,
+    double radius_clip,
+    double eps2d,
+    int64_t sh_compression_mode,
+    const at::optional<at::Tensor>& background,
+    const at::optional<at::Tensor>& out_renders,
+    const at::optional<at::Tensor>& out_alphas
+) {
+    // NOTE: No c10::NoGradGuard -- Python callers enforce inference_mode().
+    DEVICE_GUARD(means_planar);
+    CHECK_INPUT(means_planar);
+    CHECK_INPUT(qso_packed);
+    CHECK_INPUT(colors_packed);
+    CHECK_INPUT(viewmat);
+    CHECK_INPUT(K);
+    if (background.has_value()) {
+        CHECK_INPUT(background.value());
+    }
+    if (out_renders.has_value()) {
+        const auto& buf = out_renders.value();
+        TORCH_CHECK(buf.is_cuda(), "out_renders must be a CUDA tensor");
+        TORCH_CHECK(buf.dtype() == at::kFloat, "out_renders must be float32");
+        TORCH_CHECK(buf.is_contiguous(), "out_renders must be contiguous");
+        TORCH_CHECK(buf.dim() == 3 && buf.size(0) == height && buf.size(1) == width && buf.size(2) == 3,
+            "out_renders must have shape [", height, ", ", width, ", 3], got [",
+            buf.size(0), ", ", buf.size(1), ", ", buf.size(2), "]");
+    }
+    if (out_alphas.has_value()) {
+        const auto& buf = out_alphas.value();
+        TORCH_CHECK(buf.is_cuda(), "out_alphas must be a CUDA tensor");
+        TORCH_CHECK(buf.dtype() == at::kFloat, "out_alphas must be float32");
+        TORCH_CHECK(buf.is_contiguous(), "out_alphas must be contiguous");
+        TORCH_CHECK(buf.dim() == 3 && buf.size(0) == height && buf.size(1) == width && buf.size(2) == 1,
+            "out_alphas must have shape [", height, ", ", width, ", 1], got [",
+            buf.size(0), ", ", buf.size(1), ", ", buf.size(2), "]");
+    }
+
+    int64_t N = means_planar.size(1);  // [3, N]
+    auto opts_f = at::TensorOptions().dtype(at::kFloat).device(means_planar.device());
+    auto opts_h = at::TensorOptions().dtype(at::kHalf).device(means_planar.device());
+
+    // ---- Handle N==0 case ----
+    if (N == 0) {
+        at::Tensor renders;
+        at::Tensor alphas;
+        if (out_renders.has_value()) {
+            renders = out_renders.value();
+            renders.zero_();
+        } else {
+            renders = at::zeros({height, width, 3}, opts_f);
+        }
+        if (out_alphas.has_value()) {
+            alphas = out_alphas.value();
+            alphas.zero_();
+        } else {
+            alphas = at::zeros({height, width, 1}, opts_f);
+        }
+        if (background.has_value()) {
+            renders.add_(background.value().reshape({1, 1, 3}));
+        }
+        return std::make_tuple(renders, alphas);
+    }
+
+    // ---- Normalize colors_packed for SH degree 3 pre-packed formats ----
+    // The scene packer may store SH3 compressed data as 2-D (N, 48) tensors.
+    // Internal rendering code expects 3-D (N, 16, 3) for K detection and SH
+    // evaluation.  Reshape here so downstream code sees the canonical layout.
+    at::Tensor colors_normalized = colors_packed;
+    if (sh_degree == 3 && colors_packed.dim() == 2 && colors_packed.size(1) == 48) {
+        colors_normalized = colors_packed.reshape({N, 16, 3}).contiguous();
+    }
+
+    // ---- Construct scene and create state for exactly the requested mode ----
+    InferenceRenderScene scene;
+    scene.means_planar = means_planar;
+    scene.qso_packed = qso_packed;
+    scene.colors_packed = colors_normalized;
+    scene.sh_degree = sh_degree;
+    scene.sh_compression_mode = sh_compression_mode;
+
+    auto state = create_gaussian_render_inference_scene_state(scene, sh_compression_mode);
+
+    // ---- Render via render_gaussian_inference_scene ----
+    at::Tensor rgbt = render_gaussian_inference_scene(
+        *state, scene, viewmat, K,
+        width, height, tile_size,
+        near_plane, far_plane, radius_clip, eps2d,
+        sh_degree, sh_compression_mode,
+        background, at::nullopt);
+
+    // ---- Extract RGB and alpha from RGBT output ----
+    // rgbt: [1, H, W, 4] half {R, G, B, T}
+    auto output = rgbt.squeeze(0);           // [H, W, 4]
+    auto rgb = output.narrow(2, 0, 3);       // [H, W, 3] -- render colors in half
+    auto T = output.narrow(2, 3, 1);         // [H, W, 1] -- transmittance
+    auto alphas_h = at::ones_like(T).sub_(T);  // alpha = 1 - T
+
+    // Write results into pre-allocated buffers or allocate new ones
+    at::Tensor renders_f;
+    at::Tensor alphas_f;
+
+    if (out_renders.has_value()) {
+        renders_f = out_renders.value();
+        renders_f.copy_(rgb);  // half -> float copy into pre-allocated buffer
+    } else {
+        renders_f = rgb.to(at::kFloat);     // [H, W, 3]
+    }
+
+    if (out_alphas.has_value()) {
+        alphas_f = out_alphas.value();
+        alphas_f.copy_(alphas_h);  // half -> float copy into pre-allocated buffer
+    } else {
+        alphas_f = alphas_h.to(at::kFloat);   // [H, W, 1]
+    }
+
+    // ---- Release temporary state ----
+    release_gaussian_render_inference_scene_state(*state);
+
+    return std::make_tuple(renders_f, alphas_f);
+}
+
+} // namespace gaussian_render_inference_scene
+} // namespace gsplat

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.h
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <cstdint>
+#include <memory>
+#include <tuple>
+
+class IntersectMTFused;
+
+namespace higs {
+struct SHDecodeParams;
+} // namespace higs
+
+namespace gsplat {
+namespace gaussian_render_inference_scene {
+
+// ---------------------------------------------------------------------------
+// InferenceRenderScene — non-owning view of packed scene tensors
+// ---------------------------------------------------------------------------
+struct InferenceRenderScene {
+    at::Tensor means_planar;        // [3, N] float32
+    at::Tensor qso_packed;          // [N, 8] half
+    at::Tensor colors_packed;       // [N, K, 3] half/float (SH) or [N, 4] half (pre-activated)
+    int64_t sh_degree;              // maximum SH degree (-1 for pre-activated RGB)
+    int64_t sh_compression_mode;    // 0=NONE, 1=COMPRESS_32B, 2=COMPRESS_16B
+};
+
+// ---------------------------------------------------------------------------
+// InferenceRenderState — owns render-cache buffers
+// Not thread-safe: shared buffers assume single-stream, single-thread usage.
+// ---------------------------------------------------------------------------
+struct InferenceRenderState {
+    ~InferenceRenderState();
+    InferenceRenderState() = default;
+    InferenceRenderState(InferenceRenderState&&) = default;
+    InferenceRenderState& operator=(InferenceRenderState&&) = default;
+
+    // Scene metadata (derived at creation)
+    uint32_t num_gaussians = 0;             // total number of gaussians in the scene
+    uint32_t maxShDegree = 0;               // maximum SH degree from scene data
+    uint32_t sh_coeffs_per_channel = 0;     // number of SH coefficients per color channel (K)
+
+    // SH compression product selected at creation time for K==16.
+    int64_t shCompressionMode = 0;
+    at::Tensor shCompressed;
+    std::unique_ptr<higs::SHDecodeParams> shDecodeParams;
+
+    // Per-frame intermediates (persistent, sized once at creation)
+    at::Tensor colors;              // [N, 4] half
+    at::Tensor visible;             // [(N+31)/32] int32
+    at::Tensor means2d;             // [1, 1, N, 2] float
+    at::Tensor depths;              // [1, 1, N] float
+    at::Tensor conics;              // [1, 1, N, 4] half
+
+    // Intersection stage (fused macro-tile)
+    std::unique_ptr<IntersectMTFused> isect;
+
+    // Cached background buffer.
+    at::Tensor background;          // [1, 4] half
+    bool backgroundIsDefault = true;
+};
+
+// ---------------------------------------------------------------------------
+// Free functions
+// ---------------------------------------------------------------------------
+
+/// Allocate and initialise an InferenceRenderState from the given scene.
+/// @param sh_compression_mode  Controls eager SH precomputation for K==16 scenes:
+///   - 0 (NONE):         skip SH precomputation entirely.
+///   - 1 (COMPRESS_32B): precompute only the 32-byte codec.
+///   - 2 (COMPRESS_16B): precompute only the 16-byte codec.
+///   When a mode is requested the call includes a host-GPU sync.
+std::unique_ptr<InferenceRenderState> create_gaussian_render_inference_scene_state(
+    const InferenceRenderScene& scene,
+    int64_t sh_compression_mode = 0);
+
+/// Release all GPU resources held by the state (reset tensors/ptrs, set num_gaussians=0).
+void release_gaussian_render_inference_scene_state(InferenceRenderState& state);
+
+/// Core render function.  Scene tensors are read from `scene`; cached
+/// intermediates live in `state`.  Writes into `out_rgbt` when provided and
+/// returns [1,H,W,4] float16 RGBT.
+at::Tensor render_gaussian_inference_scene(
+    InferenceRenderState& state,
+    const InferenceRenderScene& scene,
+    const at::Tensor& viewmat,
+    const at::Tensor& K,
+    int64_t width, int64_t height,
+    int64_t tile_size,
+    double near_plane, double far_plane,
+    double radius_clip, double eps2d,
+    int64_t sh_degree,
+    int64_t sh_compression_mode,
+    const at::optional<at::Tensor>& background,
+    const at::optional<at::Tensor>& out_rgbt);
+
+// ---------------------------------------------------------------------------
+// GaussianInferenceRenderer — pybind wrapper around state + free functions
+// ---------------------------------------------------------------------------
+class GaussianInferenceRenderer {
+public:
+    /// Construct from pre-packed scene tensors.  Creates internal
+    /// InferenceRenderScene, calls create_gaussian_render_inference_scene_state, stores result.
+    GaussianInferenceRenderer(
+        const at::Tensor& means_planar,
+        const at::Tensor& qso_packed,
+        const at::Tensor& colors_packed,
+        int64_t sh_degree,
+        int64_t sh_compression_mode);
+
+    ~GaussianInferenceRenderer();
+
+    // Non-copyable, non-movable
+    GaussianInferenceRenderer(const GaussianInferenceRenderer&) = delete;
+    GaussianInferenceRenderer& operator=(const GaussianInferenceRenderer&) = delete;
+    GaussianInferenceRenderer(GaussianInferenceRenderer&&) = delete;
+    GaussianInferenceRenderer& operator=(GaussianInferenceRenderer&&) = delete;
+
+    /// Render a frame.  Scene tensors are passed per-call (NOT stored).
+    at::Tensor render(
+        const at::Tensor& means_planar,
+        const at::Tensor& qso_packed,
+        const at::Tensor& colors_packed,
+        const at::Tensor& viewmat,
+        const at::Tensor& K,
+        int64_t width, int64_t height,
+        int64_t tile_size,
+        double near_plane, double far_plane,
+        double radius_clip, double eps2d,
+        int64_t sh_degree,
+        int64_t sh_compression_mode,
+        const at::optional<at::Tensor>& background,
+        const at::optional<at::Tensor>& out_rgbt);
+
+    /// Release all GPU resources.
+    void release();
+
+    /// Number of gaussians in the loaded scene (0 after release).
+    uint32_t numGaussians() const { return state_ ? state_->num_gaussians : 0; }
+
+    /// Whether release() has been called.
+    bool isReleased() const { return !state_ || state_->num_gaussians == 0; }
+
+private:
+    std::unique_ptr<InferenceRenderState> state_;
+    at::Tensor colors_normalized_;  // cached [N,K,3] view (avoids per-frame reshape)
+};
+
+// ---------------------------------------------------------------------------
+// Stateless compatibility wrapper (torch.ops)
+// ---------------------------------------------------------------------------
+
+/// C++ compatibility wrapper for torch.ops.experimental.gaussian_render_inference_only.
+/// Keeps the EXACT same signature as the original GaussianRenderInferenceSceneViewer implementation.
+std::tuple<at::Tensor, at::Tensor> gaussian_render_inference_only(
+    const at::Tensor& means_planar,
+    const at::Tensor& qso_packed,
+    const at::Tensor& colors_packed,
+    const at::Tensor& viewmat,
+    const at::Tensor& K,
+    int64_t width,
+    int64_t height,
+    int64_t sh_degree,
+    int64_t tile_size,
+    double near_plane,
+    double far_plane,
+    double radius_clip,
+    double eps2d,
+    int64_t sh_compression_mode,
+    const at::optional<at::Tensor>& background,
+    const at::optional<at::Tensor>& out_renders,
+    const at::optional<at::Tensor>& out_alphas);
+
+} // namespace gaussian_render_inference_scene
+} // namespace gsplat

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/InferenceTypes.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/InferenceTypes.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+// SH compression mode selector (shared by renderer, CLI, and compression kernels).
+// COMPRESS_32B/16B: full YCoCg quantization codec (distinct from scene packer's PACKED layout modes)
+enum class SHCompressionMode
+{
+    NONE,         // no compression — use fp16 coefficients
+    COMPRESS_32B, // 32 bytes/gaussian: DC YCoCg fp16/fp15 + HO Y@6b + HO CoCg@4b
+    COMPRESS_16B  // 16 bytes/gaussian: DC YCoCg fp16/fp11 + HO Y@6b, no HO CoCg
+};
+
+// Abstract intersection stage interface.
+// Implementations produce tile-sorted intersection lists consumed by the rasterizer.
+class IIntersectionStage
+{
+public:
+    virtual ~IIntersectionStage() = default;
+
+    virtual void execute(const at::Tensor &means2d, const at::Tensor &depths, const at::Tensor &conics,
+                         const at::Tensor &visible, int32_t tile_size, int32_t tile_width, int32_t tile_height,
+                         cudaStream_t stream) = 0;
+};

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectCommon.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectCommon.cu
@@ -1,0 +1,555 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Fused macro-tile offset scan: shared implementation for the fused
+// macro-tile intersection pipeline.
+// Produces mt_gauss_offsets and mt_batch_offsets from raw per-macro-tile
+// gaussian counts in a single persistent kernel pass.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/zeros.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cub/block/block_scan.cuh>
+#include <cub/warp/warp_scan.cuh>
+
+#include "IntersectCommon.h"
+#include "IntersectMTConfig.h"
+
+namespace higs {
+
+// CTA size for the persistent mt offset scan kernel. must be a multiple of
+// warp size. larger values process more elements per CTA, reducing the number
+// of grid barriers needed.
+static constexpr int32_t MT_OFFSETS_BLOCK_SIZE = 128;
+static_assert(MT_OFFSETS_BLOCK_SIZE % 32 == 0, "block size must be a multiple of warp size");
+
+static constexpr int32_t MT_CHUNK_LOCAL_THREADS = MT_CHUNK_TILE * MT_META_WORDS;
+static constexpr int32_t MT_CHUNK_CARRY_ROWS    = 8;
+static constexpr int32_t MT_CHUNK_CARRY_THREADS = MT_CHUNK_CARRY_ROWS * MT_META_WORDS;
+static constexpr int32_t MT_CHUNK_SCAN_STRIDE   = MT_META_WORDS + 4;
+
+struct Int2Add
+{
+    __device__ int2 operator()(const int2 &a, const int2 &b) const
+    {
+        return {a.x + b.x, a.y + b.y};
+    }
+};
+
+// Parameter block for the chunk-base scan that converts packed uint16 counts
+// into packed uint16 local bases plus int32 carries and final mt_gauss_counts.
+struct MtChunkBasesArgs
+{
+    int32_t n_macro_tiles;        // number of macro-tiles
+    int32_t n_chunks;             // number of gaussian chunks
+    int32_t n_mt_tiles;           // ceil(n_macro_tiles / MT_META_TILE)
+    int32_t n_chunk_tiles;        // ceil(n_chunks / MT_CHUNK_TILE)
+    int32_t *mt_chunk_meta_words; // [packed rows] int32 words containing uint16 counts / local bases
+    int32_t *mt_chunk_tile_sums;  // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 tile sums
+    int32_t *mt_chunk_tile_carry; // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 exclusive tile carries
+    int32_t *mt_gauss_counts;     // [n_mt] int32 per-macro-tile gaussian counts
+};
+
+// stage 1: one CTA per metadata tile. the CTA loads the full 8x32 packed-word
+// tile to shared memory with row-major coalescing, then 32 logical 8-lane warps
+// run independent CUB warp scans across the chunk rows for one metadata column
+// each. results are written back row-major and tile sums are emitted for stage 2.
+template<int32_t MT_TILE>
+__global__ void mt_chunk_local_bases_kernel(MtChunkBasesArgs args)
+{
+    static_assert(MT_TILE == MT_META_TILE, "kernel launch must match metadata tile width");
+
+    using WarpScanT = cub::WarpScan<uint32_t, MT_CHUNK_TILE>;
+    __shared__ typename WarpScanT::TempStorage scan_storage[MT_META_WORDS * 2];
+    __shared__ uint32_t smem_words[MT_CHUNK_TILE][MT_CHUNK_SCAN_STRIDE];
+    __shared__ uint32_t smem_bases[MT_CHUNK_TILE][MT_CHUNK_SCAN_STRIDE];
+
+    const int32_t tid        = threadIdx.x;
+    const int32_t load_row   = tid / MT_META_WORDS;
+    const int32_t load_col   = tid % MT_META_WORDS;
+    const int32_t mt_tile    = blockIdx.x;
+    const int32_t chunk_tile = blockIdx.y;
+    uint32_t *const meta_u32 = reinterpret_cast<uint32_t *>(args.mt_chunk_meta_words);
+
+    auto chunk_row_word_base = [=](const int32_t row_in_tile) {
+        return ((chunk_tile * args.n_mt_tiles + mt_tile) * MT_CHUNK_TILE + row_in_tile) * MT_META_WORDS;
+    };
+    auto chunk_tile_carry_idx = [=](const int32_t mt_lane) {
+        return (chunk_tile * args.n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+    };
+
+    const int32_t global_chunk     = chunk_tile * MT_CHUNK_TILE + load_row;
+    const int32_t tile_word_base   = chunk_row_word_base(0);
+    smem_words[load_row][load_col] = (global_chunk < args.n_chunks) ? meta_u32[tile_word_base + tid] : 0u;
+    __syncthreads();
+
+    const int32_t scan_row      = tid % MT_CHUNK_TILE;
+    const int32_t scan_col      = tid / MT_CHUNK_TILE;
+    const int32_t mt0           = mt_tile * MT_TILE + scan_col * 2;
+    const int32_t mt1           = mt0 + 1;
+    const uint32_t packed_count = smem_words[scan_row][scan_col];
+    const uint32_t count_lo     = packed_count & 0xFFFFu;
+    const uint32_t count_hi     = packed_count >> 16;
+
+    uint32_t base_lo = 0;
+    uint32_t base_hi = 0;
+    WarpScanT(scan_storage[scan_col * 2 + 0]).ExclusiveSum(count_lo, base_lo);
+    WarpScanT(scan_storage[scan_col * 2 + 1]).ExclusiveSum(count_hi, base_hi);
+
+    const int32_t scan_chunk       = chunk_tile * MT_CHUNK_TILE + scan_row;
+    const uint16_t base_lo_u16     = (scan_chunk < args.n_chunks && mt0 < args.n_macro_tiles)
+                                         ? static_cast<uint16_t>(base_lo)
+                                         : static_cast<uint16_t>(0);
+    const uint16_t base_hi_u16     = (scan_chunk < args.n_chunks && mt1 < args.n_macro_tiles)
+                                         ? static_cast<uint16_t>(base_hi)
+                                         : static_cast<uint16_t>(0);
+    smem_bases[scan_row][scan_col] = static_cast<uint32_t>(base_lo_u16) | (static_cast<uint32_t>(base_hi_u16) << 16);
+
+    if (scan_row == MT_CHUNK_TILE - 1)
+    {
+        const int32_t tile_base = chunk_tile_carry_idx(0);
+
+        reinterpret_cast<int2 *>(args.mt_chunk_tile_sums + tile_base)[scan_col] = {
+            static_cast<int32_t>(base_lo + count_lo), static_cast<int32_t>(base_hi + count_hi)};
+    }
+    __syncthreads();
+
+    if (global_chunk < args.n_chunks)
+    {
+        meta_u32[tile_word_base + tid] = smem_bases[load_row][load_col];
+    }
+}
+
+// stage 2a: one CTA per chunk-block metadata tile. the CTA loads one block of
+// chunk-tile sums, runs 32 logical 8-lane warp scans over the chunk dimension,
+// writes local carries to the final tensor, and emits one block sum per column.
+template<int32_t MT_TILE>
+__global__ void mt_chunk_tile_carry_kernel(MtChunkBasesArgs args, int32_t *__restrict__ out_block_sums)
+{
+    static_assert(MT_TILE == MT_META_TILE, "kernel launch must match metadata tile width");
+
+    using WarpScanT = cub::WarpScan<int2, MT_CHUNK_CARRY_ROWS>;
+    __shared__ typename WarpScanT::TempStorage scan_storage[MT_META_WORDS];
+    __shared__ int2 smem_sums[MT_CHUNK_CARRY_ROWS][MT_CHUNK_SCAN_STRIDE];
+    __shared__ int2 smem_carries[MT_CHUNK_CARRY_ROWS][MT_CHUNK_SCAN_STRIDE];
+
+    const int32_t tid         = threadIdx.x;
+    const int32_t load_row    = tid / MT_META_WORDS;
+    const int32_t load_col    = tid % MT_META_WORDS;
+    const int32_t mt_tile     = blockIdx.x;
+    const int32_t chunk_block = blockIdx.y;
+    const int32_t chunk_tile  = chunk_block * MT_CHUNK_CARRY_ROWS + load_row;
+
+    auto chunk_tile_carry_idx = [=](const int32_t row_chunk_tile, const int32_t mt_lane) {
+        return (row_chunk_tile * args.n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+    };
+    auto block_tile_carry_idx = [=](const int32_t mt_lane) {
+        return (chunk_block * args.n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+    };
+
+    if (chunk_tile < args.n_chunk_tiles)
+    {
+        const int32_t tile_base = chunk_tile_carry_idx(chunk_tile, 0);
+        reinterpret_cast<int2 *>(smem_sums[load_row])[load_col] =
+            reinterpret_cast<const int2 *>(args.mt_chunk_tile_sums + tile_base)[load_col];
+    }
+    else
+    {
+        reinterpret_cast<int2 *>(smem_sums[load_row])[load_col] = {0, 0};
+    }
+    __syncthreads();
+
+    const int32_t scan_row = tid % MT_CHUNK_CARRY_ROWS;
+    const int32_t pair_col = tid / MT_CHUNK_CARRY_ROWS;
+    int2 scan_out;
+    WarpScanT(scan_storage[pair_col]).ExclusiveScan(smem_sums[scan_row][pair_col], scan_out, int2{0, 0}, Int2Add());
+    smem_carries[scan_row][pair_col] = scan_out;
+    __syncthreads();
+
+    if (chunk_tile < args.n_chunk_tiles)
+    {
+        const int32_t tile_base = chunk_tile_carry_idx(chunk_tile, 0);
+        reinterpret_cast<int2 *>(args.mt_chunk_tile_carry + tile_base)[load_col] =
+            reinterpret_cast<int2 *>(smem_carries[load_row])[load_col];
+    }
+
+    if (scan_row == MT_CHUNK_CARRY_ROWS - 1)
+    {
+        const int32_t block_base = block_tile_carry_idx(0);
+        reinterpret_cast<int2 *>(out_block_sums + block_base)[pair_col] =
+            Int2Add{}(smem_carries[scan_row][pair_col], smem_sums[scan_row][pair_col]);
+    }
+}
+
+// stage 2b: one CTA per mt_tile. each thread scans the much shorter block-sum
+// stream for one packed int2 metadata column and writes a block prefix for
+// stage 2c. the final accumulated prefix becomes mt_gauss_counts.
+template<int32_t MT_TILE>
+__global__ void mt_chunk_tile_block_prefix_kernel(const int32_t n_chunk_blocks, const int32_t n_mt_tiles,
+                                                  const int32_t n_macro_tiles, const int32_t *__restrict__ block_sums,
+                                                  int32_t *__restrict__ block_prefixes,
+                                                  int32_t *__restrict__ mt_gauss_counts)
+{
+    static_assert(MT_TILE == MT_META_TILE, "kernel launch must match metadata tile width");
+
+    const int32_t mt_tile  = blockIdx.x;
+    const int32_t pair_col = threadIdx.x;
+    const int32_t mt0      = mt_tile * MT_TILE + pair_col * 2;
+    const int32_t mt1      = mt0 + 1;
+
+    auto block_tile_carry_idx = [=](const int32_t chunk_block, const int32_t mt_lane) {
+        return (chunk_block * n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+    };
+
+    int2 running = {0, 0};
+#pragma unroll 1
+    for (int32_t chunk_block = 0; chunk_block < n_chunk_blocks; ++chunk_block)
+    {
+        const int32_t block_base = block_tile_carry_idx(chunk_block, 0);
+
+        reinterpret_cast<int2 *>(block_prefixes + block_base)[pair_col] = running;
+
+        const int2 sum = reinterpret_cast<const int2 *>(block_sums + block_base)[pair_col];
+        running        = Int2Add{}(running, sum);
+    }
+
+    if (mt0 < n_macro_tiles)
+    {
+        mt_gauss_counts[mt0] = running.x;
+    }
+    if (mt1 < n_macro_tiles)
+    {
+        mt_gauss_counts[mt1] = running.y;
+    }
+}
+
+// stage 2c: adds the per-block prefix from stage 2b to all local carries
+// produced by stage 2a.
+template<int32_t MT_TILE>
+__global__ void mt_chunk_tile_add_prefix_kernel(const int32_t n_chunk_tiles, const int32_t n_mt_tiles,
+                                                const int32_t *__restrict__ block_prefixes,
+                                                int32_t *__restrict__ mt_chunk_tile_carry)
+{
+    static_assert(MT_TILE == MT_META_TILE, "kernel launch must match metadata tile width");
+
+    const int32_t tid         = threadIdx.x;
+    const int32_t load_row    = tid / MT_META_WORDS;
+    const int32_t load_col    = tid % MT_META_WORDS;
+    const int32_t mt_tile     = blockIdx.x;
+    const int32_t chunk_block = blockIdx.y;
+    const int32_t chunk_tile  = chunk_block * MT_CHUNK_CARRY_ROWS + load_row;
+
+    auto block_tile_carry_idx = [=](const int32_t block_idx, const int32_t mt_lane) {
+        return (block_idx * n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+    };
+
+    auto chunk_tile_carry_idx = [=](const int32_t row_chunk_tile, const int32_t mt_lane) {
+        return (row_chunk_tile * n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+    };
+
+    if (chunk_tile >= n_chunk_tiles)
+    {
+        return;
+    }
+
+    const int32_t block_base = block_tile_carry_idx(chunk_block, 0);
+    const int2 prefix        = reinterpret_cast<const int2 *>(block_prefixes + block_base)[load_col];
+    const int32_t tile_base  = chunk_tile_carry_idx(chunk_tile, 0);
+    int2 *const carries      = reinterpret_cast<int2 *>(mt_chunk_tile_carry + tile_base);
+    carries[load_col]        = Int2Add{}(carries[load_col], prefix);
+}
+
+// parameter block for the persistent single-kernel mt offset scan.
+// n_ctas and n_scan_blocks are derived from gridDim.x and n_macro_tiles
+// inside the kernel rather than passed explicitly.
+struct MtOffsetsArgs
+{
+    int32_t n_macro_tiles;
+    const int32_t *mt_gauss_counts;
+    int32_t *mt_gauss_offsets;
+    int32_t *mt_batch_offsets;
+    int32_t gauss_batch_log2;
+    int2 *block_sums_gauss_batch; // [gridDim.x] per-CTA totals scratch
+    int32_t *barrier_counter;     // single monotonically increasing atomic counter
+    int32_t barrier_base;         // counter value at start of this invocation
+};
+
+void launch_mt_chunk_bases(at::Tensor inout_mt_chunk_meta_words, at::Tensor out_mt_chunk_tile_sums,
+                           at::Tensor out_mt_chunk_tile_carry, at::Tensor out_mt_gauss_counts, int32_t n_macro_tiles,
+                           int32_t n_chunks,
+                           at::Tensor* inout_block_sums, at::Tensor* inout_block_prefixes,
+                           int64_t* inout_scratch_capacity)
+{
+    if (n_macro_tiles == 0)
+    {
+        return;
+    }
+
+    out_mt_gauss_counts.zero_();
+    if (n_chunks == 0)
+    {
+        return;
+    }
+
+    auto ceilDivInt = [](const int32_t x, const int32_t y) -> int32_t { return (x + y - 1) / y; };
+
+    MtChunkBasesArgs args;
+    args.n_macro_tiles       = n_macro_tiles;
+    args.n_chunks            = n_chunks;
+    args.n_mt_tiles          = ceilDivInt(n_macro_tiles, MT_META_TILE);
+    args.n_chunk_tiles       = ceilDivInt(n_chunks, MT_CHUNK_TILE);
+    args.mt_chunk_meta_words = inout_mt_chunk_meta_words.data_ptr<int32_t>();
+    args.mt_chunk_tile_sums  = out_mt_chunk_tile_sums.data_ptr<int32_t>();
+    args.mt_chunk_tile_carry = out_mt_chunk_tile_carry.data_ptr<int32_t>();
+    args.mt_gauss_counts     = out_mt_gauss_counts.data_ptr<int32_t>();
+
+    const int32_t n_chunk_blocks = ceilDivInt(args.n_chunk_tiles, MT_CHUNK_CARRY_ROWS);
+    const auto stream            = at::cuda::getCurrentCUDAStream();
+    const dim3 local_grid(args.n_mt_tiles, args.n_chunk_tiles);
+    const dim3 carry_grid(args.n_mt_tiles, n_chunk_blocks);
+    auto opts_i32          = at::TensorOptions().dtype(at::kInt).device(at::kCUDA);
+    const int64_t required = (int64_t)n_chunk_blocks * args.n_mt_tiles * MT_META_TILE;
+
+    // Use caller-supplied cached scratch buffers when available (avoids 2x at::empty per frame).
+    // Falls back to local temporaries when no cache pointers are provided.
+    at::Tensor local_block_sums, local_block_prefixes;
+    at::Tensor& block_sums     = inout_block_sums     ? *inout_block_sums     : local_block_sums;
+    at::Tensor& block_prefixes = inout_block_prefixes ? *inout_block_prefixes : local_block_prefixes;
+
+    int64_t cap = inout_scratch_capacity ? *inout_scratch_capacity : 0;
+    if (required > cap) {
+        block_sums     = at::empty({required}, opts_i32);
+        block_prefixes = at::empty({required}, opts_i32);
+        if (inout_scratch_capacity) *inout_scratch_capacity = required;
+    }
+
+    mt_chunk_local_bases_kernel<MT_META_TILE><<<local_grid, MT_CHUNK_LOCAL_THREADS, 0, stream>>>(args);
+    mt_chunk_tile_carry_kernel<MT_META_TILE>
+        <<<carry_grid, MT_CHUNK_CARRY_THREADS, 0, stream>>>(args, block_sums.data_ptr<int32_t>());
+    mt_chunk_tile_block_prefix_kernel<MT_META_TILE><<<args.n_mt_tiles, MT_META_WORDS, 0, stream>>>(
+        n_chunk_blocks, args.n_mt_tiles, n_macro_tiles, block_sums.data_ptr<int32_t>(),
+        block_prefixes.data_ptr<int32_t>(), args.mt_gauss_counts);
+    mt_chunk_tile_add_prefix_kernel<MT_META_TILE><<<carry_grid, MT_CHUNK_CARRY_THREADS, 0, stream>>>(
+        args.n_chunk_tiles, args.n_mt_tiles, block_prefixes.data_ptr<int32_t>(), args.mt_chunk_tile_carry);
+}
+
+// single persistent kernel: phase 1 block-wide scan with carry, grid barrier,
+// phase 2 block-wide aggregate by CTA 0, grid barrier, phase 3 propagate.
+// launched with min(n_scan_blocks, num_sms) CTAs of MT_OFFSETS_BLOCK_SIZE threads.
+__global__ void mt_offsets_kernel(MtOffsetsArgs args)
+{
+    using BlockScanInt2 = cub::BlockScan<int2, MT_OFFSETS_BLOCK_SIZE>;
+
+    __shared__ typename BlockScanInt2::TempStorage scan_storage;
+
+    const int32_t n_ctas        = gridDim.x;
+    const int32_t n_scan_blocks = (args.n_macro_tiles + MT_OFFSETS_BLOCK_SIZE - 1) / MT_OFFSETS_BLOCK_SIZE;
+    const int32_t cta_id        = blockIdx.x;
+    const int32_t tid           = threadIdx.x;
+
+    // grid barrier using a single monotonically increasing counter. the lambda
+    // tracks how many times it's been called; signed subtraction handles int32
+    // wraparound because the "window" (n_ctas) is tiny relative to the range.
+    int32_t barrier_call_count = 0;
+    auto gridBarrier           = [&]() {
+        barrier_call_count++;
+        const int32_t target = args.barrier_base + n_ctas * barrier_call_count;
+        __threadfence();
+        if (tid == 0)
+        {
+            int32_t arrived = atomicAdd(args.barrier_counter, 1) + 1;
+            if (arrived - target < 0)
+            {
+                while (atomicAdd(args.barrier_counter, 0) - target < 0)
+                {
+                }
+            }
+        }
+        __syncthreads();
+    };
+
+    // compute contiguous scan-block range for this CTA
+    const int32_t blocks_per_cta = n_scan_blocks / n_ctas;
+    const int32_t extra_blocks   = n_scan_blocks % n_ctas;
+    const int32_t block_start    = cta_id * blocks_per_cta + min(cta_id, extra_blocks);
+    const int32_t block_end      = block_start + blocks_per_cta + (cta_id < extra_blocks ? 1 : 0);
+
+    // phase 1: block-wide scans with carry-over between scan blocks
+    int2 carry_gb = {0, 0};
+
+#pragma unroll 1
+    for (int32_t block = block_start; block < block_end; ++block)
+    {
+        const int32_t mt = block * MT_OFFSETS_BLOCK_SIZE + tid;
+
+        int32_t n_gauss   = 0;
+        int32_t n_batches = 0;
+        if (mt < args.n_macro_tiles)
+        {
+            n_gauss   = args.mt_gauss_counts[mt];
+            n_batches = (n_gauss > 0) ? ((n_gauss - 1) >> args.gauss_batch_log2) + 1 : 0;
+        }
+
+        // fused int2 block scan for gauss + batch
+        int2 gb_val = {n_gauss, n_batches};
+        int2 gb_inclusive;
+        int2 gb_aggregate;
+        BlockScanInt2(scan_storage).InclusiveScan(gb_val, gb_inclusive, Int2Add{}, gb_aggregate);
+
+        // add carry-in from previous scan blocks
+        gb_inclusive = Int2Add{}(gb_inclusive, carry_gb);
+
+        if (mt < args.n_macro_tiles)
+        {
+            args.mt_gauss_offsets[mt + 1] = gb_inclusive.x;
+            args.mt_batch_offsets[mt + 1] = gb_inclusive.y;
+        }
+
+        if (block == 0 && tid == 0)
+        {
+            args.mt_gauss_offsets[0] = 0;
+            args.mt_batch_offsets[0] = 0;
+        }
+
+        carry_gb = Int2Add{}(carry_gb, gb_aggregate);
+
+        __syncthreads();
+    }
+
+    // write per-CTA total to scratch
+    if (tid == 0)
+    {
+        args.block_sums_gauss_batch[cta_id] = carry_gb;
+    }
+
+    // single-CTA fast path: no aggregate or propagate needed
+    if (n_ctas == 1)
+    {
+        return;
+    }
+
+    gridBarrier();
+
+    // phase 2: CTA 0 computes in-place exclusive prefix over per-CTA totals
+    // using block-wide scans in chunks of MT_OFFSETS_BLOCK_SIZE, with carry between chunks
+    if (cta_id == 0)
+    {
+        int2 agg_carry_gb          = {0, 0};
+        const int32_t n_agg_chunks = (n_ctas + MT_OFFSETS_BLOCK_SIZE - 1) / MT_OFFSETS_BLOCK_SIZE;
+
+#pragma unroll 1
+        for (int32_t chunk = 0; chunk < n_agg_chunks; ++chunk)
+        {
+            const int32_t idx = chunk * MT_OFFSETS_BLOCK_SIZE + tid;
+
+            int2 gb_total = (idx < n_ctas) ? args.block_sums_gauss_batch[idx] : int2{0, 0};
+
+            int2 gb_exclusive;
+            int2 gb_aggregate;
+            BlockScanInt2(scan_storage)
+                .ExclusiveScan(gb_total, gb_exclusive, int2{0, 0}, Int2Add{}, gb_aggregate);
+
+            gb_exclusive = Int2Add{}(gb_exclusive, agg_carry_gb);
+
+            if (idx < n_ctas)
+            {
+                args.block_sums_gauss_batch[idx] = gb_exclusive;
+            }
+
+            agg_carry_gb = Int2Add{}(agg_carry_gb, gb_aggregate);
+
+            __syncthreads();
+        }
+    }
+
+    gridBarrier();
+
+    // phase 3: each CTA (except CTA 0) reads its prefix and adds to all
+    // output elements in its range. CTA 0's results are already globally correct.
+    if (cta_id == 0)
+    {
+        return;
+    }
+
+    const int2 prefix_gb = args.block_sums_gauss_batch[cta_id];
+
+#pragma unroll 1
+    for (int32_t block = block_start; block < block_end; ++block)
+    {
+        const int32_t mt  = block * MT_OFFSETS_BLOCK_SIZE + tid;
+        const int32_t pos = mt + 1;
+
+        if (mt < args.n_macro_tiles)
+        {
+            args.mt_gauss_offsets[pos] += prefix_gb.x;
+            args.mt_batch_offsets[pos] += prefix_gb.y;
+        }
+    }
+}
+
+// MTOffsets implementation
+
+MTOffsets::MTOffsets(int32_t n_macro_tiles, int32_t gauss_batch_log2)
+    : m_nMacroTiles(n_macro_tiles)
+    , m_gaussBatchLog2(gauss_batch_log2)
+    , m_numSMs(0)
+    , m_barrierExpected(0)
+{
+    cudaDeviceGetAttribute(&m_numSMs, cudaDevAttrMultiProcessorCount, 0);
+
+    const int32_t n_scan_blocks = (n_macro_tiles + MT_OFFSETS_BLOCK_SIZE - 1) / MT_OFFSETS_BLOCK_SIZE;
+    const int32_t n_ctas        = min(n_scan_blocks, m_numSMs);
+
+    // scratch layout: [32] int32 (barrier) + [n_ctas] int2 (gauss+batch sums)
+    const int64_t scratch_ints = n_ctas * 2 + 32;
+    m_scratch                  = at::zeros({scratch_ints}, at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+}
+
+void MTOffsets::execute(const at::Tensor &in_mt_gauss_counts, at::Tensor &out_mt_gauss_offsets,
+                        at::Tensor &out_mt_batch_offsets)
+{
+    if (m_nMacroTiles == 0)
+    {
+        return;
+    }
+
+    const int32_t n_scan_blocks = (m_nMacroTiles + MT_OFFSETS_BLOCK_SIZE - 1) / MT_OFFSETS_BLOCK_SIZE;
+    const int32_t n_ctas        = min(n_scan_blocks, m_numSMs);
+    int32_t *scratch_ptr        = m_scratch.data_ptr<int32_t>();
+
+    MtOffsetsArgs args;
+    args.n_macro_tiles          = m_nMacroTiles;
+    args.mt_gauss_counts        = in_mt_gauss_counts.data_ptr<int32_t>();
+    args.mt_gauss_offsets       = out_mt_gauss_offsets.data_ptr<int32_t>();
+    args.mt_batch_offsets       = out_mt_batch_offsets.data_ptr<int32_t>();
+    args.gauss_batch_log2       = m_gaussBatchLog2;
+    args.block_sums_gauss_batch = reinterpret_cast<int2 *>(scratch_ptr + 32);
+    args.barrier_counter        = scratch_ptr;
+    // barrier counter grows monotonically; signed subtraction in the kernel
+    // handles int32 wraparound so no reset is ever needed.
+
+    // TODO: this works quite well and we don't need to reset the counter ever, however the entire solution
+    // is quite fragile from thread or stream safety POV. This counter is instance specific so we shouldn't be
+    // submitting it to different streams or devices since they will all contend for the same counter.
+    args.barrier_base = m_barrierExpected;
+    m_barrierExpected += 2 * n_ctas;
+
+    mt_offsets_kernel<<<n_ctas, MT_OFFSETS_BLOCK_SIZE, 0, at::cuda::getCurrentCUDAStream()>>>(args);
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectCommon.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectCommon.h
@@ -1,0 +1,436 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Shared device code and data structures for macro-tile intersection pipelines.
+// Used by both IntersectMT.cu (standard pipeline) and IntersectMTFused.cu (fused pipeline).
+// Contains __device__ functions and plain structs — no __global__ kernels.
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+#include "Utils.h"
+
+#include "Constants.h"
+#include "IntersectMTConfig.h"
+
+namespace higs {
+
+// compile-time log2
+template<uint32_t N>
+inline constexpr uint32_t FLOOR_LOG2 = N <= 1 ? 0 : 1 + FLOOR_LOG2<N / 2>;
+
+template<uint32_t N>
+inline constexpr uint32_t CEIL_LOG2 = N <= 1 ? 0 : FLOOR_LOG2<N - 1> + 1;
+
+// ============================================================
+// Shared constants for macro-tile binning kernels
+// ============================================================
+
+enum class TileBinMode : uint32_t
+{
+    COUNT,
+    FILL
+};
+
+static constexpr int32_t MT_CTA_THREADS = 768; // threads per CTA for macro-tile binning
+static constexpr int32_t MT_MIN_BLOCKS  = 2;   // minimum number of blocks for macro-tile binning
+
+// ============================================================
+// Device helpers
+// ============================================================
+
+struct GaussianConic
+{
+    float A, B, C, disc, t;
+    float2 center, bbox_min, bbox_max, bbox_argmin, bbox_argmax;
+};
+
+__device__ inline bool decode_gaussian_conic(const __half *__restrict__ conics, const float *__restrict__ means2d,
+                                             int32_t idx, GaussianConic &gc)
+{
+    __half conics_opac[4];
+    AssignAs<uint2>(conics_opac, conics[idx * 4]);
+    const float l0      = __half2float(conics_opac[0]);
+    const float l1      = __half2float(conics_opac[1]);
+    const float l2      = __half2float(conics_opac[2]);
+    const float opacity = __half2float(conics_opac[3]);
+
+    gc.A = l0 * l0;
+    gc.B = l0 * l1;
+    gc.C = l1 * l1 + l2 * l2;
+
+    gc.disc = -(l0 * l2) * (l0 * l2);
+    gc.t    = min(MAX_EXTEND * MAX_EXTEND, 2.0f * __logf(opacity * INV_ALPHA_THRESHOLD));
+
+    const float neg_t_over_disc = -gc.t / gc.disc;
+    const float x_extent        = sqrtf(neg_t_over_disc * gc.C);
+    const float y_extent        = sqrtf(neg_t_over_disc * gc.A);
+
+    AssignAs<float2>(gc.center, means2d[idx * 2]);
+    gc.bbox_min = {gc.center.x - x_extent, gc.center.y - y_extent};
+    gc.bbox_max = {gc.center.x + x_extent, gc.center.y + y_extent};
+
+    const float Bx_over_C = gc.B * x_extent / gc.C;
+    const float By_over_A = gc.B * y_extent / gc.A;
+    gc.bbox_argmin        = {gc.center.y + Bx_over_C, gc.center.x + By_over_A};
+    gc.bbox_argmax        = {gc.center.y - Bx_over_C, gc.center.x - By_over_A};
+
+    const float dx = gc.bbox_max.x - gc.bbox_min.x;
+    const float dy = gc.bbox_max.y - gc.bbox_min.y;
+    if (dx <= 0.f || dy <= 0.f)
+    {
+        return false;
+    }
+    return true;
+}
+
+template<typename EmitFn>
+__device__ inline int32_t process_tiles_macro(float A, float B, float C, float disc, float t, float2 p, float2 bbox_min,
+                                              float2 bbox_max, float2 bbox_argmin, float2 bbox_argmax, int2 rect_min,
+                                              int2 rect_max, int32_t tile_size_x, int32_t tile_size_y,
+                                              int32_t grid_cols, bool isY, EmitFn emit)
+{
+    auto compute_ellipse_intersection = [](float A, float B, float C, float disc, float t, float2 p, bool isY,
+                                           float coord) -> float2 {
+        const float p_u   = isY ? p.y : p.x;
+        const float p_v   = isY ? p.x : p.y;
+        const float coeff = isY ? A : C;
+
+        const float h         = coord - p_u;
+        const float sqrt_term = sqrtf(disc * h * h + t * coeff);
+
+        return {(-B * h - sqrt_term) / coeff + p_v, (-B * h + sqrt_term) / coeff + p_v};
+    };
+
+    const float BLOCK_X = (float)tile_size_x;
+    const float BLOCK_Y = (float)tile_size_y;
+
+    float BLOCK_U, BLOCK_V;
+    if (isY)
+    {
+        rect_min    = {rect_min.y, rect_min.x};
+        rect_max    = {rect_max.y, rect_max.x};
+        bbox_min    = {bbox_min.y, bbox_min.x};
+        bbox_max    = {bbox_max.y, bbox_max.x};
+        bbox_argmin = {bbox_argmin.y, bbox_argmin.x};
+        bbox_argmax = {bbox_argmax.y, bbox_argmax.x};
+        BLOCK_U     = BLOCK_Y;
+        BLOCK_V     = BLOCK_X;
+    }
+    else
+    {
+        BLOCK_U = BLOCK_X;
+        BLOCK_V = BLOCK_Y;
+    }
+
+    int32_t tiles_count = 0;
+    float2 intersect_min_line, intersect_max_line;
+    float ellipse_min, ellipse_max;
+    float min_line, max_line;
+
+    intersect_max_line = {bbox_max.y, bbox_min.y};
+
+    min_line = rect_min.x * BLOCK_U;
+    if (bbox_min.x <= min_line)
+    {
+        intersect_min_line = compute_ellipse_intersection(A, B, C, disc, t, p, isY, min_line);
+    }
+    else
+    {
+        intersect_min_line = intersect_max_line;
+    }
+
+#pragma unroll 1
+    for (int u = rect_min.x; u < rect_max.x; ++u)
+    {
+        max_line = min_line + BLOCK_U;
+        if (max_line <= bbox_max.x)
+        {
+            intersect_max_line = compute_ellipse_intersection(A, B, C, disc, t, p, isY, max_line);
+        }
+
+        if (min_line <= bbox_argmin.y && bbox_argmin.y < max_line)
+        {
+            ellipse_min = bbox_min.y;
+        }
+        else
+        {
+            ellipse_min = min(intersect_min_line.x, intersect_max_line.x);
+        }
+
+        if (min_line <= bbox_argmax.y && bbox_argmax.y < max_line)
+        {
+            ellipse_max = bbox_max.y;
+        }
+        else
+        {
+            ellipse_max = max(intersect_min_line.y, intersect_max_line.y);
+        }
+
+        const int min_tile_v = max(rect_min.y, min(rect_max.y, (int)(ellipse_min / BLOCK_V)));
+        const int max_tile_v = min(rect_max.y, max(rect_min.y, (int)(ellipse_max / BLOCK_V + 1)));
+
+#pragma unroll 1
+        for (int v = min_tile_v; v < max_tile_v; v++)
+        {
+            const int32_t tile_id = isY ? (u * grid_cols + v) : (v * grid_cols + u);
+            emit(tile_id);
+        }
+        tiles_count += max_tile_v - min_tile_v;
+
+        intersect_min_line = intersect_max_line;
+        min_line           = max_line;
+    }
+    return tiles_count;
+}
+
+// Warp-cooperative 32-way binary search: all 32 lanes probe different points
+// each round, narrowing by ~33x instead of 2x. Completes in ~2-3 rounds
+// for typical macro-tile counts vs ~10-14 scalar iterations.
+// Requires all warp threads to participate (callers guarantee this).
+__device__ inline int32_t find_macro_tile(const int32_t *offsets, // [n+1] sorted offset array
+                                          int32_t n,              // number of segments
+                                          int32_t key)            // value to look up
+{
+    const int32_t lane = threadIdx.x & 31;
+    int32_t lo = 0, hi = n;
+
+    // exact a * b / 33 without 64-bit math; b must be in [1, 32].
+    // the /33 literals are compile-time constants so the compiler emits
+    // multiply-high + shift, not actual division.
+    auto div33 = [](int32_t a, int32_t b) -> int32_t {
+        const int32_t q = a / 33;
+        const int32_t r = a - q * 33;
+        return q * b + r * b / 33;
+    };
+
+    while (lo < hi)
+    {
+        const int32_t range   = hi - lo;
+        const int32_t probe   = lo + div33(range, lane + 1);
+        const bool take_more  = (offsets[probe + 1] <= key);
+        const uint32_t ballot = __ballot_sync(~0u, take_more);
+        const int32_t n_true  = __popc(ballot);
+
+        // 32 probes create 33 sub-intervals. n_true tells us which one
+        // contains the crossover.
+        if (n_true == 32)
+        {
+            lo = lo + div33(range, 32) + 1;
+        }
+        else if (n_true == 0)
+        {
+            hi = lo + div33(range, 1);
+        }
+        else
+        {
+            hi = lo + div33(range, n_true + 1);
+            lo = lo + div33(range, n_true) + 1;
+        }
+    }
+    return lo;
+}
+
+// ============================================================
+// Macro-tile binning device implementation
+// ============================================================
+//
+// Two-phase pipeline producing per-macro-tile sorted (depth, gaussian_id) lists.
+// Hoisted into a __device__ function so each .cu file can wrap it in a thin
+// __global__ kernel with its own macro-tile dimensions (MTW × MTH).
+//
+// Phase 1 — COUNT:
+//   Each CTA processes one gaussian chunk. For each gaussian, AccuTile determines
+//   which macro-tiles it overlaps and accumulates those hits into a shared-memory
+//   histogram, then flushes the chunk histogram to packed uint16 metadata rows.
+//
+// Between COUNT and FILL, launch_mt_chunk_bases() converts packed uint16 counts
+// into packed uint16 chunk-local bases plus int32 chunk-tile carries.
+// launch_mt_offsets() then scans the final per-macro-tile counts into
+// mt_gauss_offsets / mt_batch_offsets.
+//
+// Phase 2 — FILL:
+//   Loads the precomputed per-(chunk, macro-tile) bases and writes
+//   (depth_bits, gauss_id) in a single geometry pass.
+
+template<TileBinMode MODE, int32_t TILE_SIZE, int32_t MTW, int32_t MTH>
+__device__ void mt_binning_device_impl(const int32_t N, const float *__restrict__ means2d,
+                                       const uint32_t *__restrict__ visible, const float *__restrict__ depths,
+                                       const __half *__restrict__ conics, const int32_t macro_tile_cols,
+                                       const int32_t macro_tile_rows, const int32_t *__restrict__ mt_gauss_offsets,
+                                       int32_t *__restrict__ mt_depth_keys, int32_t *__restrict__ mt_gauss_ids,
+                                       int32_t *__restrict__ mt_chunk_meta_words,
+                                       const int32_t *__restrict__ mt_chunk_tile_carry, int32_t n_mt_tiles)
+{
+    const int32_t n_macro_tiles = macro_tile_cols * macro_tile_rows;
+    const int32_t chunk_idx     = blockIdx.x;
+    extern __shared__ int32_t smem[];
+    int32_t *const smem_chunk_gauss_counts = smem;
+
+    if constexpr (MODE == TileBinMode::COUNT)
+    {
+#pragma unroll 1
+        for (int32_t i = threadIdx.x; i < n_macro_tiles; i += blockDim.x)
+        {
+            smem_chunk_gauss_counts[i] = 0;
+        }
+        __syncthreads();
+    }
+
+    const int32_t chunk_start   = blockIdx.x * MT_CHUNK_SIZE;
+    const int32_t chunk_end     = min(chunk_start + MT_CHUNK_SIZE, N);
+    const int32_t chunk_tile    = chunk_idx / MT_CHUNK_TILE;
+    const int32_t chunk_in_tile = chunk_idx % MT_CHUNK_TILE;
+
+    constexpr int32_t TILE_SIZE_MACRO_X = MTW * TILE_SIZE;
+    constexpr int32_t TILE_SIZE_MACRO_Y = MTH * TILE_SIZE;
+    constexpr float INV_MTS_X           = 1.0f / (float)TILE_SIZE_MACRO_X;
+    constexpr float INV_MTS_Y           = 1.0f / (float)TILE_SIZE_MACRO_Y;
+
+    auto meta_row_word_base = [&](int32_t mt_tile, int32_t row_in_tile) {
+        return (chunk_tile * n_mt_tiles + mt_tile) * (MT_CHUNK_TILE * MT_META_WORDS) + row_in_tile * MT_META_WORDS;
+    };
+
+    // Common intersection logic: decode gaussian, compute macro-tile overlap, call emit for each hit
+    auto for_each_macro_tile_hit = [&](int32_t i, auto emit) {
+        if (!(visible[static_cast<uint32_t>(i) >> 5] & (1u << (static_cast<uint32_t>(i) & 0x1fu))))
+        {
+            return;
+        }
+
+        GaussianConic gc;
+        if (!decode_gaussian_conic(conics, means2d, i, gc))
+        {
+            return;
+        }
+
+        const int2 rect_min = {max(0, min(macro_tile_cols, (int)(gc.bbox_min.x * INV_MTS_X))),
+                               max(0, min(macro_tile_rows, (int)(gc.bbox_min.y * INV_MTS_Y)))};
+        const int2 rect_max = {max(0, min(macro_tile_cols, (int)(gc.bbox_max.x * INV_MTS_X + 1.f))),
+                               max(0, min(macro_tile_rows, (int)(gc.bbox_max.y * INV_MTS_Y + 1.f)))};
+
+        const int y_span = rect_max.y - rect_min.y;
+        const int x_span = rect_max.x - rect_min.x;
+        if (y_span * x_span == 0)
+        {
+            return;
+        }
+
+        const bool isY = y_span < x_span;
+
+        process_tiles_macro(gc.A, gc.B, gc.C, gc.disc, gc.t, gc.center, gc.bbox_min, gc.bbox_max, gc.bbox_argmin,
+                            gc.bbox_argmax, rect_min, rect_max, TILE_SIZE_MACRO_X, TILE_SIZE_MACRO_Y, macro_tile_cols,
+                            isY, emit);
+    };
+
+    if constexpr (MODE == TileBinMode::COUNT)
+    {
+        // Count mode: build a chunk-local histogram and flush it to metadata.
+#pragma unroll 1
+        for (int32_t i = chunk_start + threadIdx.x; i < chunk_end; i += blockDim.x)
+        {
+            for_each_macro_tile_hit(i, [&](int32_t mt) { atomicAdd(&smem_chunk_gauss_counts[mt], 1); });
+        }
+        __syncthreads();
+#pragma unroll 1
+        for (int32_t pair_idx = threadIdx.x; pair_idx < n_mt_tiles * MT_META_WORDS; pair_idx += blockDim.x)
+        {
+            const int32_t mt_tile      = pair_idx / MT_META_WORDS;
+            const int32_t pair_in_tile = pair_idx % MT_META_WORDS;
+            const int32_t mt0          = mt_tile * MT_META_TILE + pair_in_tile * 2;
+            const int32_t mt1          = mt0 + 1;
+
+            const int32_t count0 = (mt0 < n_macro_tiles) ? smem_chunk_gauss_counts[mt0] : 0;
+            const int32_t count1 = (mt1 < n_macro_tiles) ? smem_chunk_gauss_counts[mt1] : 0;
+
+            mt_chunk_meta_words[meta_row_word_base(mt_tile, chunk_in_tile) + pair_in_tile] = count0 | (count1 << 16);
+        }
+    }
+    else
+    {
+        int32_t *const smem_chunk_base_idx = smem + n_macro_tiles;
+
+#pragma unroll 1
+        for (int32_t mt = threadIdx.x; mt < n_macro_tiles; mt += blockDim.x)
+        {
+            const int32_t mt_tile = mt / MT_META_TILE;
+            const int32_t mt_lane = mt % MT_META_TILE;
+
+            const uint32_t packed    = mt_chunk_meta_words[meta_row_word_base(mt_tile, chunk_in_tile) + mt_lane / 2];
+            const int32_t local_base = (mt_lane & 1) ? (packed >> 16) : (packed & 0xFFFFu);
+
+            const int32_t carry_idx = (chunk_tile * n_mt_tiles + mt_tile) * MT_META_TILE + mt_lane;
+
+            smem_chunk_base_idx[mt]     = mt_gauss_offsets[mt] + mt_chunk_tile_carry[carry_idx] + local_base;
+            smem_chunk_gauss_counts[mt] = 0;
+        }
+        __syncthreads();
+
+        // Fill (depth, gauss_id) pairs to global output
+#pragma unroll 1
+        for (int32_t i = chunk_start + threadIdx.x; i < chunk_end; i += blockDim.x)
+        {
+            const int32_t depth_i32 = reinterpret_cast<const int32_t *>(depths)[i];
+
+            for_each_macro_tile_hit(i, [&](int32_t mt) {
+                const int32_t local_slot = atomicAdd(&smem_chunk_gauss_counts[mt], 1);
+                const int32_t write_pos  = smem_chunk_base_idx[mt] + local_slot;
+                mt_depth_keys[write_pos] = depth_i32;
+                mt_gauss_ids[write_pos]  = i;
+            });
+        }
+    }
+}
+
+// Computes chunk-local bases and chunk-tile carries from packed uint16 count rows.
+// Outputs final per-macro-tile gaussian counts for the existing mt offset scan.
+void launch_mt_chunk_bases(
+    at::Tensor inout_mt_chunk_meta_words, // [packed rows] int32 words containing uint16 counts / local bases
+    at::Tensor out_mt_chunk_tile_sums,    // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 tile sums
+    at::Tensor out_mt_chunk_tile_carry,   // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 exclusive tile carries
+    at::Tensor out_mt_gauss_counts,       // [n_mt] int32 per-macro-tile gaussian counts
+    int32_t n_macro_tiles,                // number of macro-tiles
+    int32_t n_chunks,                     // number of gaussian chunks
+    at::Tensor* inout_block_sums = nullptr,     // optional cached scratch buffer
+    at::Tensor* inout_block_prefixes = nullptr, // optional cached scratch buffer
+    int64_t* inout_scratch_capacity = nullptr);  // optional high-water-mark tracker
+
+// stateful helper that owns scratch buffers for the persistent mt offset scan.
+// construct once per resolution; call execute() each frame.
+class MTOffsets
+{
+public:
+    // n_macro_tiles: number of macro-tiles (cols x rows)
+    // gauss_batch_log2: log2(gaussians per batch)
+    MTOffsets(int32_t n_macro_tiles, int32_t gauss_batch_log2);
+
+    // launches the single persistent kernel on the current CUDA stream.
+    void execute(const at::Tensor &in_mt_gauss_counts, at::Tensor &out_mt_gauss_offsets,
+                 at::Tensor &out_mt_batch_offsets);
+
+private:
+    int32_t m_nMacroTiles;
+    int32_t m_gaussBatchLog2;
+    int m_numSMs;              // cached SM count for persistent CTA grid sizing
+    int32_t m_barrierExpected; // monotonically increasing barrier target, grows by n_ctas each execute()
+    at::Tensor m_scratch;      // [n_ctas*2 + 32] int32: barrier + int2 block sums
+};
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTConfig.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTConfig.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdint>
+
+namespace higs {
+
+// Fused macro-tile dimensions
+static constexpr int32_t FUSED_MACRO_TILE_WIDTH  = 8;
+static constexpr int32_t FUSED_MACRO_TILE_HEIGHT = 4;
+static constexpr int32_t FUSED_GAUSS_BATCH_SIZE  = 1024;
+
+static constexpr int32_t MT_CHUNK_SIZE = 8192;
+static constexpr int32_t MT_META_TILE  = 64;
+static constexpr int32_t MT_META_WORDS = MT_META_TILE / 2;
+static constexpr int32_t MT_CHUNK_TILE = 65535 / MT_CHUNK_SIZE + 1;
+
+static_assert(MT_META_TILE % 2 == 0, "metadata tile must pack an even number of uint16 entries");
+static_assert(MT_CHUNK_SIZE <= 65535, "chunk-local counts must fit in uint16_t");
+static_assert((MT_CHUNK_TILE - 1) * MT_CHUNK_SIZE <= 65535, "chunk-local base must fit in uint16_t");
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.cu
@@ -1,0 +1,287 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// IntersectMTFused: fused macro-tile intersection + rasterization pipeline.
+// Uses FUSED_MACRO_TILE_WIDTH/HEIGHT for macro-tile dimensions.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/zeros.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_fp16.h>
+
+#include "Constants.h"
+#include "IntersectCommon.h"
+#include "MacroTileIntersect.h"
+#include "IntersectMTConfig.h"
+#include "IntersectMTFused.h"
+#include "MacroTileRasterize.h"
+
+namespace higs {
+
+// ============================================================
+// Thin __global__ wrappers using FUSED_MACRO_TILE_WIDTH/HEIGHT
+// ============================================================
+
+// Macro-tile binning kernel for fused pipeline.
+// Thin wrapper around mt_binning_device_impl using FUSED_MACRO_TILE_WIDTH/HEIGHT.
+// See IntersectCommon.h for the fused count -> chunk-base scan -> single-pass fill flow.
+template<TileBinMode MODE, int32_t TILE_SIZE>
+__global__ void __launch_bounds__(MT_CTA_THREADS, MT_MIN_BLOCKS)
+    fused_mt_binning_kernel(const int32_t N,                                 // total gaussian count
+                            const float *__restrict__ means2d,               // [N, 2] gaussian 2D positions
+                            const uint32_t *__restrict__ visible,            // [ceil(N/32)] visibility bitmask
+                            const float *__restrict__ depths,                // [N] gaussian depths (FILL only)
+                            const __half *__restrict__ conics,               // [N, 4] half {l0,l1,l2,opacity}
+                            const int32_t macro_tile_cols,                   // macro-tile grid width
+                            const int32_t macro_tile_rows,                   // macro-tile grid height
+                            const int32_t *__restrict__ mt_gauss_offsets,    // [n_mt+1] FILL in: exclusive prefix sum
+                            int32_t *__restrict__ mt_depth_keys,             // [n_mt_isects] FILL out: depth as int32
+                            int32_t *__restrict__ mt_gauss_ids,              // [n_mt_isects] FILL out: gaussian index
+                            int32_t *__restrict__ mt_chunk_meta_words,       // [packed rows] COUNT/FILL metadata
+                            const int32_t *__restrict__ mt_chunk_tile_carry, // [chunk_tile, mt] carry prefixes
+                            const int32_t n_mt_tiles)                        // number of macro-tile metadata tiles
+{
+    mt_binning_device_impl<MODE, TILE_SIZE, FUSED_MACRO_TILE_WIDTH, FUSED_MACRO_TILE_HEIGHT>(
+        N, means2d, visible, depths, conics, macro_tile_cols, macro_tile_rows, mt_gauss_offsets, mt_depth_keys,
+        mt_gauss_ids, mt_chunk_meta_words, mt_chunk_tile_carry, n_mt_tiles);
+}
+
+// ============================================================
+// Host launch helpers
+// ============================================================
+
+static void launch_fused_mt_binning_impl(TileBinMode mode, int32_t N, int32_t tile_size, int32_t macro_tile_cols,
+                                         int32_t macro_tile_rows, const float *means2d, const uint32_t *visible,
+                                         const float *depths, const __half *conics, const int32_t *mt_gauss_offsets,
+                                         int32_t *mt_depth_keys, int32_t *mt_gauss_ids, int32_t *mt_chunk_meta_words,
+                                         const int32_t *mt_chunk_tile_carry, int32_t n_mt_tiles)
+{
+    if (N == 0)
+    {
+        return;
+    }
+
+    const int32_t n_macro_tiles = macro_tile_cols * macro_tile_rows;
+    const int32_t n_blocks      = (N + MT_CHUNK_SIZE - 1) / MT_CHUNK_SIZE;
+    const bool is_fill          = (mode == TileBinMode::FILL);
+
+    // COUNT: 1 smem array (chunk_gauss_counts), FILL: 2 (+ chunk_base_idx)
+    const size_t smem_bytes = (is_fill ? 2 : 1) * n_macro_tiles * sizeof(int32_t);
+
+    auto launch = [&](auto kernel_fn) {
+        if (smem_bytes > 48 * 1024 &&
+            cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes) != cudaSuccess)
+        {
+            AT_ERROR("Failed to set shared memory size for fused macro-tile binning kernel (requested ", smem_bytes,
+                     " bytes, ", n_macro_tiles, " macro-tiles)");
+        }
+        kernel_fn<<<n_blocks, MT_CTA_THREADS, smem_bytes, at::cuda::getCurrentCUDAStream()>>>(
+            N, means2d, visible, depths, conics, macro_tile_cols, macro_tile_rows, mt_gauss_offsets, mt_depth_keys,
+            mt_gauss_ids, mt_chunk_meta_words, mt_chunk_tile_carry, n_mt_tiles);
+    };
+
+    if (is_fill)
+    {
+        switch (tile_size)
+        {
+        case 16:
+            launch(fused_mt_binning_kernel<TileBinMode::FILL, 16>);
+            break;
+        case 8:
+            launch(fused_mt_binning_kernel<TileBinMode::FILL, 8>);
+            break;
+        default:
+            TORCH_CHECK(false, "tile_size must be 8 or 16, got ", tile_size);
+            break;
+        }
+    }
+    else
+    {
+        switch (tile_size)
+        {
+        case 16:
+            launch(fused_mt_binning_kernel<TileBinMode::COUNT, 16>);
+            break;
+        case 8:
+            launch(fused_mt_binning_kernel<TileBinMode::COUNT, 8>);
+            break;
+        default:
+            TORCH_CHECK(false, "tile_size must be 8 or 16, got ", tile_size);
+            break;
+        }
+    }
+}
+
+} // namespace higs
+
+// ============================================================
+// IntersectMTFused implementation
+// ============================================================
+
+IntersectMTFused::IntersectMTFused() = default;
+IntersectMTFused::~IntersectMTFused() = default;
+
+// Runs macro-tile intersection stages for the fused pipeline.
+// Dispatch order:
+//   1. mt count       — chunk-local histograms flushed to packed metadata rows
+//   2. mt chunk scan  — packed uint16 local bases + chunk-tile carries
+//   3. mt offsets     — fused prefix sums: mt_gauss_offsets + mt_batch_offsets
+//   4. mt fill        — single-pass write of (depth_key, gauss_id) pairs
+//   5. mt sort        — segmented radix sort by depth within each macro-tile
+void IntersectMTFused::execute(const at::Tensor &means2d, const at::Tensor &depths, const at::Tensor &conics,
+                               const at::Tensor &visible, int32_t tile_size, int32_t tile_width, int32_t tile_height,
+                               cudaStream_t stream)
+{
+    using namespace higs;
+    auto ceilDivInt = [](int32_t x, int32_t y) -> int32_t { return (x + y - 1) / y; };
+
+    static constexpr int32_t MTW  = FUSED_MACRO_TILE_WIDTH;
+    static constexpr int32_t MTH  = FUSED_MACRO_TILE_HEIGHT;
+    m_macroTileCols               = (tile_width + MTW - 1) / MTW;
+    const int32_t macro_tile_rows = (tile_height + MTH - 1) / MTH;
+    m_nMacroTiles                 = m_macroTileCols * macro_tile_rows;
+    m_tileSize                    = tile_size;
+    m_tileWidth                   = tile_width;
+    m_tileHeight                  = tile_height;
+
+    const int32_t N = means2d.size(-2);
+    auto opts_i32   = at::TensorOptions().dtype(at::kInt).device(at::kCUDA);
+
+    m_numChunks          = ceilDivInt(N, MT_CHUNK_SIZE);
+    m_numMtTiles         = ceilDivInt(m_nMacroTiles, MT_META_TILE);
+    m_numChunkTiles      = ceilDivInt(m_numChunks, MT_CHUNK_TILE);
+    m_chunkMetaWordsSize = m_numChunkTiles * m_numMtTiles * MT_CHUNK_TILE * MT_META_WORDS;
+    m_chunkTileCarrySize = m_numChunkTiles * m_numMtTiles * MT_META_TILE;
+
+    // Ensure macro-tile buffers are allocated for current grid size
+    if (!m_mtGaussOffsets.defined() || m_mtGaussOffsets.size(0) != (int64_t)(m_nMacroTiles + 1))
+    {
+        m_mtGaussCounts   = at::zeros({(int64_t)m_nMacroTiles}, opts_i32);
+        m_mtGaussOffsets  = at::zeros({(int64_t)m_nMacroTiles + 1}, opts_i32);
+        m_mtBatchOffsets  = at::zeros({(int64_t)m_nMacroTiles + 1}, opts_i32);
+        m_mtIsectCapacity = 0;
+        static_assert((FUSED_GAUSS_BATCH_SIZE & (FUSED_GAUSS_BATCH_SIZE - 1)) == 0,
+                      "FUSED_GAUSS_BATCH_SIZE must be a power of 2");
+        m_mtOffsets = std::make_unique<higs::MTOffsets>(m_nMacroTiles, CEIL_LOG2<FUSED_GAUSS_BATCH_SIZE>);
+    }
+
+    if (!m_mtChunkMetaWords.defined() || m_mtChunkMetaWords.size(0) != (int64_t)m_chunkMetaWordsSize)
+    {
+        m_mtChunkMetaWords = at::empty({(int64_t)m_chunkMetaWordsSize}, opts_i32);
+    }
+
+    if (!m_mtChunkTileCarry.defined() || m_mtChunkTileCarry.size(0) != (int64_t)m_chunkTileCarrySize)
+    {
+        m_mtChunkTileCarry = at::empty({(int64_t)m_chunkTileCarrySize}, opts_i32);
+    }
+
+    if (!m_mtChunkTileSums.defined() || m_mtChunkTileSums.size(0) != (int64_t)m_chunkTileCarrySize)
+    {
+        m_mtChunkTileSums = at::empty({(int64_t)m_chunkTileCarrySize}, opts_i32);
+    }
+
+    // Stage 1: macro-tile count
+    launch_fused_mt_binning_impl(TileBinMode::COUNT, N, tile_size, m_macroTileCols, macro_tile_rows,
+                                 means2d.data_ptr<float>(),
+                                 reinterpret_cast<const uint32_t *>(visible.data_ptr<int32_t>()), nullptr,
+                                 reinterpret_cast<const __half *>(conics.data_ptr<at::Half>()), nullptr, nullptr,
+                                 nullptr, m_mtChunkMetaWords.data_ptr<int32_t>(), nullptr, m_numMtTiles);
+
+    // Stage 2: macro-tile chunk-base scan
+    launch_mt_chunk_bases(m_mtChunkMetaWords, m_mtChunkTileSums, m_mtChunkTileCarry, m_mtGaussCounts, m_nMacroTiles,
+                          m_numChunks,
+                          &m_chunkBlockSums, &m_chunkBlockPrefixes, &m_chunkBlockScratchCapacity);
+
+    // Stage 3: macro-tile offsets (gauss + batch prefix sums from counts)
+    m_mtOffsets->execute(m_mtGaussCounts, m_mtGaussOffsets, m_mtBatchOffsets);
+
+    m_nMacroIsects = m_mtGaussOffsets[m_nMacroTiles].item<int64_t>();
+
+    if (m_nMacroIsects > 0)
+    {
+        if (m_nMacroIsects > m_mtIsectCapacity)
+        {
+            m_mtDepthKeys     = at::empty({m_nMacroIsects}, opts_i32);
+            m_mtGaussIds      = at::empty({m_nMacroIsects}, opts_i32);
+            m_mtIsectCapacity = m_nMacroIsects;
+        }
+        if (m_nMacroIsects > m_mtSortedCapacity)
+        {
+            m_mtDepthKeysSorted = at::empty({m_nMacroIsects}, opts_i32);
+            m_mtGaussIdsSorted  = at::empty({m_nMacroIsects}, opts_i32);
+            m_mtSortedCapacity  = m_nMacroIsects;
+        }
+
+        // Stage 4: Macro-tile fill
+        launch_fused_mt_binning_impl(
+            TileBinMode::FILL, N, tile_size, m_macroTileCols, macro_tile_rows, means2d.data_ptr<float>(),
+            reinterpret_cast<const uint32_t *>(visible.data_ptr<int32_t>()), depths.data_ptr<float>(),
+            reinterpret_cast<const __half *>(conics.data_ptr<at::Half>()), m_mtGaussOffsets.data_ptr<int32_t>(),
+            m_mtDepthKeys.data_ptr<int32_t>(), m_mtGaussIds.data_ptr<int32_t>(), m_mtChunkMetaWords.data_ptr<int32_t>(),
+            m_mtChunkTileCarry.data_ptr<int32_t>(), m_numMtTiles);
+
+        // Stage 5: Macro-tile segmented sort
+        launch_mt_segmented_sort(m_nMacroIsects, m_nMacroTiles, m_mtGaussOffsets, m_mtDepthKeys, m_mtGaussIds,
+                                 m_mtDepthKeysSorted, m_mtGaussIdsSorted);
+        m_numRasterBatches = m_mtBatchOffsets[-1].item<int32_t>();
+    }
+    else
+    {
+        m_numRasterBatches = 0;
+    }
+}
+
+void IntersectMTFused::rasterize(const at::Tensor &means2d, const at::Tensor &conics, const at::Tensor &colors,
+                                 const at::Tensor &backgrounds, uint32_t image_width, uint32_t image_height,
+                                 at::Tensor &render_colors)
+{
+    using namespace higs;
+
+    auto opts_i32 = at::TensorOptions().dtype(at::kInt).device(at::kCUDA);
+
+    // per-batch metadata (high-water-mark; first frame or capacity growth only)
+    const int32_t num_batches = max(m_numRasterBatches, 1);
+    if (num_batches > m_metadataCapacity)
+    {
+        m_activeMask       = at::zeros({num_batches}, opts_i32);
+        m_metadataCapacity = num_batches;
+    }
+
+    // worst-case tile buffer: each batch can write up to MACRO_TILE_SIZE tiles
+    constexpr int32_t MACRO_TILE_SIZE = FUSED_MACRO_TILE_WIDTH * FUSED_MACRO_TILE_HEIGHT;
+    const int64_t max_tiles           = max(static_cast<int64_t>(m_numRasterBatches) * MACRO_TILE_SIZE, static_cast<int64_t>(1));
+    const int64_t max_tile_buf_size   = max_tiles * m_tileSize * m_tileSize * 4;
+    if (max_tile_buf_size > m_tileBufferCapacity)
+    {
+        m_tileBuffer         = at::empty({max_tile_buf_size}, at::TensorOptions().dtype(at::kHalf).device(at::kCUDA));
+        m_tileBufferCapacity = max_tile_buf_size;
+    }
+
+    // Fused macro-tile rasterize kernel (skipped when no intersections)
+    if (m_nMacroIsects > 0 && m_numRasterBatches > 0)
+    {
+        launch_macro_tile_rasterize(m_numRasterBatches, m_nMacroTiles, m_macroTileCols, m_tileSize, m_tileWidth,
+                                    m_tileHeight, means2d, conics, colors, m_mtGaussOffsets, m_mtGaussIdsSorted,
+                                    m_mtBatchOffsets, m_tileBuffer, m_activeMask);
+    }
+
+    // Post-blend: composites partial results → final image (always runs; renders background when no gaussians)
+    launch_macro_tile_post_blend(m_tileWidth, m_tileHeight, m_tileSize, m_nMacroTiles, m_macroTileCols,
+                                 m_mtBatchOffsets, m_tileBuffer, m_activeMask, backgrounds, image_width, image_height,
+                                 render_colors);
+}

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.h
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <memory>
+
+#include "InferenceTypes.h"
+
+namespace higs {
+class MTOffsets;
+}
+
+// Fused macro-tile intersection + rasterization pipeline.
+//
+// execute() runs the macro-tile intersection stages:
+//   count → chunk-base scan + offsets → fill → sort
+//
+// rasterize() runs the fused rasterization kernels:
+//   macro_tile_rasterize → macro_tile_post_blend
+//
+// Uses FUSED_MACRO_TILE_WIDTH/HEIGHT constants for macro-tile dimensions.
+class IntersectMTFused : public IIntersectionStage
+{
+public:
+    IntersectMTFused();
+    ~IntersectMTFused() override;
+
+    // Runs macro-tile intersection stages (count, offsets, fill, sort).
+    void execute(const at::Tensor &means2d, const at::Tensor &depths, const at::Tensor &conics,
+                 const at::Tensor &visible, int32_t tile_size, int32_t tile_width, int32_t tile_height,
+                 cudaStream_t stream) override;
+
+    // Runs fused rasterize + post-blend kernels using the intersection results from execute().
+    // Must be called after execute() on the same frame.
+    void rasterize(const at::Tensor &means2d, const at::Tensor &conics, const at::Tensor &colors,
+                   const at::Tensor &backgrounds, uint32_t image_width, uint32_t image_height,
+                   at::Tensor &render_colors);
+
+private:
+    // Macro-tile intersection buffers
+    at::Tensor m_mtGaussCounts;                     // [n_mt] int32 — per-macro-tile gaussian hit counts
+    at::Tensor m_mtGaussOffsets;                    // [n_mt+1] int32 — exclusive prefix sum of counts
+    at::Tensor m_mtChunkMetaWords;                  // [packed rows] int32 words containing uint16 counts / local bases
+    at::Tensor m_mtChunkTileSums;                   // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 chunk-tile sums
+    at::Tensor m_mtChunkTileCarry;                  // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 chunk-tile carries
+    at::Tensor m_mtDepthKeys;                       // [n_mt_isects] int32 — depth as bit-reinterpreted int32
+    at::Tensor m_mtGaussIds;                        // [n_mt_isects] int32 — gaussian indices
+    at::Tensor m_mtDepthKeysSorted;                 // [n_mt_isects] int32 — sorted depth keys
+    at::Tensor m_mtGaussIdsSorted;                  // [n_mt_isects] int32 — gaussian IDs sorted by depth per macro-tile
+    at::Tensor m_mtBatchOffsets;                    // [n_mt+1] int32 — gaussian batch start indices per macro-tile
+    int64_t m_mtIsectCapacity    = 0;               // high-water-mark for m_mtDepthKeys/m_mtGaussIds allocation
+    int64_t m_mtSortedCapacity   = 0;               // high-water-mark for m_mtDepthKeysSorted/m_mtGaussIdsSorted
+    int64_t m_nMacroIsects       = 0;               // total macro-tile intersections (from offsets readback)
+    int32_t m_macroTileCols      = 0;               // macro-tile grid width
+    int32_t m_nMacroTiles        = 0;               // total macro-tiles (cols × rows)
+    int32_t m_numRasterBatches   = 0;               // total CTA batches across all macro-tiles
+    int32_t m_tileSize           = 0;               // render-tile size in pixels (8 or 16)
+    int32_t m_tileWidth          = 0;               // render-tile grid width
+    int32_t m_tileHeight         = 0;               // render-tile grid height
+    int32_t m_chunkMetaWordsSize = 0;               // number of packed int32 metadata words
+    int32_t m_chunkTileCarrySize = 0;               // number of int32 carry entries
+    int32_t m_numChunks          = 0;               // number of gaussian chunks in the current frame
+    int32_t m_numChunkTiles      = 0;               // number of chunk tiles in the current frame
+    int32_t m_numMtTiles         = 0;               // number of macro-tile metadata tiles in the current frame
+    std::unique_ptr<higs::MTOffsets> m_mtOffsets; // persistent mt offset scan helper
+
+    // Cached scratch buffers for launch_mt_chunk_bases (avoids 2 x at::empty per frame)
+    at::Tensor m_chunkBlockSums;                    // [n_chunk_blocks * n_mt_tiles * MT_META_TILE] int32
+    at::Tensor m_chunkBlockPrefixes;                // [n_chunk_blocks * n_mt_tiles * MT_META_TILE] int32
+    int64_t m_chunkBlockScratchCapacity = 0;        // high-water-mark for block_sums/block_prefixes
+
+    // Fused rasterize buffers (written by macro_tile_rasterize_kernel, read by post_blend)
+    at::Tensor m_tileBuffer;             // [N] half — fixed-layout partial RGBT per (cta, mt-slot)
+    at::Tensor m_activeMask;             // [total_ctas] uint32 — per-CTA 32-bit tile overlap mask
+    int64_t m_tileBufferCapacity    = 0; // high-water-mark for m_tileBuffer (in half elements)
+    int64_t m_metadataCapacity      = 0; // high-water-mark for m_activeMask
+
+};

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.cu
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Shared macro-tile segmented sort helper used by the fused intersection pipeline.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include "SegmentedSort.h"
+#include "MacroTileIntersect.h"
+
+namespace higs {
+
+void launch_mt_segmented_sort(int64_t n_macro_isects,
+                              int32_t n_macro_tiles,
+                              const at::Tensor in_mt_gauss_offsets,
+                              at::Tensor inout_mt_depth_keys,
+                              at::Tensor inout_mt_gauss_ids,
+                              at::Tensor out_mt_depth_keys_sorted,
+                              at::Tensor out_mt_gauss_ids_sorted)
+{
+    if (n_macro_isects <= 0)
+    {
+        return;
+    }
+
+    int32_t *d_keys_in       = inout_mt_depth_keys.data_ptr<int32_t>();
+    int32_t *d_keys_out      = out_mt_depth_keys_sorted.data_ptr<int32_t>();
+    int32_t *d_vals_in       = inout_mt_gauss_ids.data_ptr<int32_t>();
+    int32_t *d_vals_out      = out_mt_gauss_ids_sorted.data_ptr<int32_t>();
+    const int32_t *d_offsets = in_mt_gauss_offsets.data_ptr<int32_t>();
+    cudaStream_t stream      = at::cuda::getCurrentCUDAStream();
+
+    auto &alloc = *::c10::cuda::CUDACachingAllocator::get();
+
+    SegmentedSortState state;
+    size_t scratch_bytes = SegmentedSortSetup(state, n_macro_tiles, (int32_t)n_macro_isects, nullptr);
+    auto scratch         = alloc.allocate(scratch_bytes);
+    SegmentedSortSetup(state, n_macro_tiles, (int32_t)n_macro_isects, scratch.get());
+
+    int32_t *d_keys[2]   = {d_keys_in, d_keys_out};
+    int32_t *d_values[2] = {d_vals_in, d_vals_out};
+
+    int result_buf = SegmentedSortAsync(state, d_offsets, d_keys, d_values, stream);
+
+    if (result_buf == 0)
+    {
+        // copy_ instead of set_ to avoid aliasing the input and output
+        // tensors — high-water-mark reuse across frames would otherwise
+        // cause the sort's ping-pong buffers to overlap on the next frame.
+        // Narrow to n_macro_isects since the buffers may have different
+        // high-water-mark capacities.
+        out_mt_depth_keys_sorted.narrow(0, 0, n_macro_isects).copy_(
+            inout_mt_depth_keys.narrow(0, 0, n_macro_isects));
+        out_mt_gauss_ids_sorted.narrow(0, 0, n_macro_isects).copy_(
+            inout_mt_gauss_ids.narrow(0, 0, n_macro_isects));
+    }
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <cstdint>
+
+namespace higs {
+
+// Sort gaussian IDs by depth key within each macro-tile segment.
+// Only sorted values (gaussian IDs) are guaranteed in the output;
+// key buffers are used as working space and their final contents
+// are undefined.
+void launch_mt_segmented_sort(int64_t n_macro_isects,
+                              int32_t n_macro_tiles,
+                              const at::Tensor in_mt_gauss_offsets,
+                              at::Tensor inout_mt_depth_keys,
+                              at::Tensor inout_mt_gauss_ids,
+                              at::Tensor out_mt_depth_keys_sorted,
+                              at::Tensor out_mt_gauss_ids_sorted);
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileRasterize.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileRasterize.cu
@@ -1,0 +1,937 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Macro-tile rasterize + post-blend kernels.
+//
+// Kernel 1 (macro_tile_rasterize_kernel):
+//   CTA_WARPS warps per (macro-tile, batch) pair.  Two-phase design
+//   that trades the MACRO_TILE_SIZE-tile register accumulators for smem masks.
+//
+//   Phase 1 — fused load + visibility mask generation:
+//     Each warp processes one 32-gaussian mini-batch per iteration.
+//     Lane j loads gaussian j from global, writes persistent smem
+//     (xy_mt, conic_raw), then computes overlap against all 32
+//     render-tiles (4 rows x 8 cols) with the data still in registers.
+//     Each lane produces a 32-bit tile_mask (bit t = overlaps tile t).
+//     A 5-stage warp_bit_transpose converts the per-gaussian tile masks
+//     into per-tile gaussian masks (bit j = gaussian j overlaps this
+//     tile), which are written directly to smem_masks — no atomicOr
+//     needed since each warp owns its mini-batch slots exclusively.
+//     Colors are NOT loaded here — they are deferred to right before
+//     phase 2 into the overlap region.
+//
+//   Transition:
+//     Warp 0 ORs mask words across all mini-batches to find any_hit
+//     per tile.  Computes active_mask via __ballot_sync, writes output
+//     mask, populates the tile work queue.
+//
+//   Deferred color load (between transition and phase 2):
+//     Full CTA re-reads gauss ids and pulls per-gaussian colors from
+//     global into the overlap region.  Colors are packed {RG : half2,
+//     B : half} to drop the unused 4th slot of the [N,4] half layout.
+//
+//   Phase 2 — per-tile rasterization:
+//     Loops over active tiles with work-stealing warp assignment.  Each
+//     warp cooperatively rasterizes one tile using N_PAIRS x 4 half2
+//     accumulators.  For each tile, reads pre-computed masks from smem
+//     and iterates set bits to fetch gaussian data from smem (xy_mt,
+//     conic, color_rg, color_b).
+//     Writes partial RGBT to sparse tile_buffer after each tile.
+//
+// Kernel 2 (macro_tile_post_blend_kernel):
+//   1 warp per render tile.  Walks batches of the parent macro-tile in
+//   order, reads partial RGBT from sparse buffer (skipping inactive
+//   batches via active_mask), composites front-to-back with transmittance
+//   early-out, writes final image.
+
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/empty.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_fp16.h>
+#include <cmath>
+#include <cstdint>
+#include "Common.h"
+#include "Constants.h"
+#include "IntersectCommon.h"
+#include "IntersectMTConfig.h"
+#include "MacroTileRasterize.h"
+
+namespace higs {
+
+static constexpr int32_t RASTERIZE_CTA_SIZE   = 320;
+static constexpr int32_t RASTERIZE_MIN_BLOCKS = 3;
+// ring-buffer queue capacity
+static constexpr int32_t RASTERIZE_QUEUE_CAPACITY = 128;
+
+static constexpr int32_t BLEND_CTA_SIZE   = 256;
+static constexpr int32_t BLEND_MIN_BLOCKS = 4;
+
+static constexpr float LOG2_INV_AT = 7.9943534f; // log2(1/ALPHA_THRESHOLD) = log2(255)
+static_assert(ALPHA_THRESHOLD == 1.0f / 255.0f, "LOG2_INV_AT / ALPHA_THRESHOLD mismatch -> update LOG2_INV_AT");
+static constexpr float MIN_TRANSPARENCY = 1e-4f;
+
+// 32x32 bit-matrix transpose within a warp via 5 stages of __shfl_xor_sync.
+// input:  thread j holds val where bit t means "gaussian j overlaps tile t"
+// output: thread t holds val where bit j means "gaussian j overlaps tile t"
+__device__ __forceinline__ uint32_t WarpBitTranspose(uint32_t val)
+{
+    constexpr uint32_t MASKS[5] = {0x0000FFFF, 0x00FF00FF, 0x0F0F0F0F, 0x33333333, 0x55555555};
+    const int32_t lane_id       = threadIdx.x & 31;
+#pragma unroll
+    for (int32_t k = 4; k >= 0; --k)
+    {
+        const int32_t delta  = 1 << k;
+        const uint32_t m     = MASKS[4 - k];
+        const uint32_t other = __shfl_xor_sync(~0u, val, delta);
+        val = (lane_id & delta) ? (val & ~m) | ((other >> delta) & m) : (val & m) | ((other & m) << delta);
+    }
+    return val;
+};
+
+// generate a 32-bit render-tile mask for a single gaussian against all 32 render-tiles.
+__device__ __forceinline__ uint32_t GetMacroTileVisibilityMask(const __half2 &xy_mt, const __half2 (&rast_conic)[2],
+                                                               float neg_l1_rcp_C, float t_rast)
+{
+    // test against all 32 render-tiles (4 rows x 4 column-pairs).
+    // row setup and inner loop are pure half2 math.
+
+    // half2 broadcasts for the overlap test (2 columns at a time)
+    const __half2 h2_mt_rel_x     = __low2half2(xy_mt);
+    const __half2 h2_mt_rel_y     = __high2half2(xy_mt);
+    const __half2 h2_c_l0         = __low2half2(rast_conic[0]);
+    const __half2 h2_c_l1         = __high2half2(rast_conic[0]);
+    const __half2 h2_c_l2         = __low2half2(rast_conic[1]);
+    const __half2 h2_neg_l1_rcp_C = __float2half2_rn(neg_l1_rcp_C);
+    const __half2 h2_t_rast       = __float2half2_rn(t_rast);
+
+    uint32_t tile_mask_even = 0;
+    uint32_t tile_mask_odd  = 0;
+#pragma unroll
+    for (int32_t r = 0; r < FUSED_MACRO_TILE_HEIGHT; ++r)
+    {
+        const __half2 h2_ny = __hsub2(h2_mt_rel_y, __float2half2_rn(r + 0.5f - FUSED_MACRO_TILE_HEIGHT * 0.5f));
+        const uint32_t ny_inside_mask = __hlt2_mask(__habs2(h2_ny), __float2half2_rn(0.5f));
+        const __half2 h2_dy0          = __hsub2(__float2half2_rn(-0.5f), h2_ny);
+        const __half2 h2_dy1          = __hadd2(h2_dy0, __float2half2_rn(1.f));
+        const __half2 h2_dy_h         = __h2if(__hgeu2_mask(h2_ny, __float2half2_rn(0.0f)), h2_dy1, h2_dy0);
+        const __half2 h2_l1_dy        = __hmul2(h2_c_l1, h2_dy_h);
+        const __half2 h2_v_h          = __hmul2(h2_c_l2, h2_dy_h);
+        const __half2 h2_v_h_sq       = __hmul2(h2_v_h, h2_v_h);
+
+#pragma unroll
+        for (int32_t c = 0; c < FUSED_MACRO_TILE_WIDTH; c += 2)
+        {
+            const int32_t t = r * FUSED_MACRO_TILE_WIDTH + c;
+
+            const __half2 nx = __hsub2(h2_mt_rel_x, __floats2half2_rn(c + 0.5f - FUSED_MACRO_TILE_WIDTH * 0.5f,
+                                                                      c + 1.5f - FUSED_MACRO_TILE_WIDTH * 0.5f));
+
+            const __half2 dx0    = __hsub2(__float2half2_rn(-0.5f), nx);
+            const __half2 l0_dx0 = __hmul2(h2_c_l0, dx0);
+            const __half2 l0_dx1 = __hadd2(l0_dx0, h2_c_l0);
+
+            // horizontal edge test
+            const __half2 u_h =
+                __hmin2(__hmax2(__float2half2_rn(0.0f), __hadd2(l0_dx0, h2_l1_dy)), __hadd2(l0_dx1, h2_l1_dy));
+            const __half2 q_h = __hfma2(u_h, u_h, h2_v_h_sq);
+
+            // vertical edge test
+            const __half2 l0_dx = __h2if(__hgeu2_mask(nx, __float2half2_rn(0.0f)), l0_dx1, l0_dx0);
+            const __half2 dy_v  = __hmin2(__hmax2(__hmul2(l0_dx, h2_neg_l1_rcp_C), h2_dy0), h2_dy1);
+            const __half2 u_v   = __hfma2(h2_c_l1, dy_v, l0_dx);
+            const __half2 v_v   = __hmul2(h2_c_l2, dy_v);
+            const __half2 q_v   = __hfma2(v_v, v_v, __hmul2(u_v, u_v));
+
+            // center inside = |nx| < 0.5 AND |ny| < 0.5 (both masks in {bit0, bit16} format)
+            const uint32_t center_hit = ny_inside_mask & __hlt2_mask(__habs2(nx), __float2half2_rn(0.5f));
+            const uint32_t edge_hit   = __hle2_mask(__hmin2(q_h, q_v), h2_t_rast);
+            const uint32_t hit        = center_hit | edge_hit;
+
+            // __hxx2_mask: bit 0 = low half, bit 16 = high half → pack to positions t, t+1
+            tile_mask_even |= (hit & 1u) << t;
+            tile_mask_odd |= (hit >> 31) << (t + 1);
+        }
+    }
+    return tile_mask_even | tile_mask_odd;
+};
+
+// kernel arguments passed as a single struct to reduce parameter count.
+struct MacroTileRasterizeArgs
+{
+    int32_t n_macro_tiles;
+    int32_t macro_tile_cols;
+    int32_t tile_width;
+    int32_t tile_height;
+    const float *means2d;
+    const __half *conics;
+    const __half *colors;
+    const int32_t *mt_gauss_offsets;
+    const int32_t *mt_gauss_ids_sorted;
+    const int32_t *mt_batch_offsets;
+    __half *tile_buffer;
+    uint32_t *out_active_mask;
+};
+
+template<int32_t TILE_SIZE>
+__global__ void __launch_bounds__(RASTERIZE_CTA_SIZE, RASTERIZE_MIN_BLOCKS)
+    macro_tile_rasterize_kernel(MacroTileRasterizeArgs args)
+{
+    constexpr int32_t MACRO_TILE_SIZE = FUSED_MACRO_TILE_WIDTH * FUSED_MACRO_TILE_HEIGHT;
+    constexpr int32_t CTA_WARPS       = RASTERIZE_CTA_SIZE / 32;
+
+    // a single mini-batch corresponds to a 32-bit mask
+    constexpr int32_t MINI_BATCH_SIZE  = 32;
+    constexpr int32_t MAX_MINI_BATCHES = FUSED_GAUSS_BATCH_SIZE / MINI_BATCH_SIZE;
+
+    static_assert(MACRO_TILE_SIZE == 32, "macro-tile must be exactly one warp");
+    static_assert(TILE_SIZE == 8 || TILE_SIZE == 16, "TILE_SIZE must be 8 or 16");
+    static_assert(RASTERIZE_CTA_SIZE % 32 == 0, "RASTERIZE_CTA_SIZE must be a multiple of warp size");
+    static_assert(CTA_WARPS > 1, "single-warp path removed — CTA_WARPS must be > 1");
+
+    constexpr float INV_TILE_SIZE      = 1.0f / TILE_SIZE;
+    // std::numbers::log2e_v<float> would be preferable (C++20) but M_LOG2E
+    // is used for CUDA device-code compatibility.
+    constexpr float LOG2E              = static_cast<float>(M_LOG2E);
+    constexpr float CHOL_SCALE         = 0.84932180028f * TILE_SIZE; // sqrt(LOG2E/2) * TILE_SIZE
+    constexpr float MAX_EXTEND_CHOL_SQ = (LOG2E * 0.5f) * MAX_EXTEND * MAX_EXTEND;
+
+    // tile=8 splits a warp into 2 half-warps so each gaussian is broadcast to 16 lanes
+    // instead of 32 — halves smem LDS issue rate at the cost of 2x the accumulator
+    // register pressure per thread. tile=16 keeps GAUSS_PER_WARP=1 (registers would otherwise spike).
+    constexpr int32_t GAUSS_PER_WARP    = (TILE_SIZE == 8) ? 2 : 1;
+    constexpr int32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / (32 / GAUSS_PER_WARP);
+    constexpr int32_t N_PAIRS           = PIXELS_PER_THREAD / 2;
+
+    // shared memory — single raw block, pointers chained from top
+    constexpr int32_t SMEM_MASKS_COUNT = MAX_MINI_BATCHES * MACRO_TILE_SIZE;
+    constexpr int32_t SMEM_SIZE =
+        FUSED_GAUSS_BATCH_SIZE * (sizeof(__half2) + sizeof(uint2) + sizeof(__half2) + sizeof(__half2)) +
+        (MACRO_TILE_SIZE + 2) * sizeof(int32_t) + SMEM_MASKS_COUNT * sizeof(uint32_t) + 1 * sizeof(int32_t);
+
+    static_assert((RASTERIZE_QUEUE_CAPACITY & (RASTERIZE_QUEUE_CAPACITY - 1)) == 0,
+                  "QUEUE_CAPACITY must be a power of 2");
+
+    // N_PAIRS x {R,G,B,T} half2 accumulators — each [pp] is a contiguous uint4
+    using TileAccum = __half2[N_PAIRS][4];
+
+    // let NVCC know that warp_id is a warm uniform (doh!)
+    const int32_t warp_id = __shfl_sync(~0u, threadIdx.x >> 5, 0);
+    const int32_t lane_id = threadIdx.x & 31;
+
+    __shared__ alignas(16) char smem_raw[SMEM_SIZE];
+
+    // gaussian position + conic (written in phase 1, read in phase 2)
+    __half2 *smem_xy_mt   = reinterpret_cast<__half2 *>(smem_raw);
+    uint2 *smem_conic_raw = reinterpret_cast<uint2 *>(smem_xy_mt + FUSED_GAUSS_BATCH_SIZE);
+
+    // tile work queue: [0..31] tile ids, [32] queue size, [33] pull counter
+    int32_t *smem_tile_queue = reinterpret_cast<int32_t *>(smem_conic_raw + FUSED_GAUSS_BATCH_SIZE);
+    int32_t &smem_queue_size = smem_tile_queue[MACRO_TILE_SIZE];
+    int32_t &smem_queue_idx  = smem_tile_queue[MACRO_TILE_SIZE + 1];
+
+    // per-gaussian color packed as 4xfp16 (loaded before phase 2)
+    ushort4 *smem_color = reinterpret_cast<ushort4 *>(smem_tile_queue + MACRO_TILE_SIZE + 2);
+
+    // visibility masks (filled during fused load via warp transpose, read in phase 2)
+    uint32_t *smem_masks = reinterpret_cast<uint32_t *>(smem_color + FUSED_GAUSS_BATCH_SIZE);
+
+    // cross-warp broadcast scratch:
+    int32_t *smem_scratch = reinterpret_cast<int32_t *>(smem_masks + SMEM_MASKS_COUNT);
+    int32_t &smem_mt_id   = smem_scratch[0];
+
+    // per-warp gaussian index queue for rasterization (ring buffer, filled across mini-batches).
+    // align to 16-bytes so the unrolled rasterization loop can use uint4 loads.
+    __shared__ __align__(16) uint16_t smem_warp_queue[CTA_WARPS * RASTERIZE_QUEUE_CAPACITY];
+
+    // pixel coordinates within a tile (same for all tiles, derived from lane_id).
+    // for GAUSS_PER_WARP=2 each half-warp owns the entire tile; lane_in_half/is_half_a reduce to
+    // lane_id/true respectively for GAUSS_PER_WARP=1, so the GAUSS_PER_WARP=1 codegen is unchanged.
+    constexpr uint32_t TILE_X_MASK  = TILE_SIZE - 1;
+    constexpr uint32_t TILE_X_SHIFT = (TILE_SIZE == 16) ? 4 : 3;
+    const int32_t lane_in_half      = lane_id & ((32 / GAUSS_PER_WARP) - 1);
+    const bool is_half_a            = lane_id < (32 / GAUSS_PER_WARP);
+    const uint32_t thread_x         = lane_in_half & TILE_X_MASK;
+    const uint32_t thread_y         = lane_in_half >> TILE_X_SHIFT;
+    // pixel x in tile units relative to macro-tile center (includes intra-tile + centering offset)
+    const float px = static_cast<float>(thread_x) * INV_TILE_SIZE + (0.5f * INV_TILE_SIZE - 0.5f) +
+                     (0.5f - FUSED_MACRO_TILE_WIDTH * 0.5f);
+    // pixel y in tile units relative to macro-tile center (includes intra-tile + centering offset)
+    const float py = static_cast<float>(thread_y) * INV_TILE_SIZE + (0.5f * INV_TILE_SIZE - 0.5f) +
+                     (0.5f - FUSED_MACRO_TILE_HEIGHT * 0.5f);
+
+    // rasterize a single gaussian into all N_PAIRS row-pair accumulators.
+    // smem loads and dx/u0_base are invariant across pairs — only dy-dependent
+    // math runs per pair, keeping smem traffic at 1 load per gaussian.
+    auto rasterizeGaussian = [&smem_xy_mt, &smem_conic_raw, &smem_color](int32_t idx, const __half2 &offset_x,
+                                                                         const __half2(&offset_y)[N_PAIRS],
+                                                                         TileAccum &acc) {
+        const __half2 xy_mt_j = smem_xy_mt[idx];
+        __half2 rc[2];
+        AssignAs<uint2>(rc, smem_conic_raw[idx]);
+        __half2 col[2];
+        AssignAs<uint2>(col, smem_color[idx]);
+
+        const __half2 sigma_thresh = __float2half2_rn(LOG2_INV_AT);
+        const __half2 l00          = __low2half2(rc[0]);
+        const __half2 l10          = __high2half2(rc[0]);
+        const __half2 l11          = __low2half2(rc[1]);
+        const __half2 neg_log_opac = __high2half2(rc[1]);
+        const __half2 cr           = __half2half2(__low2half(col[0]));
+        const __half2 cg           = __half2half2(__high2half(col[0]));
+        const __half2 cb           = __low2half2(col[1]);
+
+        const __half2 dx      = __hsub2(__low2half2(xy_mt_j), offset_x);
+        const __half2 mean_y  = __high2half2(xy_mt_j);
+        const __half2 u0_base = __hmul2(l00, dx);
+
+#pragma unroll
+        for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+        {
+            const __half2 dy = __hsub2(mean_y, offset_y[pp]);
+            const __half2 u0 = __hfma2(l10, dy, u0_base);
+            const __half2 u1 = __hmul2(l11, dy);
+            // fused sigma: u0^2 + u1^2 - log2(opac), so exp2(-sigma) = opac * exp2(-(u0^2+u1^2))
+            const __half2 sigma = __hfma2(u1, u1, __hfma2(u0, u0, neg_log_opac));
+            // threshold in sigma domain (sigma < log2(1/AT) implies alpha > AT);
+            // strict < avoids boundary rounding from exp2 approx; comparison
+            // runs parallel with hneg2+exp2, off the critical path
+            const uint32_t ok_mask = __hlt2_mask(sigma, sigma_thresh);
+            const __half2 alpha    = __h2exp2_approx(__hneg2(sigma));
+            const __half2 alpha_ht = __h2if(ok_mask, alpha, __float2half2_rn(0.0f));
+            const __half2 vis      = __hmul2(alpha_ht, acc[pp][3]);
+            acc[pp][0]             = __hfma2(cr, vis, acc[pp][0]);
+            acc[pp][1]             = __hfma2(cg, vis, acc[pp][1]);
+            acc[pp][2]             = __hfma2(cb, vis, acc[pp][2]);
+            acc[pp][3]             = __hsub2_sat(acc[pp][3], vis);
+        }
+    };
+
+    // CTA → (mt_id, mt_batch_idx) mapping: plain sequential dispatch.
+    int32_t mt_batch_idx = blockIdx.x;
+    if (warp_id == 0)
+    {
+        smem_mt_id = find_macro_tile(args.mt_batch_offsets, args.n_macro_tiles, mt_batch_idx);
+    }
+    __syncthreads();
+    const int32_t mt_id  = smem_mt_id;
+    const int32_t mt_col = mt_id % args.macro_tile_cols;
+    const int32_t mt_row = mt_id / args.macro_tile_cols;
+
+    const int32_t batch_idx = mt_batch_idx - args.mt_batch_offsets[mt_id];
+
+    // PHASE 1: fused load + overlap + transpose + transition ----
+
+    // macro-tile center in tile units
+    const float mt_cx = static_cast<float>(mt_col * FUSED_MACRO_TILE_WIDTH) + FUSED_MACRO_TILE_WIDTH * 0.5f;
+    const float mt_cy = static_cast<float>(mt_row * FUSED_MACRO_TILE_HEIGHT) + FUSED_MACRO_TILE_HEIGHT * 0.5f;
+
+    // gaussian range for this batch
+    const int32_t mt_start         = args.mt_gauss_offsets[mt_id];
+    const int32_t mt_end           = args.mt_gauss_offsets[mt_id + 1];
+    const int32_t gauss_start      = mt_start + batch_idx * FUSED_GAUSS_BATCH_SIZE;
+    const int32_t gauss_end        = min(gauss_start + FUSED_GAUSS_BATCH_SIZE, mt_end);
+    const int32_t n_gauss          = gauss_end - gauss_start;
+    const int32_t num_mini_batches = (n_gauss + MINI_BATCH_SIZE - 1) / MINI_BATCH_SIZE;
+
+    // fused load + visibility mask generation: each warp processes one mini-batch
+    // per iteration. lane j loads gaussian j and computes overlap against all 32
+    // render-tiles, then a warp bit-matrix transpose converts the per-gaussian
+    // tile masks into per-tile gaussian masks written directly to smem_masks.
+#pragma unroll 1
+    for (int32_t mb = warp_id; mb < num_mini_batches; mb += CTA_WARPS)
+    {
+        const int32_t i = mb * MINI_BATCH_SIZE + lane_id;
+
+        uint32_t tile_mask = 0;
+        if (i < n_gauss)
+        {
+            const int32_t g = args.mt_gauss_ids_sorted[gauss_start + i];
+
+            float2 pos;
+            AssignAs<float2>(pos, args.means2d[g * 2]);
+            __half2 raw_conic[2];
+            AssignAs<uint2>(raw_conic, args.conics[g * 4]);
+
+            // write persistent smem for phase 2
+            const float mt_rel_x = pos.x * INV_TILE_SIZE - mt_cx;
+            const float mt_rel_y = pos.y * INV_TILE_SIZE - mt_cy;
+            // gaussian position in render-tile units relative to macro-tile center
+            const __half2 xy_mt = __floats2half2_rn(mt_rel_x, mt_rel_y);
+            smem_xy_mt[i]       = xy_mt;
+
+            // cholesky factors in render-tile units, with -log2(opac) fused into the conic
+            // slot formerly occupied by raw opacity (eliminates one hmul2 in the rasterization loop)
+            const float opacity   = __half2float(__high2half(raw_conic[1]));
+            const float log2_opac = __log2f(opacity);
+            __half2 rast_conic[2] = {
+                __hmul2(raw_conic[0], __floats2half2_rn(CHOL_SCALE, CHOL_SCALE)),
+                __floats2half2_rn(__half2float(__low2half(raw_conic[1])) * CHOL_SCALE, -log2_opac)};
+            AssignAs<uint2>(smem_conic_raw[i], rast_conic);
+
+            // neg_l1_rcp_C and t_rast need fp32 (division, log2)
+            const float c_l1_f = __half2float(__high2half(rast_conic[0]));
+            const float c_l2_f = __half2float(__low2half(rast_conic[1]));
+
+            const float C            = c_l1_f * c_l1_f + c_l2_f * c_l2_f;
+            const float neg_l1_rcp_C = (C > 0.f) ? (-c_l1_f / C) : 0.f;
+            const float t_rast       = min(MAX_EXTEND_CHOL_SQ, log2_opac + LOG2_INV_AT);
+
+            tile_mask = GetMacroTileVisibilityMask(xy_mt, rast_conic, neg_l1_rcp_C, t_rast);
+        }
+
+        // warp bit-matrix transpose: per-gaussian tile masks -> per-tile gaussian masks
+        const uint32_t gauss_mask                  = WarpBitTranspose(tile_mask);
+        smem_masks[mb * MACRO_TILE_SIZE + lane_id] = gauss_mask;
+    }
+
+    // zero remaining mask slots (no shuffles, just stores)
+#pragma unroll 1
+    for (int32_t mb = num_mini_batches + warp_id; mb < MAX_MINI_BATCHES; mb += CTA_WARPS)
+    {
+        smem_masks[mb * MACRO_TILE_SIZE + lane_id] = 0;
+    }
+
+    // deferred color load
+#pragma unroll 1
+    for (int32_t i = threadIdx.x; i < n_gauss; i += blockDim.x)
+    {
+        const int32_t g = args.mt_gauss_ids_sorted[gauss_start + i];
+        AssignAs<uint2>(smem_color[i], args.colors[g * 4]);
+    }
+
+    __syncthreads(); // persistent smem + masks visible to all warps
+
+    // transition: warp 0 reads combined masks from smem, computes active_mask, writes output mask.
+    // tile_buffer write positions are fixed (batch_cta_idx * MACRO_TILE_SIZE + t) so no offset
+    // allocation is needed for addressing.
+    if (warp_id == 0)
+    {
+        uint32_t any_hit = 0;
+#pragma unroll
+        for (int32_t mb = 0; mb < MAX_MINI_BATCHES; ++mb)
+        {
+            any_hit |= smem_masks[mb * MACRO_TILE_SIZE + lane_id];
+        }
+
+        const int32_t global_tile_x = mt_col * FUSED_MACRO_TILE_WIDTH + (lane_id % FUSED_MACRO_TILE_WIDTH);
+        const int32_t global_tile_y = mt_row * FUSED_MACRO_TILE_HEIGHT + (lane_id / FUSED_MACRO_TILE_WIDTH);
+        const uint32_t valid_mask =
+            __ballot_sync(~0u, (global_tile_x < args.tile_width) && (global_tile_y < args.tile_height));
+        const uint32_t active_mask = __ballot_sync(~0u, any_hit != 0) & valid_mask;
+
+        // populate tile work queue for multi-warp rasterization
+        if (active_mask & (1u << lane_id))
+        {
+            smem_tile_queue[__popc(active_mask & ((1u << lane_id) - 1))] = lane_id;
+        }
+        // get number of tiles to render
+        const int32_t n_active_tiles = __popc(active_mask);
+        if (lane_id == 0)
+        {
+            // write queue metadata
+            smem_queue_size = n_active_tiles;
+            smem_queue_idx  = CTA_WARPS;
+            // write output mask for post-blend kernel
+            args.out_active_mask[mt_batch_idx] = active_mask;
+        }
+    }
+    __syncthreads();
+
+    // PHASE 2: per-tile rasterization
+
+    // work-stealing: warps pull tiles from shared queue via atomics
+    const int32_t n_active_tiles = smem_queue_size;
+    int32_t queue_idx            = warp_id;
+
+#pragma unroll 1
+    while (queue_idx < n_active_tiles)
+    {
+        // rasterize one tile and write its RGBT to tile_buffer.
+        // tile_buffer layout is fixed: slot (batch_cta_idx, t) lives at index batch_cta_idx * MACRO_TILE_SIZE + t.
+        const int32_t tile_idx = smem_tile_queue[queue_idx];
+
+        // combined pixel offset: render-tile column + intra-tile pixel x, in macro-tile-relative tile units
+        const __half2 offset_x = __float2half2_rn(static_cast<float>(tile_idx % FUSED_MACRO_TILE_WIDTH) + px);
+        // combined pixel-pair offsets: render-tile row + intra-tile pixel y + per-pair row step
+        const __half2 base_y = __float2half2_rn(static_cast<float>(tile_idx / FUSED_MACRO_TILE_WIDTH) + py);
+
+        // distance in rows between even/odd lanes of the accumulator.
+        // for GAUSS_PER_WARP=2 each half-warp (16 lanes) covers the entire tile, so the row stride
+        // halves and N_PAIRS doubles compared to GAUSS_PER_WARP=1 — total pixel coverage per half is identical.
+        constexpr int32_t ROW_STRIDE  = (32 / GAUSS_PER_WARP) / TILE_SIZE;
+        constexpr float ROW_PAIR_STEP = ROW_STRIDE * INV_TILE_SIZE;
+        __half2 offset_y[N_PAIRS];
+#pragma unroll
+        for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+        {
+            offset_y[pp] = __hadd2(base_y, __floats2half2_rn((2 * pp) * ROW_PAIR_STEP, (2 * pp + 1) * ROW_PAIR_STEP));
+        }
+
+        constexpr int32_t TILE_SIZE_BYTES = TILE_SIZE * TILE_SIZE * 4 * sizeof(__half);
+        constexpr int32_t PAIR_STRIDE     = 32 * sizeof(uint4);
+
+        // seed accumulators to identity.
+        // For GAUSS_PER_WARP=2 the drain loop wipes half-B's slot back to identity at the
+        // start of every iteration, so half-B never needs a special seed: its
+        // identity init here just feeds into the (immediately overwritten) wipe.
+        TileAccum acc_rgbt;
+#pragma unroll
+        for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+        {
+            acc_rgbt[pp][0] = __float2half2_rn(0.f);
+            acc_rgbt[pp][1] = __float2half2_rn(0.f);
+            acc_rgbt[pp][2] = __float2half2_rn(0.f);
+            acc_rgbt[pp][3] = __float2half2_rn(1.f);
+        }
+
+        // ring-buffer rasterization: stream masks across mini-batches into a
+        // 64-entry queue, drain in 32-entry batches so the 8x-unrolled core
+        // always runs at full ILP.
+        constexpr int32_t QUEUE_MASK    = RASTERIZE_QUEUE_CAPACITY - 1;
+        constexpr int32_t DRAIN_BATCH   = RASTERIZE_QUEUE_CAPACITY / 2;
+        constexpr int32_t UNROLL_FACTOR = GAUSS_PER_WARP == 1 ? 8 : 4;
+
+        auto *warp_queue   = smem_warp_queue + warp_id * RASTERIZE_QUEUE_CAPACITY;
+        int32_t write_head = 0;
+        int32_t read_head  = 0;
+        int32_t mini_batch = 0;
+        uint32_t tile_done = 0;
+
+#pragma unroll 1
+        while (mini_batch < num_mini_batches || write_head > read_head)
+        {
+            // fill phase: stream masks into queue until >= DRAIN_BATCH entries or out of masks
+#pragma unroll 1
+            while (mini_batch < num_mini_batches && write_head - read_head < DRAIN_BATCH)
+            {
+                const uint32_t mask = smem_masks[mini_batch * MACRO_TILE_SIZE + tile_idx];
+                if (mask & (1u << lane_id))
+                {
+                    const int32_t pos = __popc(mask & ((1u << lane_id) - 1));
+
+                    warp_queue[(write_head + pos) & QUEUE_MASK] = mini_batch * MINI_BATCH_SIZE + lane_id;
+                }
+                write_head += __popc(mask);
+                ++mini_batch;
+            }
+            __syncwarp();
+
+            // process phase: drain up to DRAIN_BATCH entries
+            const int32_t count = min(write_head - read_head, DRAIN_BATCH);
+            const int32_t base  = read_head & QUEUE_MASK;
+            if constexpr (GAUSS_PER_WARP == 1)
+            {
+                const int32_t n_unrolled = count & ~(UNROLL_FACTOR - 1);
+#pragma unroll 1
+                for (int32_t q = 0; q < n_unrolled; q += UNROLL_FACTOR)
+                {
+                    static_assert(UNROLL_FACTOR == 4 || UNROLL_FACTOR == 8, "UNROLL_FACTOR must be 4 or 8");
+                    using VT = std::conditional_t<UNROLL_FACTOR == 4, uint2, uint4>;
+                    // let's use batched loads of queue indices to improve performance
+                    uint16_t b_idx[UNROLL_FACTOR];
+                    AssignAs<VT>(b_idx, warp_queue[base + q]);
+#pragma unroll
+                    for (int32_t i = 0; i < UNROLL_FACTOR; ++i)
+                    {
+                        rasterizeGaussian(b_idx[i], offset_x, offset_y, acc_rgbt);
+                    }
+                }
+                // tail
+#pragma unroll 1
+                for (int32_t q = n_unrolled; q < count; ++q)
+                {
+                    rasterizeGaussian(warp_queue[base + q], offset_x, offset_y, acc_rgbt);
+                }
+            }
+            else
+            {
+                // reset half-B's accumulator to identity so the next drain batch's compose
+                // adds half-B's fresh contributions on top of pure-identity; half-A carries
+                // forward the merged state to serve as the running "previous-merged" seed.
+                if (!is_half_a)
+                {
+#pragma unroll
+                    for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+                    {
+                        acc_rgbt[pp][0] = __float2half2_rn(0.f);
+                        acc_rgbt[pp][1] = __float2half2_rn(0.f);
+                        acc_rgbt[pp][2] = __float2half2_rn(0.f);
+                        acc_rgbt[pp][3] = __float2half2_rn(1.f);
+                    }
+                }
+
+                // GAUSS_PER_WARP=2 drain: half-A processes a contiguous prefix of the queue, half-B the
+                // suffix, so the compose below merges them in front-to-back order. Both halves
+                // run the same loop shape with their own (base, count) parameters.
+                const int32_t n_unroll_iters = count / (2 * UNROLL_FACTOR);
+                const int32_t n_unrolled     = n_unroll_iters * UNROLL_FACTOR;
+                const int32_t half_a_total   = (n_unroll_iters > 0) ? n_unrolled : ((count + 1) >> 1);
+
+                const int32_t unrolled_base = is_half_a ? base : (base + half_a_total);
+                const int32_t tail_base     = unrolled_base + n_unrolled;
+                const int32_t tail_count =
+                    is_half_a ? (half_a_total - n_unrolled) : (count - half_a_total - n_unrolled);
+
+#pragma unroll 1
+                for (int32_t q = 0; q < n_unrolled; q += UNROLL_FACTOR)
+                {
+                    static_assert(UNROLL_FACTOR == 4 || UNROLL_FACTOR == 8, "UNROLL_FACTOR must be 4 or 8");
+                    using VT = std::conditional_t<UNROLL_FACTOR == 4, uint2, uint4>;
+                    // each half-warp broadcasts UNROLL_FACTOR queue indices to its 16 lanes via
+                    // a single LDS with two aligned effective addresses (one per half).
+                    uint16_t b_idx[UNROLL_FACTOR];
+                    AssignAs<VT>(b_idx, warp_queue[unrolled_base + q]);
+#pragma unroll
+                    for (int32_t i = 0; i < UNROLL_FACTOR; ++i)
+                    {
+                        rasterizeGaussian(b_idx[i], offset_x, offset_y, acc_rgbt);
+                    }
+                }
+#pragma unroll 1
+                for (int32_t q = 0; q < tail_count; ++q)
+                {
+                    // no QUEUE_MASK wrap needed: same invariant as the unrolled phase
+                    // (base in {0, 32}, my_tail_base + q < QUEUE_CAPACITY).
+                    rasterizeGaussian(warp_queue[tail_base + q], offset_x, offset_y, acc_rgbt);
+                }
+
+                // half-warp merge: exchange accumulator state with the shfl_xor(16) partner,
+                // then redundantly compose A-on-top-of-B on both halves so every lane ends
+                // up holding the full merged GAUSS_PER_WARP=2 state. this lets the saturation test below
+                // (and the write-out's GAUSS_PER_WARP=2->GAUSS_PER_WARP=1 reshape) run without any half-warp masking.
+                TileAccum other;
+#pragma unroll
+                for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+                {
+#pragma unroll
+                    for (int32_t k = 0; k < 4; ++k)
+                    {
+                        other[pp][k] = __shfl_xor_sync(~0u, acc_rgbt[pp][k], 16);
+                    }
+                }
+#pragma unroll
+                for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+                {
+                    const __half2 a_r = is_half_a ? acc_rgbt[pp][0] : other[pp][0];
+                    const __half2 a_g = is_half_a ? acc_rgbt[pp][1] : other[pp][1];
+                    const __half2 a_b = is_half_a ? acc_rgbt[pp][2] : other[pp][2];
+                    const __half2 a_t = is_half_a ? acc_rgbt[pp][3] : other[pp][3];
+                    const __half2 b_r = is_half_a ? other[pp][0] : acc_rgbt[pp][0];
+                    const __half2 b_g = is_half_a ? other[pp][1] : acc_rgbt[pp][1];
+                    const __half2 b_b = is_half_a ? other[pp][2] : acc_rgbt[pp][2];
+                    const __half2 b_t = is_half_a ? other[pp][3] : acc_rgbt[pp][3];
+                    acc_rgbt[pp][0]   = __hfma2(a_t, b_r, a_r);
+                    acc_rgbt[pp][1]   = __hfma2(a_t, b_g, a_g);
+                    acc_rgbt[pp][2]   = __hfma2(a_t, b_b, a_b);
+                    acc_rgbt[pp][3]   = __hmul2(a_t, b_t);
+                }
+            }
+            read_head += count;
+
+            // early exit: all pixels in this tile saturated
+#pragma unroll
+            for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+            {
+                uint32_t stripe_done = __hlt2_mask(acc_rgbt[pp][3], __float2half2_rn(MIN_TRANSPARENCY));
+                if constexpr (N_PAIRS > 1)
+                {
+                    stripe_done &= (0x10001u << pp);
+                }
+                tile_done |= stripe_done;
+            }
+            // done bitmask: bits 0..N_PAIRS-1 = even pixels, bits 16..16+N_PAIRS-1 = odd pixels.
+            // for N_PAIRS == 1, use ~0u for all pixels done
+            constexpr uint32_t DONE_MASK = N_PAIRS == 1 ? ~0u : (((1u << N_PAIRS) - 1u) * 0x10001);
+
+            if (__ballot_sync(~0u, tile_done == DONE_MASK) == ~0u)
+            {
+                break;
+            }
+        }
+
+        // write tile — pair-major layout for coalesced access across the warp
+        const int64_t tile_base = static_cast<int64_t>(mt_batch_idx) * (MACRO_TILE_SIZE * TILE_SIZE_BYTES) +
+                                  tile_idx * TILE_SIZE_BYTES + lane_id * sizeof(uint4);
+        uint8_t *dst_ptr = reinterpret_cast<uint8_t *>(args.tile_buffer) + tile_base;
+        if constexpr (GAUSS_PER_WARP == 1)
+        {
+#pragma unroll
+            for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+            {
+                // let's use streaming stores since we're not going to touch this data anymore
+                uint4 val;
+                AssignAs<uint4>(val, acc_rgbt[pp]);
+                __stcs(reinterpret_cast<uint4 *>(dst_ptr + pp * PAIR_STRIDE), val);
+            }
+        }
+        else
+        {
+            // GAUSS_PER_WARP=2 write-out: reshape the merged GAUSS_PER_WARP=2 accumulator back to the tile_buffer's
+            // GAUSS_PER_WARP=1 (full-warp) layout. lane i and lane i+16 hold identical merged GAUSS_PER_WARP=2 data
+            // post-compose, so they extract complementary halves: half-A keeps the lows
+            // (lower GAUSS_PER_WARP=1 thread_y rows), half-B keeps the highs (upper thread_y rows).
+            constexpr int32_t N_PAIRS_OUT = N_PAIRS / 2;
+#pragma unroll
+            for (int32_t pp = 0; pp < N_PAIRS_OUT; ++pp)
+            {
+                __half2 out[4];
+#pragma unroll
+                for (int32_t k = 0; k < 4; ++k)
+                {
+                    out[k] = is_half_a ? __lows2half2(acc_rgbt[2 * pp][k], acc_rgbt[2 * pp + 1][k])
+                                       : __highs2half2(acc_rgbt[2 * pp][k], acc_rgbt[2 * pp + 1][k]);
+                }
+                uint4 val;
+                AssignAs<uint4>(val, out);
+                __stcs(reinterpret_cast<uint4 *>(dst_ptr + pp * PAIR_STRIDE), val);
+            }
+        }
+
+        // get next tile from queue
+        if (lane_id == 0)
+        {
+            queue_idx = atomicAdd(&smem_queue_idx, 1);
+        }
+        queue_idx = __shfl_sync(~0u, queue_idx, 0);
+    }
+
+}
+
+// post-blend kernel: composites partial RGBT batches into final image.
+// multiple warps per CTA, each warp independently processes one render tile.
+template<int32_t TILE_SIZE>
+__global__ void __launch_bounds__(BLEND_CTA_SIZE, BLEND_MIN_BLOCKS)
+    macro_tile_post_blend_kernel(const int32_t n_tiles, const int32_t tile_width, const int32_t macro_tile_cols,
+                                 const int32_t *__restrict__ mt_batch_offsets, const __half *__restrict__ tile_buffer,
+                                 const uint32_t *__restrict__ in_active_mask, const __half *__restrict__ backgrounds,
+                                 const uint32_t image_width, const uint32_t image_height,
+                                 __half *__restrict__ render_colors)
+{
+    static_assert(TILE_SIZE == 8 || TILE_SIZE == 16, "TILE_SIZE must be 8 or 16");
+    constexpr int32_t MACRO_TILE_SIZE   = FUSED_MACRO_TILE_WIDTH * FUSED_MACRO_TILE_HEIGHT;
+    constexpr int32_t WARPS_PER_CTA     = BLEND_CTA_SIZE / 32;
+    constexpr int32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / 32;
+    constexpr int32_t N_PAIRS           = PIXELS_PER_THREAD / 2;
+
+    using TileAccum = __half2[N_PAIRS][4];
+
+    const int32_t warp_id       = threadIdx.x >> 5;
+    const int32_t lane_id       = threadIdx.x & 31;
+    const int32_t flat_tile_idx = blockIdx.x * WARPS_PER_CTA + warp_id;
+
+    if (flat_tile_idx >= n_tiles)
+    {
+        return;
+    }
+
+    const int32_t tile_x = flat_tile_idx % tile_width;
+    const int32_t tile_y = flat_tile_idx / tile_width;
+
+    const int32_t mt_col = tile_x / FUSED_MACRO_TILE_WIDTH;
+    const int32_t mt_row = tile_y / FUSED_MACRO_TILE_HEIGHT;
+    const int32_t mt_id  = mt_row * macro_tile_cols + mt_col;
+    const int32_t local_rt =
+        (tile_y % FUSED_MACRO_TILE_HEIGHT) * FUSED_MACRO_TILE_WIDTH + (tile_x % FUSED_MACRO_TILE_WIDTH);
+
+    constexpr uint32_t TILE_X_MASK  = TILE_SIZE - 1;
+    constexpr uint32_t TILE_X_SHIFT = (TILE_SIZE == 16) ? 4 : 3;
+
+    const int32_t thread_x = lane_id & TILE_X_MASK;
+    const int32_t thread_y = lane_id >> TILE_X_SHIFT;
+    const int32_t out_x    = tile_x * TILE_SIZE + thread_x;
+
+    // per-pair accumulators: N_PAIRS x {R, G, B, T}
+    TileAccum acc_rgbt;
+#pragma unroll
+    for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+    {
+        acc_rgbt[pp][0] = __float2half2_rn(0.0f);
+        acc_rgbt[pp][1] = __float2half2_rn(0.0f);
+        acc_rgbt[pp][2] = __float2half2_rn(0.0f);
+        acc_rgbt[pp][3] = __float2half2_rn(1.0f);
+    }
+
+    const int32_t batch_start = mt_batch_offsets[mt_id];
+    const int32_t batch_end   = mt_batch_offsets[mt_id + 1];
+
+    constexpr int32_t TILE_SIZE_BYTES = TILE_SIZE * TILE_SIZE * 4 * sizeof(__half);
+    // pair-major layout: all 32 lanes' data for one pair contiguous, then next pair
+    constexpr int32_t PAIR_STRIDE = 32 * sizeof(uint4);
+
+    uint32_t tile_done = 0;
+#pragma unroll 1
+    for (int32_t batch_idx = batch_start; batch_idx < batch_end; ++batch_idx)
+    {
+        const uint32_t mask = in_active_mask[batch_idx];
+        if (!(mask & (1u << local_rt)))
+        {
+            continue;
+        }
+
+        // fixed layout: tile (batch_idx, local_rt) lives at slot batch_idx * MACRO_TILE_SIZE + local_rt
+        const int64_t pos =
+            static_cast<int64_t>(batch_idx) * (MACRO_TILE_SIZE * TILE_SIZE_BYTES) + local_rt * TILE_SIZE_BYTES;
+        const int64_t tile_base = pos + lane_id * sizeof(uint4);
+
+#pragma unroll
+        for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+        {
+            __half2 batch[4];
+            AssignAs<uint4>(batch, reinterpret_cast<const uint8_t *>(tile_buffer)[tile_base + pp * PAIR_STRIDE]);
+
+            acc_rgbt[pp][0] = __hfma2(acc_rgbt[pp][3], batch[0], acc_rgbt[pp][0]);
+            acc_rgbt[pp][1] = __hfma2(acc_rgbt[pp][3], batch[1], acc_rgbt[pp][1]);
+            acc_rgbt[pp][2] = __hfma2(acc_rgbt[pp][3], batch[2], acc_rgbt[pp][2]);
+            acc_rgbt[pp][3] = __hmul2(acc_rgbt[pp][3], batch[3]);
+
+            uint32_t is_done = __hlt2_mask(acc_rgbt[pp][3], __float2half2_rn(MIN_TRANSPARENCY));
+            if constexpr (N_PAIRS > 1)
+            {
+                is_done &= (0x10001u << pp);
+            }
+            tile_done |= is_done;
+        }
+
+        constexpr uint32_t DONE_MASK = N_PAIRS == 1 ? ~0u : (((1u << N_PAIRS) - 1u) * 0x10001);
+
+        // warp-wide early exit: all pixels in this tile are saturated
+        if (__ballot_sync(~0u, tile_done == DONE_MASK) == ~0u)
+        {
+            break;
+        }
+    }
+
+    if (out_x < image_width)
+    {
+        __half2 bg[2];
+        if (backgrounds != nullptr)
+        {
+            AssignAs<uint2>(bg, backgrounds[0]);
+        }
+        else
+        {
+            bg[0] = __float2half2_rn(0.0f);
+            bg[1] = __float2half2_rn(0.0f);
+        }
+
+        constexpr uint32_t ROW_STRIDE = 32 / TILE_SIZE;
+
+#pragma unroll
+        for (int32_t pp = 0; pp < N_PAIRS; ++pp)
+        {
+            const __half2 final_r = __hfma2(acc_rgbt[pp][3], __low2half2(bg[0]), acc_rgbt[pp][0]);
+            const __half2 final_g = __hfma2(acc_rgbt[pp][3], __high2half2(bg[0]), acc_rgbt[pp][1]);
+            const __half2 final_b = __hfma2(acc_rgbt[pp][3], __low2half2(bg[1]), acc_rgbt[pp][2]);
+
+            const uint32_t out_y0 = tile_y * TILE_SIZE + thread_y + (2 * pp) * ROW_STRIDE;
+            if (out_y0 < image_height)
+            {
+                const __half2 out[2] = {__lows2half2(final_r, final_g), __lows2half2(final_b, acc_rgbt[pp][3])};
+                AssignAs<uint2>(reinterpret_cast<uint2 *>(render_colors)[out_y0 * image_width + out_x], out);
+            }
+            const uint32_t out_y1 = out_y0 + ROW_STRIDE;
+            if (out_y1 < image_height)
+            {
+                const __half2 out[2] = {__highs2half2(final_r, final_g), __highs2half2(final_b, acc_rgbt[pp][3])};
+                AssignAs<uint2>(reinterpret_cast<uint2 *>(render_colors)[out_y1 * image_width + out_x], out);
+            }
+        }
+    }
+}
+
+// host launch wrappers
+
+void launch_macro_tile_rasterize(int32_t total_ctas, int32_t n_macro_tiles, int32_t macro_tile_cols, int32_t tile_size,
+                                 int32_t tile_width, int32_t tile_height, const at::Tensor &means2d,
+                                 const at::Tensor &conics, const at::Tensor &colors, const at::Tensor &mt_gauss_offsets,
+                                 const at::Tensor &mt_gauss_ids_sorted, const at::Tensor &mt_batch_offsets,
+                                 at::Tensor &tile_buffer, at::Tensor &active_mask)
+{
+    TORCH_CHECK(tile_size == 8 || tile_size == 16, "fused kernel supports tile_size 8 or 16, got ", tile_size);
+
+    if (total_ctas == 0)
+    {
+        return;
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    MacroTileRasterizeArgs kargs;
+    kargs.n_macro_tiles       = n_macro_tiles;
+    kargs.macro_tile_cols     = macro_tile_cols;
+    kargs.tile_width          = tile_width;
+    kargs.tile_height         = tile_height;
+    kargs.means2d             = means2d.data_ptr<float>();
+    kargs.conics              = reinterpret_cast<const __half *>(conics.data_ptr<at::Half>());
+    kargs.colors              = reinterpret_cast<const __half *>(colors.data_ptr<at::Half>());
+    kargs.mt_gauss_offsets    = mt_gauss_offsets.data_ptr<int32_t>();
+    kargs.mt_gauss_ids_sorted = mt_gauss_ids_sorted.data_ptr<int32_t>();
+    kargs.mt_batch_offsets    = mt_batch_offsets.data_ptr<int32_t>();
+    kargs.tile_buffer         = reinterpret_cast<__half *>(tile_buffer.data_ptr<at::Half>());
+    kargs.out_active_mask     = reinterpret_cast<uint32_t *>(active_mask.data_ptr<int32_t>());
+
+    auto launch = [&](auto kernel_fn) { kernel_fn<<<total_ctas, RASTERIZE_CTA_SIZE, 0, stream>>>(kargs); };
+
+    switch (tile_size)
+    {
+    case 16:
+        launch(macro_tile_rasterize_kernel<16>);
+        break;
+    case 8:
+        launch(macro_tile_rasterize_kernel<8>);
+        break;
+    }
+}
+
+void launch_macro_tile_post_blend(int32_t tile_width, int32_t tile_height, int32_t tile_size, int32_t n_macro_tiles,
+                                  int32_t macro_tile_cols, const at::Tensor &mt_batch_offsets,
+                                  const at::Tensor &tile_buffer, const at::Tensor &active_mask,
+                                  const at::Tensor &backgrounds, uint32_t image_width, uint32_t image_height,
+                                  at::Tensor &render_colors)
+{
+    TORCH_CHECK(tile_size == 8 || tile_size == 16, "post-blend supports tile_size 8 or 16, got ", tile_size);
+
+    constexpr int32_t WARPS_PER_CTA = BLEND_CTA_SIZE / 32;
+
+    const int32_t n_tiles = tile_width * tile_height;
+    const int32_t grid    = (n_tiles + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+
+    const __half *bg_ptr =
+        backgrounds.defined() ? reinterpret_cast<const __half *>(backgrounds.data_ptr<at::Half>()) : nullptr;
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    auto launch = [&](auto kernel_fn) {
+        kernel_fn<<<grid, BLEND_CTA_SIZE, 0, stream>>>(
+            n_tiles, tile_width, macro_tile_cols, mt_batch_offsets.data_ptr<int32_t>(),
+            reinterpret_cast<const __half *>(tile_buffer.data_ptr<at::Half>()),
+            reinterpret_cast<const uint32_t *>(active_mask.data_ptr<int32_t>()), bg_ptr, image_width, image_height,
+            reinterpret_cast<__half *>(render_colors.data_ptr<at::Half>()));
+    };
+
+    switch (tile_size)
+    {
+    case 16:
+        launch(macro_tile_post_blend_kernel<16>);
+        break;
+    case 8:
+        launch(macro_tile_post_blend_kernel<8>);
+        break;
+    }
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileRasterize.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileRasterize.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace higs {
+
+// Macro-tile rasterize: 1 warp (32 threads) per (macro-tile, batch) pair.
+// Each thread loads one gaussian to shared memory per mini-batch.
+// For each gaussian: thread t tests tile t overlap (__ballot_sync gives
+// 32-bit tile mask), then a compile-time unrolled loop over 32 tiles
+// rasterizes into register-resident per-tile accumulators.
+// Writes per-pixel partial RGBT to a sparse intermediate buffer.
+void launch_macro_tile_rasterize(int32_t total_ctas,                    // total batch items across all macro-tiles
+                                 int32_t n_macro_tiles,                 // number of macro-tiles
+                                 int32_t macro_tile_cols,               // macro-tile grid width
+                                 int32_t tile_size,                     // 8 or 16
+                                 int32_t tile_width,                    // render-tile grid width
+                                 int32_t tile_height,                   // render-tile grid height
+                                 const at::Tensor &means2d,             // [N, 2] float
+                                 const at::Tensor &conics,              // [N, 4] half {l0,l1,l2,opacity}
+                                 const at::Tensor &colors,              // [N, 4] half {R,G,B,0}
+                                 const at::Tensor &mt_gauss_offsets,    // [n_mt+1] macro-tile segment offsets
+                                 const at::Tensor &mt_gauss_ids_sorted, // [n_mt_isects] sorted gaussian IDs
+                                 const at::Tensor &mt_batch_offsets,    // [n_mt+1] gaussian batch start indices
+                                 at::Tensor &tile_buffer,     // fixed-layout partial RGBT
+                                 at::Tensor &active_mask);    // [total_ctas] uint32
+
+// Post-blend: 1 warp (32 threads) per render tile.  Walks batches of parent
+// macro-tile in order, reads partial RGBT from sparse tile_buffer, composites
+// front-to-back with transmittance early-out.
+void launch_macro_tile_post_blend(int32_t tile_width,                 // render-tile grid width
+                                  int32_t tile_height,                // render-tile grid height
+                                  int32_t tile_size,                  // 8 or 16
+                                  int32_t n_macro_tiles,              // number of macro-tiles
+                                  int32_t macro_tile_cols,            // macro-tile grid width
+                                  const at::Tensor &mt_batch_offsets, // [n_mt+1] gaussian batch start indices
+                                  const at::Tensor &tile_buffer,      // fixed-layout partial RGBT
+                                  const at::Tensor &active_mask,      // [total_ctas] uint32
+                                  const at::Tensor &backgrounds,      // [4] half {R,G,B,pad}
+                                  uint32_t image_width, uint32_t image_height,
+                                  at::Tensor &render_colors); // [H, W, 4] half {R,G,B,T} output
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/Projection.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/Projection.cu
@@ -1,0 +1,372 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/core/Tensor.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cooperative_groups.h>
+#include <cuda_fp16.h>
+
+#include "Common.h"
+#include "Constants.h"
+#include "SHCommon.h"
+#include "SHCompression.h"
+#include "Utils.cuh"
+#include "Projection.h"
+#include "Utils.h"
+
+namespace higs {
+
+static constexpr int CTA_SIZE         = 256;
+static constexpr int PROJ_MIN_BLOCKS  = 6;
+static constexpr int FUSED_MIN_BLOCKS = 4;
+
+using gsplat::CameraModelType;
+using gsplat::mat2;
+using gsplat::mat3;
+using gsplat::vec2;
+using gsplat::vec3;
+using gsplat::vec4;
+
+template<bool FUSE_SH, SHInputMode SH_MODE = SHInputMode::RAW_HALF>
+__global__ void __launch_bounds__(CTA_SIZE, FUSE_SH ? FUSED_MIN_BLOCKS : PROJ_MIN_BLOCKS)
+    projection_fwd_kernel(const uint32_t B, const uint32_t C, const uint32_t N,
+                          const float *__restrict__ means,    // [B, 3, N]
+                          const float *__restrict__ covars,   // [B, N, 6] optional
+                          const __half *__restrict__ inference,     // [B, N, 8] half — packed {quat(4), scale(3), opacity(1)}
+                          const float *__restrict__ viewmats, // [B, C, 4, 4]
+                          const float *__restrict__ Ks,       // [B, C, 3, 3]
+                          const uint32_t image_width, const uint32_t image_height, const float eps2d,
+                          const float near_plane, const float far_plane, const float radius_clip,
+                          const CameraModelType camera_model,
+                          // outputs
+                          uint32_t *__restrict__ visible,    // [(B*C*N+31)/32] packed bitfield
+                          float *__restrict__ means2d,       // [B, C, N, 2]
+                          float *__restrict__ depths,        // [B, C, N]
+                          __half *__restrict__ conics,       // [B, C, N, 4] half {l0,l1,l2,opacity}
+                          float *__restrict__ compensations, // [B, C, N] optional
+                          // SH parameters (used only when FUSE_SH=true; dead-code-eliminated otherwise)
+                          const int32_t degrees_to_use, const void *__restrict__ sh_input, const float sh_bias,
+                          const float sh_min_value, const SHDecodeParams sh_decode_params,
+                          __half *__restrict__ colors // [N, 4] half {R,G,B,0}
+    )
+{
+    // parallelize over B * C * N.
+    // OOB threads must not early-return — they participate in __ballot_sync.
+    const int32_t idx  = blockIdx.x * blockDim.x + threadIdx.x;
+    const int32_t lane = threadIdx.x & 31u;
+
+    auto processGaussian = [&]() -> bool {
+        if (idx >= B * C * N)
+        {
+            return false;
+        }
+        const int32_t bid = idx / (C * N); // batch id
+        const int32_t cid = (idx / N) % C; // camera id
+        const int32_t gid = idx % N;       // gaussian id
+
+        // shift pointers to the current camera and gaussian
+        const float *means_b    = means + bid * 3 * N;
+        const float *viewmats_b = viewmats + bid * C * 16 + cid * 16;
+        const float *Ks_b       = Ks + bid * C * 9 + cid * 9;
+
+        // planar [B, 3, N] layout: coalesced reads across threads
+        const vec3 mean_w = vec3(means_b[gid], means_b[N + gid], means_b[2 * N + gid]);
+
+        // glm is column-major but input is row-major
+        const mat3 R = mat3(viewmats_b[0], viewmats_b[4],
+                            viewmats_b[8], // 1st column
+                            viewmats_b[1], viewmats_b[5],
+                            viewmats_b[9], // 2nd column
+                            viewmats_b[2], viewmats_b[6],
+                            viewmats_b[10] // 3rd column
+        );
+        const vec3 t = vec3(viewmats_b[3], viewmats_b[7], viewmats_b[11]);
+
+        // transform Gaussian center to camera space
+        vec3 mean_c;
+        gsplat::posW2C(R, t, mean_w, mean_c);
+        if (mean_c.z < near_plane || mean_c.z > far_plane)
+        {
+            return false;
+        }
+
+        // Wide 128-bit load of packed {quat(4), scale(3), opacity(1)} in half
+        __half inference_local[8];
+        AssignAs<uint4>(inference_local[0], inference[(bid * N + gid) * 8]);
+
+        const vec4 quat  = vec4(__half2float(inference_local[0]), __half2float(inference_local[1]), __half2float(inference_local[2]),
+                                __half2float(inference_local[3]));
+        const vec3 scale = vec3(__half2float(inference_local[4]), __half2float(inference_local[5]), __half2float(inference_local[6]));
+        float opacity    = __half2float(inference_local[7]);
+
+        // transform Gaussian covariance to camera space
+        mat3 covar;
+        if (covars != nullptr)
+        {
+            const float *covars_g = covars + bid * N * 6 + gid * 6;
+
+            covar = mat3(covars_g[0], covars_g[1],
+                         covars_g[2], // 1st column
+                         covars_g[1], covars_g[3],
+                         covars_g[4], // 2nd column
+                         covars_g[2], covars_g[4],
+                         covars_g[5] // 3rd column
+            );
+        }
+        else
+        {
+            gsplat::quat_scale_to_covar_preci(quat, scale, &covar, nullptr);
+        }
+
+        mat3 covar_c;
+        gsplat::covarW2C(R, covar, covar_c);
+
+        // perspective projection
+        mat2 covar2d;
+        vec2 mean2d;
+
+        switch (camera_model)
+        {
+        case CameraModelType::PINHOLE:
+            gsplat::persp_proj(mean_c, covar_c, Ks_b[0], Ks_b[4], Ks_b[2], Ks_b[5], image_width, image_height, covar2d,
+                               mean2d);
+            break;
+        case CameraModelType::ORTHO:
+            gsplat::ortho_proj(mean_c, covar_c, Ks_b[0], Ks_b[4], Ks_b[2], Ks_b[5], image_width, image_height, covar2d,
+                               mean2d);
+            break;
+        case CameraModelType::FISHEYE:
+            gsplat::fisheye_proj(mean_c, covar_c, Ks_b[0], Ks_b[4], Ks_b[2], Ks_b[5], image_width, image_height,
+                                 covar2d, mean2d);
+            break;
+        }
+
+        float compensation;
+        const float det = gsplat::add_blur(eps2d, covar2d, compensation);
+        if (det <= 0.f)
+        {
+            return false;
+        }
+
+        // compute the inverse of the 2d covariance
+        const mat2 covar2d_inv = glm::inverse(covar2d);
+
+        float extend = MAX_EXTEND;
+        if (compensations != nullptr)
+        {
+            opacity *= compensation;
+        }
+        if (opacity < ALPHA_THRESHOLD)
+        {
+            return false;
+        }
+        extend = min(extend, sqrt(2.0f * __logf(opacity / ALPHA_THRESHOLD)));
+
+        // compute tight rectangular bounding box
+        float radius_x = extend * sqrtf(covar2d[0][0]);
+        float radius_y = extend * sqrtf(covar2d[1][1]);
+
+        // let's do the radius clip test prior ceil for finer fidelity of clipping
+        if (radius_x <= radius_clip && radius_y <= radius_clip)
+        {
+            return false;
+        }
+
+        radius_x = ceilf(radius_x);
+        radius_y = ceilf(radius_y);
+
+        // mask out gaussians outside the image region
+        if (mean2d.x + radius_x <= 0 || mean2d.x - radius_x >= image_width || mean2d.y + radius_y <= 0 ||
+            mean2d.y - radius_y >= image_height)
+        {
+            return false;
+        }
+
+        // write to outputs
+        AssignAs<float2>(means2d[idx * 2], mean2d);
+        depths[idx] = mean_c.z;
+        // Store Cholesky factor L of the inverse covariance: Sigma^{-1} = L*L^T,
+        // L = [[l0, 0], [l1, l2]].  Consumers reconstruct A=l0², B=l0*l1,
+        // C=l1²+l2² when needed.  This lets the rasterizer use the factors
+        // directly for a numerically stable sum-of-squares sigma in fp16.
+        const float ci_00 = covar2d_inv[0][0];
+        const float ci_01 = covar2d_inv[0][1];
+        const float ci_11 = covar2d_inv[1][1];
+        const float l0    = sqrtf(fmaxf(ci_00, 0.f));
+        const float l1    = (l0 > 1e-12f) ? ci_01 / l0 : 0.f;
+        const float l2    = sqrtf(fmaxf(ci_11 - l1 * l1, 0.f));
+
+        __half2 conics_opac[2];
+        conics_opac[0] = __floats2half2_rn(l0, l1);
+        conics_opac[1] = __floats2half2_rn(l2, opacity);
+        AssignAs<uint2>(conics[idx * 4], conics_opac);
+
+        if (compensations != nullptr)
+        {
+            compensations[idx] = compensation;
+        }
+
+        // Fused SH evaluation: mean_w, R, t are still in scope from the projection load above.
+        if constexpr (FUSE_SH)
+        {
+            // Camera world position: cam_pos = -R^T * t (R is column-major glm mat3)
+            const vec3 cam_w   = -glm::transpose(R) * t;
+            const float dx     = mean_w.x - cam_w.x;
+            const float dy     = mean_w.y - cam_w.y;
+            const float dz     = mean_w.z - cam_w.z;
+            const float inorm  = rsqrtf(dx * dx + dy * dy + dz * dz);
+            const float3 dir_n = make_float3(dx * inorm, dy * inorm, dz * inorm);
+            EvalSHForGaussian<SH_MODE>(dir_n, gid, N, degrees_to_use, sh_input, sh_bias, sh_min_value, sh_decode_params,
+                                       colors);
+        }
+
+        return true;
+    };
+
+    const bool is_visible   = processGaussian();
+    const uint32_t ballot   = __ballot_sync(~0u, is_visible);
+    const int32_t word_idx  = idx >> 5;
+    const int32_t num_words = (B * C * N + 31) >> 5;
+    if (lane == 0 && word_idx < num_words)
+    {
+        visible[word_idx] = ballot;
+    }
+}
+
+// ============================================================
+// Launch wrappers
+// ============================================================
+
+void launch_projection_fwd_kernel(
+    // inputs
+    const at::Tensor means, const at::optional<at::Tensor> covars, const at::Tensor inference, const at::Tensor viewmats,
+    const at::Tensor Ks, const uint32_t image_width, const uint32_t image_height, const float eps2d,
+    const float near_plane, const float far_plane, const float radius_clip, const gsplat::CameraModelType camera_model,
+    // outputs
+    at::Tensor visible, at::Tensor means2d, at::Tensor depths, at::Tensor conics,
+    at::optional<at::Tensor> compensations)
+{
+    uint32_t N = means.size(-1);
+    uint32_t C = viewmats.size(-3);
+    uint32_t B = means.numel() / (3 * N);
+
+    int64_t n_elements = B * C * N;
+    dim3 threads(CTA_SIZE);
+    dim3 grid((n_elements + threads.x - 1) / threads.x);
+
+    if (n_elements == 0)
+    {
+        return;
+    }
+
+    const float *covars_ptr = nullptr;
+    if (covars.has_value())
+    {
+        covars_ptr = covars.value().data_ptr<float>();
+    }
+    float *comp_ptr = nullptr;
+    if (compensations.has_value())
+    {
+        comp_ptr = compensations.value().data_ptr<float>();
+    }
+
+    projection_fwd_kernel<false><<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        B, C, N, means.data_ptr<float>(), covars_ptr, reinterpret_cast<const __half *>(inference.data_ptr<at::Half>()),
+        viewmats.data_ptr<float>(), Ks.data_ptr<float>(), image_width, image_height, eps2d, near_plane, far_plane,
+        radius_clip, camera_model, reinterpret_cast<uint32_t *>(visible.data_ptr<int32_t>()), means2d.data_ptr<float>(),
+        depths.data_ptr<float>(), reinterpret_cast<__half *>(conics.data_ptr<at::Half>()), comp_ptr,
+        // SH params (unused, dead-code-eliminated)
+        0, nullptr, 0.f, 0.f, SHDecodeParams{}, nullptr);
+}
+
+void launch_projection_sh_fused_kernel(
+    // inputs
+    const at::Tensor means, const at::optional<at::Tensor> covars, const at::Tensor inference, const at::Tensor viewmats,
+    const at::Tensor Ks, const uint32_t image_width, const uint32_t image_height, const float eps2d,
+    const float near_plane, const float far_plane, const float radius_clip, const gsplat::CameraModelType camera_model,
+    // SH inputs
+    const int32_t degrees_to_use, const at::Tensor sh_input, const float bias, const float min_value,
+    const SHCompressionMode mode, const SHDecodeParams *decode_params,
+    // outputs
+    at::Tensor visible, at::Tensor means2d, at::Tensor depths, at::Tensor conics, at::Tensor colors,
+    at::optional<at::Tensor> compensations)
+{
+    uint32_t N = means.size(-1);
+    uint32_t C = viewmats.size(-3);
+    uint32_t B = means.numel() / (3 * N);
+
+    int64_t n_elements = B * C * N;
+    dim3 threads(CTA_SIZE);
+    dim3 grid((n_elements + threads.x - 1) / threads.x);
+
+    if (n_elements == 0)
+    {
+        return;
+    }
+
+    const float *covars_ptr = nullptr;
+    if (covars.has_value())
+    {
+        covars_ptr = covars.value().data_ptr<float>();
+    }
+    float *comp_ptr = nullptr;
+    if (compensations.has_value())
+    {
+        comp_ptr = compensations.value().data_ptr<float>();
+    }
+
+    const SHDecodeParams dp = decode_params ? *decode_params : SHDecodeParams{};
+    auto stream             = at::cuda::getCurrentCUDAStream();
+    auto *vis_ptr           = reinterpret_cast<uint32_t *>(visible.data_ptr<int32_t>());
+    auto *means2d_ptr       = means2d.data_ptr<float>();
+    auto *depths_ptr        = depths.data_ptr<float>();
+    auto *conics_ptr        = reinterpret_cast<__half *>(conics.data_ptr<at::Half>());
+    auto *colors_ptr        = reinterpret_cast<__half *>(colors.data_ptr<at::Half>());
+
+    auto launch = [&](auto mode_tag, const void *sh_data_ptr) {
+        constexpr SHInputMode MODE = decltype(mode_tag)::value;
+        projection_fwd_kernel<true, MODE><<<grid, threads, 0, stream>>>(
+            B, C, N, means.data_ptr<float>(), covars_ptr, reinterpret_cast<const __half *>(inference.data_ptr<at::Half>()),
+            viewmats.data_ptr<float>(), Ks.data_ptr<float>(), image_width, image_height, eps2d, near_plane, far_plane,
+            radius_clip, camera_model, vis_ptr, means2d_ptr, depths_ptr, conics_ptr, comp_ptr, degrees_to_use,
+            sh_data_ptr,
+            bias, min_value, dp, colors_ptr);
+    };
+
+    if (mode == SHCompressionMode::COMPRESS_32B)
+    {
+        launch(std::integral_constant<SHInputMode, SHInputMode::COMPRESS_32B>{},
+               static_cast<const void *>(sh_input.data_ptr<int32_t>()));
+    }
+    else if (mode == SHCompressionMode::COMPRESS_16B)
+    {
+        launch(std::integral_constant<SHInputMode, SHInputMode::COMPRESS_16B>{},
+               static_cast<const void *>(sh_input.data_ptr<int32_t>()));
+    }
+    else if (sh_input.scalar_type() == at::kFloat)
+    {
+        launch(std::integral_constant<SHInputMode, SHInputMode::RAW_FLOAT>{},
+               static_cast<const void *>(sh_input.data_ptr<float>()));
+    }
+    else
+    {
+        launch(std::integral_constant<SHInputMode, SHInputMode::RAW_HALF>{},
+               static_cast<const void *>(sh_input.data_ptr<at::Half>()));
+    }
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/Projection.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/Projection.h
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "InferenceTypes.h"
+
+#include <ATen/core/Tensor.h>
+#include <cstdint>
+
+// Need CameraModelType from gsplat
+#include "Common.h"
+
+namespace higs {
+
+struct SHDecodeParams; // defined in SHCompression.h (CUDA-only)
+
+// Projection-only launch (FUSE_SH=false). Supports arbitrary B, C.
+void launch_projection_fwd_kernel(
+    // inputs
+    const at::Tensor means,                // [3, N]
+    const at::optional<at::Tensor> covars, // [N, 6] optional
+    const at::Tensor inference,                  // [N, 8] half — packed {quat(4), scale(3), opacity(1)}
+    const at::Tensor viewmats,             // [1, 1, 4, 4]
+    const at::Tensor Ks,                   // [1, 1, 3, 3]
+    const uint32_t image_width, const uint32_t image_height, const float eps2d, const float near_plane,
+    const float far_plane, const float radius_clip, const gsplat::CameraModelType camera_model,
+    // outputs
+    at::Tensor visible,                    // [(N+31)/32] int32 packed bitfield
+    at::Tensor means2d,                    // [1, 1, N, 2]
+    at::Tensor depths,                     // [1, 1, N]
+    at::Tensor conics,                     // [1, 1, N, 4] half {l0,l1,l2,opacity}
+    at::optional<at::Tensor> compensations // [1, 1, N] optional
+);
+
+// Fused projection + SH evaluation launch (FUSE_SH=true).
+// Camera world position is derived from viewmats inside the kernel.
+void launch_projection_sh_fused_kernel(
+    // inputs
+    const at::Tensor means,                // [B, 3, N]
+    const at::optional<at::Tensor> covars, // [B, N, 6] optional
+    const at::Tensor inference,                  // [B, N, 8] half
+    const at::Tensor viewmats,             // [B, C, 4, 4]
+    const at::Tensor Ks,                   // [B, C, 3, 3]
+    const uint32_t image_width, const uint32_t image_height, const float eps2d, const float near_plane,
+    const float far_plane, const float radius_clip, const gsplat::CameraModelType camera_model,
+    // SH inputs
+    const int32_t degrees_to_use,
+    const at::Tensor sh_input, // [N, K, 3] half (uncompressed) OR [M, 4] int32 (compressed)
+    const float bias, const float min_value, const SHCompressionMode mode, const SHDecodeParams *decode_params,
+    // outputs
+    at::Tensor visible,                    // [(N+31)/32] int32 packed bitfield
+    at::Tensor means2d,                    // [1, 1, N, 2]
+    at::Tensor depths,                     // [1, 1, N]
+    at::Tensor conics,                     // [1, 1, N, 4] half
+    at::Tensor colors,                     // [N, 4] half {R,G,B,0}
+    at::optional<at::Tensor> compensations // [1, 1, N] optional
+);
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCommon.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCommon.h
@@ -1,0 +1,759 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cstdint>
+#include "SHCompression.h"
+#include "Utils.h"
+
+namespace higs {
+
+// input mode for the unified K=16 SH evaluation kernel
+enum class SHInputMode
+{
+    RAW_FLOAT,
+    RAW_HALF,
+    COMPRESS_32B,
+    COMPRESS_16B
+};
+
+// 32-byte SH coefficient compression for K=16 (degree 3).
+//
+// Packed layout (256 bits = 8 × uint32):
+//
+//   block[0] bits  0..15: DC_Y fp16 (16 bits, lossless)
+//   block[0] bits 16..30: DC_Co fp15 (fp16 >> 1, drop mantissa LSB)
+//   block[0] bit  31:     DC_Cg fp15 bit 14 (MSB)
+//
+//   CoCg interleaved region (uint32-aligned, k=2..15, unsigned bias U1 encoding):
+//     block[1]: [Co2|Cg2, Co3|Cg3, Co4|Cg4, Co5|Cg5]   each byte = (qCo+8)<<4 | (qCg+8)
+//     block[2]: [Co6|Cg6, Co7|Cg7, Co8|Cg8, Co9|Cg9]
+//     block[3]: [Co10|Cg10, Co11|Cg11, Co12|Cg12, Co13|Cg13]
+//     block[4] bits 0..15: [Co14|Cg14, Co15|Cg15]
+//
+//   Remaining region (112 bits in block[4] bits 16..31 + block[5..7]):
+//     bits  0..13:  DC_Cg fp15 low 14 bits (total Cg = 1 + 14 = 15 bits)
+//     bits 14..19:  k=1 Y  (6-bit unsigned bias: qY+32)
+//     bits 20..23:  k=1 Co (4-bit unsigned bias: qCo+8)
+//     bits 24..27:  k=1 Cg (4-bit unsigned bias: qCg+8)
+//     bits 28..33:  Y2  (6-bit unsigned bias: qY+32) ─┐
+//     bits 34..39:  Y3                                  │ 14 × 6-bit Y values
+//     bits 40..45:  Y4                                  │ for k=2..15
+//     ...                                               │ (funnel shift extraction)
+//     bits 106..111: Y15                               ─┘
+//
+//   HO quantization: signed q ∈ [-(max_q+1), max_q] stored as unsigned (q + max_q + 1).
+//     Y:    6-bit, max_q=31, stored as (q+32) ∈ [0,63], spread to uint8 as (q+32)<<2
+//     CoCg: 4-bit, max_q=7,  stored as (q+8)  ∈ [0,15], spread to uint8 as (q+8)<<4
+//   Decoder uses __uint8x4_to_half4 (no sign correction needed), then FMA:
+//     normalized = val * inv_norm + offset   (offset = -(max_q+1)/max_q)
+//
+//   Per-basis scaling: each SH basis k has its own Y/Co/Cg scale factor (p99.99 percentile).
+//   Scales are stored in SHDecodeParams (half2[8] per channel) for the decoder and
+//   SHEncodeParams (float[16] per channel) for the encoder.
+//
+//   Bit budget: 32 + 96 + 16 + 14 + 14 + 84 = 256 bits ✓
+//
+// Constants for SH degree-0 basis and 3DGS color bias.
+static constexpr float SH_Y00  = 0.2820947917738781f;
+static constexpr float SH_BIAS = 0.5f;
+
+// Convert any element type to float (works under __CUDA_NO_HALF_CONVERSIONS__).
+template<typename T>
+__device__ __forceinline__ float _sh_to_float(T v) { return static_cast<float>(v); }
+template<>
+__device__ __forceinline__ float _sh_to_float<__half>(__half v) { return __half2float(v); }
+
+// Encode K=16 SH coefficients into 32-byte packed representation.
+// T = float or __half.
+// coeffs:      input [3][16] — channel-first (R/G/B × 16 bases), caller loads.
+// block:       output [8] uint32 — caller stores.
+// inv_scales:  per-basis inverse scales (float arrays, indexed by basis k).
+// Fixed gamma = 1/2 — matches decoder's square_signed_h2 in Phase 2.
+template<typename T>
+__device__ void sh_encode_32b(const T (&coeffs)[3][16], uint32_t (&block)[8], const float (&inv_scales)[3][16])
+{
+    // Linear RGB → YCoCg-R-style luma/chroma basis used by the codec.
+    auto rgb_to_ycocg = [](float R, float G, float B, float &Y, float &Co, float &Cg) {
+        Y  = 0.25f * R + 0.5f * G + 0.25f * B;
+        Co = 0.5f * R - 0.5f * B;
+        Cg = -0.25f * R + 0.5f * G - 0.25f * B;
+    };
+
+    // Quantize to the float domain consumed by __cvt_pack_sat_u8_f32.
+    // Full two's complement range: q ∈ [-(max_q+1), max_q], stored as q + (max_q+1) ∈ [0, 2*max_q+1].
+    // Matches the decoder: normalized = q/max_q via FMA(stored*spread, inv_norm, offset).
+    // `roundf` is used explicitly (round half away from zero) because __cvt_pack_sat_u8_f32
+    // does cvt.rni (round half to even) which tiebreaks differently at bin boundaries and
+    // can shift reconstructed values by ~0.1 near the edge of range (where post-square bin
+    // width is large). Pre-rounding yields an integer-valued float so the hardware rni is
+    // idempotent; saturation in the pack still clamps to [0, 255] as a safety net.
+    auto quantize_u1f = [](float val, float inv_scale, float max_q) -> float {
+        float norm       = val * inv_scale;
+        float compressed = copysignf(sqrtf(fabsf(norm)), norm);
+        float q          = fminf(fmaxf(roundf(compressed * max_q), -(max_q + 1.0f)), max_q);
+        return q + (max_q + 1.0f);
+    };
+
+    // --- DC (k=0) : YCoCg in fp16 / fp15 / fp15 ---
+    float R0 = _sh_to_float(coeffs[0][0]) * SH_Y00 + SH_BIAS;
+    float G0 = _sh_to_float(coeffs[1][0]) * SH_Y00 + SH_BIAS;
+    float B0 = _sh_to_float(coeffs[2][0]) * SH_Y00 + SH_BIAS;
+
+    float dc_Y, dc_Co, dc_Cg;
+    rgb_to_ycocg(R0, G0, B0, dc_Y, dc_Co, dc_Cg);
+
+    uint16_t y_bits;
+    AssignAs<uint16_t>(y_bits, __float2half(dc_Y));
+    const __half2 tr_cocg = RoundToNearest<9, false>(__floats2half2_rn(dc_Co, dc_Cg));
+    const uint32_t co15   = (reinterpret_cast<const uint32_t &>(tr_cocg) >> 1) & 0x7FFF;
+    const uint32_t cg15   = (reinterpret_cast<const uint32_t &>(tr_cocg) >> 17) & 0x7FFF;
+    block[0]              = static_cast<uint32_t>(y_bits) | (co15 << 16) | ((cg15 >> 14) << 31);
+
+    // --- k=1 (HO head): 6-bit Y + 4-bit Co + 4-bit Cg, all biased ---
+    // One __cvt_pack_sat_u8_f32 gives us {uY, uCo, uCg, 0} in a u8x4.
+    float Y1, Co1, Cg1;
+    {
+        float R = _sh_to_float(coeffs[0][1]);
+        float G = _sh_to_float(coeffs[1][1]);
+        float B = _sh_to_float(coeffs[2][1]);
+        rgb_to_ycocg(R, G, B, Y1, Co1, Cg1);
+    }
+    const uint32_t k1_u8x4 =
+        __cvt_pack_sat_u8_f32(quantize_u1f(Y1, inv_scales[0][1], 31.f), quantize_u1f(Co1, inv_scales[1][1], 7.f),
+                              quantize_u1f(Cg1, inv_scales[2][1], 7.f), 0.f);
+
+    // --- HO groups g=0..3 spanning k=2..15 ---
+    // Each group produces one CoCg output word + one 24-bit Y chunk.
+    // Group 3 only has k=14,15 live; the rest is zero-padded and the CoCg tail
+    // uses pack_4x8_to_4x4 into the low 16 bits of block[4].
+    uint32_t y_packed[4];
+    uint32_t cocg_tail16 = 0;
+#pragma unroll
+    for (int g = 0; g < 4; g++)
+    {
+        float Yg[4]  = {0.f, 0.f, 0.f, 0.f};
+        float Cog[4] = {0.f, 0.f, 0.f, 0.f};
+        float Cgg[4] = {0.f, 0.f, 0.f, 0.f};
+#pragma unroll
+        for (int j = 0; j < 4; j++)
+        {
+            const int k = 2 + g * 4 + j;
+            if (k <= 15)
+            {
+                float R = _sh_to_float(coeffs[0][k]);
+                float G = _sh_to_float(coeffs[1][k]);
+                float B = _sh_to_float(coeffs[2][k]);
+                rgb_to_ycocg(R, G, B, Yg[j], Cog[j], Cgg[j]);
+            }
+        }
+
+        // Compress u8x4 of 4 Y lanes (each ≤ 0x3F) into a 24-bit field:
+        //   Y0 | (Y1<<6) | (Y2<<12) | (Y3<<18). Top 2 bits of each byte are dropped.
+        const int k_base    = 2 + g * 4;
+        const uint32_t Y_u8 = __cvt_pack_sat_u8_f32(
+            quantize_u1f(Yg[0], inv_scales[0][k_base], 31.f), quantize_u1f(Yg[1], inv_scales[0][k_base + 1], 31.f),
+            quantize_u1f(Yg[2], inv_scales[0][k_base + 2], 31.f), quantize_u1f(Yg[3], inv_scales[0][k_base + 3], 31.f));
+        y_packed[g] =
+            (Y_u8 & 0x3Fu) | ((Y_u8 & 0x3F00u) >> 2) | ((Y_u8 & 0x3F0000u) >> 4) | ((Y_u8 & 0x3F000000u) >> 6);
+
+        if (g < 3)
+        {
+            // Bytes will be (qCo+8)<<4 | (qCg+8) as the decoder expects.
+            const uint32_t Co_u8 = __cvt_pack_sat_u8_f32(quantize_u1f(Cog[0], inv_scales[1][k_base], 7.f),
+                                                         quantize_u1f(Cog[1], inv_scales[1][k_base + 1], 7.f),
+                                                         quantize_u1f(Cog[2], inv_scales[1][k_base + 2], 7.f),
+                                                         quantize_u1f(Cog[3], inv_scales[1][k_base + 3], 7.f));
+            const uint32_t Cg_u8 = __cvt_pack_sat_u8_f32(quantize_u1f(Cgg[0], inv_scales[2][k_base], 7.f),
+                                                         quantize_u1f(Cgg[1], inv_scales[2][k_base + 1], 7.f),
+                                                         quantize_u1f(Cgg[2], inv_scales[2][k_base + 2], 7.f),
+                                                         quantize_u1f(Cgg[3], inv_scales[2][k_base + 3], 7.f));
+            block[1 + g]         = (Co_u8 << 4) | Cg_u8;
+        }
+        else
+        {
+            // Tail: k=14,15 live in lanes 0,1; interleave {Cg14, Co14, Cg15, Co15} and
+            // compress u8x4 (each lane ≤ 0xF) into a 16-bit field by dropping the top
+            // nibble of every byte, yielding bytes [(Co14<<4)|Cg14, (Co15<<4)|Cg15].
+            const uint32_t tail_u8 = __cvt_pack_sat_u8_f32(quantize_u1f(Cgg[0], inv_scales[2][k_base], 7.f),
+                                                           quantize_u1f(Cog[0], inv_scales[1][k_base], 7.f),
+                                                           quantize_u1f(Cgg[1], inv_scales[2][k_base + 1], 7.f),
+                                                           quantize_u1f(Cog[1], inv_scales[1][k_base + 1], 7.f));
+            cocg_tail16            = (tail_u8 & 0xFu) | ((tail_u8 & 0xF00u) >> 4) | ((tail_u8 & 0xF0000u) >> 8) |
+                          ((tail_u8 & 0xF000000u) >> 12);
+        }
+    }
+
+    // --- Remaining 112-bit stream: block[4] hi16 + block[5..7] ---
+    // 28-bit header packs cg15_lo14 | uY1(6) | uCo1(4) | uCg1(4).
+    // k1_u8x4 byte layout: [uY1, uCo1, uCg1, 0] → shift each into place.
+    const uint32_t hdr28 = (cg15 & 0x3FFFu)                    // bits  0..13
+                           | ((k1_u8x4 & 0x3Fu) << 14)         // bits 14..19: uY (6 bits)
+                           | (((k1_u8x4 >> 8) & 0xFu) << 20)   // bits 20..23: uCo (4 bits)
+                           | (((k1_u8x4 >> 16) & 0xFu) << 24); // bits 24..27: uCg (4 bits)
+
+    // Four 24-bit Y chunks placed contiguously starting at bit 28 of the 128-bit stream.
+    // Simple shifts+OR here (not funnel shifts): y_packed[] are 24-bit payloads with
+    // zero high 8 bits, so naive funnel shift would inject those zeros into the seam.
+    uint32_t rem[4];
+    rem[0] = hdr28 | (y_packed[0] << 28);
+    rem[1] = (y_packed[0] >> 4) | (y_packed[1] << 20);
+    rem[2] = (y_packed[1] >> 12) | (y_packed[2] << 12);
+    rem[3] = (y_packed[2] >> 20) | (y_packed[3] << 4);
+
+    // Final 32-bit stitch between rem[] words and the pre-filled block[4] low 16
+    // is a plain 16-bit funnel shift since rem[] are fully populated.
+    block[4] = cocg_tail16 | (rem[0] << 16);
+    block[5] = __funnelshift_l(rem[0], rem[1], 16);
+    block[6] = __funnelshift_l(rem[1], rem[2], 16);
+    block[7] = __funnelshift_l(rem[2], rem[3], 16);
+}
+
+// Decode 32-byte packed SH coefficients to fp16 SoA.
+// block:      input [8] uint32 — caller loads.
+// out_coeffs: output [3][8] half2 — [R/G/B][pair0..7], 16 bases as 8 half2 pairs.
+//             Pair 0 = {k=0, k=1}, pair 1 = {k=2, k=3}, ..., pair 7 = {k=14, k=15}.
+// scales:     per-basis decoder scales (half2[8] per channel, pair 0 low = 1.0 for DC).
+//
+// Two-phase design:
+//   Phase 1: extract all U1-biased quantized values → __uint8x4_to_half4 → fp16 arrays
+//   Phase 2: uniform half2: FMA(val, inv_norm, offset) → x^2 → scale → YCoCg→RGB
+// Fixed inv_gamma = 2 (gamma = 1/2): x^2 with sign copy, pure half2 SIMD, no transcendentals.
+__device__ inline void sh_decode_32b(const uint32_t (&block)[8], __half2 (&out_coeffs)[3][8],
+                                     const __half2 (&scales)[3][8])
+{
+    // ===== Phase 1: Extract all values into fp16 arrays =====
+
+    __half Y[16], Co[16], Cg[16];
+
+    // --- DC (k=0): Y fp16 (16) + Co fp15 (15) + Cg fp15 (15) = 46 bits ---
+    // Y: full fp16 from block[0] bits 0..15
+    AssignAs<uint16_t>(Y[0], block[0]);
+
+    // Co fp15: block[0] bits 17..31
+    AssignAs<uint16_t>(Co[0], (block[0] >> 15) & 0xFFFEu);
+
+    // Cg fp15: bit 15 from block[0] bit 31, bits 1..14 from remaining region
+    AssignAs<uint16_t>(Cg[0], ((block[0] >> 16) & 0x8000u) | ((block[4] >> 15) & 0x7FFEu));
+
+    // --- k=1: extract from remaining region ---
+    const uint32_t k1_raw = __funnelshift_rc(block[4], block[5], 30);
+    const __half2 k1_cocg = __uint8x2_to_half2(((k1_raw >> 2) & 0xF0u) | ((k1_raw << 2) & 0xF000u));
+
+    Y[1]  = __uint2half_rn((k1_raw << 2) & 0xFFu);
+    Co[1] = __low2half(k1_cocg);
+    Cg[1] = __high2half(k1_cocg);
+
+    // --- CoCg k=2..15: 3 clean uint32 reads + 1 partial ---
+    // Bytes are (qCo+8)<<4 | (qCg+8). Upper nibble = Co uint4, lower = Cg uint4.
+    // After masking: upper nibble already in uint8 position for __uint8x4_to_half4.
+#pragma unroll
+    for (int i = 0; i < 3; i++)
+    {
+        const uint32_t co_u8 = block[1 + i] & 0xF0F0F0F0u;        // Co nibbles in upper nibble of each byte
+        const uint32_t cg_u8 = (block[1 + i] & 0x0F0F0F0Fu) << 4; // Cg nibbles shifted to upper nibble
+        __uint8x4_to_half4(&Co[i * 4 + 2], co_u8);
+        __uint8x4_to_half4(&Cg[i * 4 + 2], cg_u8);
+    }
+    // partial pair decode for k=14, k=15
+    AssignAs<__half2>(Co[14], __uint8x2_to_half2(block[4] & 0xF0F0u));
+    AssignAs<__half2>(Cg[14], __uint8x2_to_half2((block[4] & 0x0F0Fu) << 4));
+
+    // --- Y k=2..15: funnel shift extraction (14×6-bit unsigned bias) ---
+    // Y data at rem bit 28 → absolute block[5] bit 12.
+    auto spread_6bit_to_uint8x4 = [](uint32_t packed_6x4) -> uint32_t {
+        const uint32_t lo = __select(0x003FC0u, packed_6x4 << 2, packed_6x4);
+        const uint32_t hi = __select(0xFF0000u, packed_6x4, packed_6x4 >> 2);
+        return __prmt_idx(lo << 2, hi, 0x6510) & 0xFCFCFCFCu;
+    };
+
+    // k=2..13: 3 full batches of 4 at half2-aligned offsets
+#pragma unroll
+    for (int batch = 0; batch < 3; batch++)
+    {
+        const int bit_offset = 12 + batch * 24;
+        const int word_idx   = 5 + bit_offset / 32;
+        const int shift      = bit_offset % 32;
+
+        __uint8x4_to_half4(&Y[2 + batch * 4],
+                           spread_6bit_to_uint8x4(__funnelshift_rc(block[word_idx], block[word_idx + 1], shift)));
+    }
+
+    // k=14..15: pair write to avoid out-of-bounds Y[16]
+    AssignAs<__half2>(Y[14], __uint8x2_to_half2(((block[7] >> 18) & 0xFCu) | ((block[7] >> 16) & 0xFC00u)));
+
+    // ===== Phase 2: Uniform half2 arithmetic =====
+    //
+    // U1 decode: val * inv_norm gives (q + max_q + 1) / max_q.
+    // FMA with offset (-(max_q+1)/max_q) gives q / max_q.
+    // Then x^2 with sign copy (fixed inv_gamma=2), then per-basis scale.
+
+    constexpr float INV_NORM_Y    = 1.0f / (4.0f * 31.0f);
+    constexpr float INV_NORM_COCG = 1.0f / (16.0f * 7.0f);
+
+    // Y:    uint8 = (q+32)<<2 → fp16 = (q+32)*4 → *(1/(4*31)) - 32/31 = q/31
+    // CoCg: uint8 = (q+8)<<4  → fp16 = (q+8)*16 → *(1/(16*7)) - 8/7  = q/7
+
+    // x^2 with sign copy in half2: pure SIMD, no float conversion, no transcendentals.
+    auto square_signed_h2 = [](__half2 v) -> __half2 { return __h2_copy_sign(__hmul2(v, v), v); };
+    auto square_signed_h  = [](__half v) -> __half { return __h_copy_sign(__hmul(v, v), v); };
+
+    __half2 *Y_h2  = reinterpret_cast<__half2 *>(Y);
+    __half2 *Co_h2 = reinterpret_cast<__half2 *>(Co);
+    __half2 *Cg_h2 = reinterpret_cast<__half2 *>(Cg);
+
+    // Normalize + x^2 + scale for HO (pairs 1..7 fully, pair 0 high lane = k=1)
+    // Pair 0 low lane is DC YCoCg — not int-N quantized, skip normalization.
+    // Handle k=1 separately, then pairs 1..7 uniformly.
+    const __half2 inv_norm_y    = __float2half2_rn(INV_NORM_Y);
+    const __half2 inv_norm_cocg = __float2half2_rn(INV_NORM_COCG);
+    // FMA offsets: -(max_q+1)/max_q to account for the asymmetric bias (stored = q + max_q + 1).
+    constexpr float OFFSET_Y    = -32.0f / 31.0f;
+    constexpr float OFFSET_COCG = -8.0f / 7.0f;
+    const __half2 offset_y      = __float2half2_rn(OFFSET_Y);
+    const __half2 offset_cocg   = __float2half2_rn(OFFSET_COCG);
+
+    // Normalize + inv-gamma for k=1 (scalar, high lane of pair 0)
+    Y[1]          = square_signed_h(__hfma(Y[1], __float2half_rn(INV_NORM_Y), __float2half_rn(OFFSET_Y)));
+    __half2 cocg1 = __highs2half2(Co_h2[0], Cg_h2[0]);
+    cocg1         = square_signed_h2(__hfma2(cocg1, inv_norm_cocg, offset_cocg));
+    Co[1]         = __low2half(cocg1);
+    Cg[1]         = __high2half(cocg1);
+
+    // Normalize + inv-gamma for pairs 1..7
+#pragma unroll
+    for (int p = 1; p < 8; p++)
+    {
+        Y_h2[p]  = square_signed_h2(__hfma2(Y_h2[p], inv_norm_y, offset_y));
+        Co_h2[p] = square_signed_h2(__hfma2(Co_h2[p], inv_norm_cocg, offset_cocg));
+        Cg_h2[p] = square_signed_h2(__hfma2(Cg_h2[p], inv_norm_cocg, offset_cocg));
+    }
+
+#pragma unroll
+    for (int p = 0; p < 8; p++)
+    {
+        // Apply per-basis scales (pair 0 DC lane = 1.0, so DC is unmodified)
+        Y_h2[p]  = __hmul2(Y_h2[p], scales[0][p]);
+        Co_h2[p] = __hmul2(Co_h2[p], scales[1][p]);
+        Cg_h2[p] = __hmul2(Cg_h2[p], scales[2][p]);
+
+        // YCoCg → RGB for all 8 pairs (DC included — DC is in YCoCg color space)
+        const __half2 Y_sub_Cg = __hsub2(Y_h2[p], Cg_h2[p]);
+        out_coeffs[0][p]       = __hadd2(Y_sub_Cg, Co_h2[p]);
+        out_coeffs[1][p]       = __hadd2(Y_h2[p], Cg_h2[p]);
+        out_coeffs[2][p]       = __hsub2(Y_sub_Cg, Co_h2[p]);
+    }
+
+    // DC fixup (pair 0 low lane only): YCoCg→RGB produced the color, undo color transform.
+    // coeff = color * (1/Y_00) + (-SH_BIAS/Y_00).  k=1 (high lane): color * 1.0 + 0.0.
+    const __half2 dc_mul = __halves2half2(__float2half(1.0f / SH_Y00), __float2half(1.0f));
+    const __half2 dc_add = __halves2half2(__float2half(-SH_BIAS / SH_Y00), __float2half(0.0f));
+    out_coeffs[0][0]     = __hfma2(out_coeffs[0][0], dc_mul, dc_add);
+    out_coeffs[1][0]     = __hfma2(out_coeffs[1][0], dc_mul, dc_add);
+    out_coeffs[2][0]     = __hfma2(out_coeffs[2][0], dc_mul, dc_add);
+}
+
+// 16-byte SH coefficient compression for K=16 (degree 3).
+//
+// Packed layout (128 bits = 4 × uint32):
+//
+//   block[0] bits  0..15:  DC_Y fp16 (16 bits, lossless)
+//   block[0] bits 16..26:  DC_Co fp11 (fp16 >> 5, drop 5 mantissa LSBs)
+//   block[0] bits 27..31:  DC_Cg fp11 high 5 bits
+//
+//   block[1] bits  0..5:   DC_Cg fp11 low 6 bits  (total Cg = 5 + 6 = 11)
+//   block[1] bits  6..31:  Y1..Y4 packed 6-bit ─┐
+//   block[2] bits  0..31:  Y5..Y9 + Y10 lo      │ 15 × 6-bit Y values for k=1..15
+//   block[3] bits  0..31:  Y10 hi..Y15          ─┘
+//
+//   HO CoCg entirely dropped (zero on decode).
+//
+//   Bit budget: 16 + 11 + 11 + 15*6 = 128 bits ✓
+
+// Encode K=16 SH coefficients into 16-byte packed representation.
+// T = float or __half.
+// coeffs:      input [3][16] — channel-first (R/G/B × 16 bases), caller loads.
+// block:       output [4] uint32 — caller stores.
+// inv_scales:  per-basis inverse scales (only y[] used for HO; co[]/cg[] ignored).
+template<typename T>
+__device__ void sh_encode_16b(const T (&coeffs)[3][16], uint32_t (&block)[4], const float (&inv_scales)[3][16])
+{
+    auto rgb_to_ycocg = [](float R, float G, float B, float &Y, float &Co, float &Cg) {
+        Y  = 0.25f * R + 0.5f * G + 0.25f * B;
+        Co = 0.5f * R - 0.5f * B;
+        Cg = -0.25f * R + 0.5f * G - 0.25f * B;
+    };
+
+    // HO only needs luma — no CoCg in 16B format
+    auto rgb_to_y = [](float R, float G, float B) -> float { return 0.25f * R + 0.5f * G + 0.25f * B; };
+
+    auto quantize_u1f = [](float val, float inv_scale, float max_q) -> float {
+        float norm       = val * inv_scale;
+        float compressed = copysignf(sqrtf(fabsf(norm)), norm);
+        float q          = fminf(fmaxf(roundf(compressed * max_q), -(max_q + 1.0f)), max_q);
+        return q + (max_q + 1.0f);
+    };
+
+    // --- DC (k=0) : Y@fp16 + Co@fp11 + Cg@fp11 ---
+    float R0 = _sh_to_float(coeffs[0][0]) * SH_Y00 + SH_BIAS;
+    float G0 = _sh_to_float(coeffs[1][0]) * SH_Y00 + SH_BIAS;
+    float B0 = _sh_to_float(coeffs[2][0]) * SH_Y00 + SH_BIAS;
+
+    float dc_Y, dc_Co, dc_Cg;
+    rgb_to_ycocg(R0, G0, B0, dc_Y, dc_Co, dc_Cg);
+
+    uint16_t y_bits;
+    AssignAs<uint16_t>(y_bits, __float2half(dc_Y));
+
+    // fp11 = fp16 rounded to 5 mantissa bits (drop 5 LSBs with rounding), then >> 5
+    const __half2 tr_cocg = RoundToNearest<5, false>(__floats2half2_rn(dc_Co, dc_Cg));
+    const uint32_t co11   = (reinterpret_cast<const uint32_t &>(tr_cocg) >> 5) & 0x7FFu;
+    const uint32_t cg11   = (reinterpret_cast<const uint32_t &>(tr_cocg) >> 21) & 0x7FFu;
+
+    block[0] = static_cast<uint32_t>(y_bits) | (co11 << 16) | (cg11 << 27);
+
+    // --- HO Y k=1..15: 4 groups of 4 (last group zero-pads k=16) ---
+    // Each group packs 4 Y values via __cvt_pack_sat_u8_f32, then compresses
+    // the u8x4 into a 24-bit chunk by dropping the top 2 bits of each byte.
+    uint32_t y_packed[4];
+#pragma unroll
+    for (int g = 0; g < 4; g++)
+    {
+        float Yg[4] = {0.f, 0.f, 0.f, 0.f};
+#pragma unroll
+        for (int j = 0; j < 4; j++)
+        {
+            const int k = 1 + g * 4 + j;
+            if (k <= 15)
+            {
+                Yg[j] = rgb_to_y(_sh_to_float(coeffs[0][k]), _sh_to_float(coeffs[1][k]),
+                                 _sh_to_float(coeffs[2][k]));
+            }
+        }
+
+        const int k_base    = 1 + g * 4;
+        const uint32_t Y_u8 = __cvt_pack_sat_u8_f32(
+            quantize_u1f(Yg[0], inv_scales[0][k_base], 31.f), quantize_u1f(Yg[1], inv_scales[0][k_base + 1], 31.f),
+            quantize_u1f(Yg[2], inv_scales[0][k_base + 2], 31.f), quantize_u1f(Yg[3], inv_scales[0][k_base + 3], 31.f));
+        y_packed[g] =
+            (Y_u8 & 0x3Fu) | ((Y_u8 & 0x3F00u) >> 2) | ((Y_u8 & 0x3F0000u) >> 4) | ((Y_u8 & 0x3F000000u) >> 6);
+    }
+
+    // Stitch: 6-bit cg11_hi header + four 24-bit Y chunks → block[1..3].
+    // Simple shifts+OR (not funnel shifts) because y_packed[] have zero high-8 bits.
+    const uint32_t cg11_hi = (cg11 >> 5) & 0x3Fu;
+    block[1]               = cg11_hi | (y_packed[0] << 6) | (y_packed[1] << 30);
+    block[2]               = (y_packed[1] >> 2) | (y_packed[2] << 22);
+    block[3]               = (y_packed[2] >> 10) | (y_packed[3] << 14);
+}
+
+// Decode 16-byte packed SH coefficients to fp16 SoA.
+// block:      input [4] uint32 — caller loads.
+// out_coeffs: output [3][8] half2 — same format as sh_decode_32b.
+//             HO CoCg is zero (not encoded in 16B format).
+// scales:     per-basis decoder scales (only y[] used for HO).
+__device__ inline void sh_decode_16b(const uint32_t (&block)[4], __half2 (&out_coeffs)[3][8],
+                                     const __half2 (&scales)[3][8])
+{
+    // ===== Phase 1: Extract Y[0..15] and DC CoCg =====
+
+    __half Y[16];
+
+    // --- DC (k=0): Y fp16 (16) + Co fp11 (11) + Cg fp11 (11) = 38 bits ---
+    AssignAs<uint16_t>(Y[0], block[0]);
+
+    __half dc_Co, dc_Cg;
+    AssignAs<uint16_t>(dc_Co, ((block[0] >> 16) & 0x7FFu) << 5);
+    const uint32_t cg11 = (block[0] >> 27) | ((block[1] & 0x3Fu) << 5);
+    AssignAs<uint16_t>(dc_Cg, (cg11 & 0x7FFu) << 5);
+
+    // --- HO Y k=1..15: 15 × 6-bit unsigned bias, starting at block[1] bit 6 ---
+    // Reconstruct the 90-bit Y stream aligned to bit 0.
+    const uint32_t s0 = (block[1] >> 6) | (block[2] << 26);
+    const uint32_t s1 = (block[2] >> 6) | (block[3] << 26);
+    const uint32_t s2 = block[3] >> 6;
+
+    // k=1: scalar extract (keeps half2 pair alignment for subsequent writes)
+    Y[1] = __uint2half_rn((s0 & 0x3Fu) << 2);
+
+    // k=2..13: 3 full batches of 4 at half2-aligned offsets
+    auto spread_6bit_to_uint8x4 = [](uint32_t packed_6x4) -> uint32_t {
+        const uint32_t lo = __select(0x003FC0u, packed_6x4 << 2, packed_6x4);
+        const uint32_t hi = __select(0xFF0000u, packed_6x4, packed_6x4 >> 2);
+        return __prmt_idx(lo << 2, hi, 0x6510) & 0xFCFCFCFCu;
+    };
+
+    __uint8x4_to_half4(&Y[2], spread_6bit_to_uint8x4(__funnelshift_rc(s0, s1, 6)));
+    __uint8x4_to_half4(&Y[6], spread_6bit_to_uint8x4(__funnelshift_rc(s0, s1, 30)));
+    __uint8x4_to_half4(&Y[10], spread_6bit_to_uint8x4(__funnelshift_rc(s1, s2, 22)));
+
+    // k=14..15: pair write via __uint8x2_to_half2 (avoids out-of-bounds Y[16])
+    AssignAs<__half2>(Y[14], __uint8x2_to_half2(((s2 >> 12) & 0xFCu) | (((s2 >> 18) & 0xFCu) << 8)));
+
+    // ===== Phase 2: Normalize, inv-gamma, scale, YCoCg → RGB =====
+
+    constexpr float INV_NORM_Y = 1.0f / (4.0f * 31.0f);
+    constexpr float OFFSET_Y   = -32.0f / 31.0f;
+
+    auto square_signed_h2 = [](__half2 v) -> __half2 { return __h2_copy_sign(__hmul2(v, v), v); };
+    auto square_signed_h  = [](__half v) -> __half { return __h_copy_sign(__hmul(v, v), v); };
+
+    __half2 *Y_h2 = reinterpret_cast<__half2 *>(Y);
+
+    // Normalize + inv-gamma for k=1 (scalar, high lane of pair 0)
+    Y[1] = square_signed_h(__hfma(Y[1], __float2half_rn(INV_NORM_Y), __float2half_rn(OFFSET_Y)));
+
+    // Scale k=1 by its per-basis Y scale (high lane of scales.y[0])
+    const __half k1_scaled = __hmul(Y[1], __high2half(scales[0][0]));
+
+    // DC (pair 0 low lane): full YCoCg → RGB, then undo SH color transform
+    const __half dc_Y_sub_Cg = __hsub(Y[0], dc_Cg);
+    const __half dc_inv_y00  = __float2half(1.0f / SH_Y00);
+    const __half dc_bias     = __float2half(-SH_BIAS / SH_Y00);
+    const __half dc_R        = __hfma(__hadd(dc_Y_sub_Cg, dc_Co), dc_inv_y00, dc_bias);
+    const __half dc_G        = __hfma(__hadd(Y[0], dc_Cg), dc_inv_y00, dc_bias);
+    const __half dc_B        = __hfma(__hsub(dc_Y_sub_Cg, dc_Co), dc_inv_y00, dc_bias);
+
+    out_coeffs[0][0] = __halves2half2(dc_R, k1_scaled);
+    out_coeffs[1][0] = __halves2half2(dc_G, k1_scaled);
+    out_coeffs[2][0] = __halves2half2(dc_B, k1_scaled);
+
+    // HO pairs 1..7: CoCg = 0 → R = G = B = Y * scale
+    const __half2 inv_norm_y = __float2half2_rn(INV_NORM_Y);
+    const __half2 offset_y   = __float2half2_rn(OFFSET_Y);
+
+#pragma unroll
+    for (int p = 1; p < 8; p++)
+    {
+        const __half2 y_scaled = __hmul2(square_signed_h2(__hfma2(Y_h2[p], inv_norm_y, offset_y)), scales[0][p]);
+        out_coeffs[0][p]       = y_scaled;
+        out_coeffs[1][p]       = y_scaled;
+        out_coeffs[2][p]       = y_scaled;
+    }
+}
+
+// Compute normalized view direction from camera position to gaussian center.
+// means is in [3, N] planar layout.
+__device__ __forceinline__ float3 GetViewDir(const float *__restrict__ means, uint32_t N, uint32_t idx, float cam_x,
+                                             float cam_y, float cam_z)
+{
+    const float dx    = means[idx] - cam_x;
+    const float dy    = means[N + idx] - cam_y;
+    const float dz    = means[2 * N + idx] - cam_z;
+    const float inorm = rsqrtf(dx * dx + dy * dy + dz * dz);
+    return make_float3(dx * inorm, dy * inorm, dz * inorm);
+}
+
+// Evaluate spherical harmonics bases at unit direction for high orders using
+// approach described by Efficient Spherical Harmonic Evaluation, Peter-Pike
+// Sloan, JCGT 2013 See https://jcgt.org/published/0002/02/06/ for reference
+// implementation
+
+__device__ __forceinline__ void EvaluteSHCoeffs(const uint32_t degree, // degree of SH to be evaluated
+                                                const uint32_t c,      // color channel
+                                                const float3 &dir,     // pre-normalized direction
+                                                const float *coeffs,   // [K, 3]
+                                                float bias, float min_value, float &color_out)
+{
+    float result = 0.2820947917738781f * coeffs[c];
+    if (degree >= 1)
+    {
+        const float x = dir.x;
+        const float y = dir.y;
+        const float z = dir.z;
+
+        result += 0.48860251190292f * (-y * coeffs[1 * 3 + c] + z * coeffs[2 * 3 + c] - x * coeffs[3 * 3 + c]);
+        if (degree >= 2)
+        {
+            const float z2 = z * z;
+
+            const float fTmp0B = -1.092548430592079f * z;
+            const float fC1    = x * x - y * y;
+            const float fS1    = 2.f * x * y;
+            const float pSH6   = (0.9461746957575601f * z2 - 0.3153915652525201f);
+            const float pSH7   = fTmp0B * x;
+            const float pSH5   = fTmp0B * y;
+            const float pSH8   = 0.5462742152960395f * fC1;
+            const float pSH4   = 0.5462742152960395f * fS1;
+
+            result += pSH4 * coeffs[4 * 3 + c] + pSH5 * coeffs[5 * 3 + c] + pSH6 * coeffs[6 * 3 + c] +
+                      pSH7 * coeffs[7 * 3 + c] + pSH8 * coeffs[8 * 3 + c];
+            if (degree >= 3)
+            {
+                const float fTmp0C = -2.285228997322329f * z2 + 0.4570457994644658f;
+                const float fTmp1B = 1.445305721320277f * z;
+                const float fC2    = x * fC1 - y * fS1;
+                const float fS2    = x * fS1 + y * fC1;
+                const float pSH12  = z * (1.865881662950577f * z2 - 1.119528997770346f);
+                const float pSH13  = fTmp0C * x;
+                const float pSH11  = fTmp0C * y;
+                const float pSH14  = fTmp1B * fC1;
+                const float pSH10  = fTmp1B * fS1;
+                const float pSH15  = -0.5900435899266435f * fC2;
+                const float pSH9   = -0.5900435899266435f * fS2;
+
+                result += pSH9 * coeffs[9 * 3 + c] + pSH10 * coeffs[10 * 3 + c] + pSH11 * coeffs[11 * 3 + c] +
+                          pSH12 * coeffs[12 * 3 + c] + pSH13 * coeffs[13 * 3 + c] + pSH14 * coeffs[14 * 3 + c] +
+                          pSH15 * coeffs[15 * 3 + c];
+
+                if (degree >= 4)
+                {
+                    const float fTmp0D = z * (-4.683325804901025f * z2 + 2.007139630671868f);
+                    const float fTmp1C = 3.31161143515146f * z2 - 0.47308734787878f;
+                    const float fTmp2B = -1.770130769779931f * z;
+                    const float fC3    = x * fC2 - y * fS2;
+                    const float fS3    = x * fS2 + y * fC2;
+                    const float pSH20  = (1.984313483298443f * z * pSH12 - 1.006230589874905f * pSH6);
+                    const float pSH21  = fTmp0D * x;
+                    const float pSH19  = fTmp0D * y;
+                    const float pSH22  = fTmp1C * fC1;
+                    const float pSH18  = fTmp1C * fS1;
+                    const float pSH23  = fTmp2B * fC2;
+                    const float pSH17  = fTmp2B * fS2;
+                    const float pSH24  = 0.6258357354491763f * fC3;
+                    const float pSH16  = 0.6258357354491763f * fS3;
+
+                    result += pSH16 * coeffs[16 * 3 + c] + pSH17 * coeffs[17 * 3 + c] + pSH18 * coeffs[18 * 3 + c] +
+                              pSH19 * coeffs[19 * 3 + c] + pSH20 * coeffs[20 * 3 + c] + pSH21 * coeffs[21 * 3 + c] +
+                              pSH22 * coeffs[22 * 3 + c] + pSH23 * coeffs[23 * 3 + c] + pSH24 * coeffs[24 * 3 + c];
+                }
+            }
+        }
+    }
+
+    color_out = max(result + bias, min_value);
+}
+
+// Vectorized coefficient load: reads N_VECS × VEC from src, converts each element to float.
+template<typename T, typename VEC, int N_VECS>
+__device__ __forceinline__ void LoadSHCoeffs(const T *src, float *dst)
+{
+    constexpr int ELEMS_PER_VEC = sizeof(VEC) / sizeof(T);
+#pragma unroll
+    for (int i = 0; i < N_VECS; ++i)
+    {
+        T tmp[ELEMS_PER_VEC];
+        reinterpret_cast<VEC *>(tmp)[0] = reinterpret_cast<const VEC *>(src)[i];
+#pragma unroll
+        for (int j = 0; j < ELEMS_PER_VEC; ++j)
+        {
+            dst[i * ELEMS_PER_VEC + j] = _sh_to_float(tmp[j]);
+        }
+    }
+}
+
+// Evaluate SH for 3 color channels at the given degree and write packed half4 output pixel.
+// DEGREE is a template parameter so sh_coeffs_to_color_fast receives a compile-time constant.
+template<int DEGREE>
+__device__ __forceinline__ void EvalSHAndPack(const float3 &dir_n, const float *sh_coeffs, float bias, float min_value,
+                                              __half *pixel)
+{
+    float out_color[3];
+    EvaluteSHCoeffs(DEGREE, 0, dir_n, sh_coeffs, bias, min_value, out_color[0]);
+    EvaluteSHCoeffs(DEGREE, 1, dir_n, sh_coeffs, bias, min_value, out_color[1]);
+    EvaluteSHCoeffs(DEGREE, 2, dir_n, sh_coeffs, bias, min_value, out_color[2]);
+    __half2 packed_out[2];
+    packed_out[0] = __floats2half2_rn(out_color[0], out_color[1]);
+    packed_out[1] = __floats2half2_rn(out_color[2], 0.f);
+    AssignAs<uint2>(pixel[0], packed_out);
+}
+
+// Load SH coefficients for gaussian idx, evaluate all 3 color channels, write packed half4
+// output pixel. MODE selects the coefficient source at compile time. dir_n must be the
+// pre-computed normalized view direction for this gaussian.
+template<SHInputMode MODE>
+__device__ __forceinline__ void EvalSHForGaussian(const float3 &dir_n, int idx, int N, int degrees_to_use,
+                                                  const void *__restrict__ input_data, float bias, float min_value,
+                                                  const SHDecodeParams &decode_params, __half *__restrict__ colors)
+{
+    float sh_coeffs[16 * 3];
+    __half *pixel = colors + idx * 4;
+
+    if constexpr (MODE == SHInputMode::RAW_FLOAT || MODE == SHInputMode::RAW_HALF)
+    {
+        using T          = std::conditional_t<MODE == SHInputMode::RAW_FLOAT, float, __half>;
+        using VEC_SMALL  = std::conditional_t<MODE == SHInputMode::RAW_FLOAT, uint4, ushort4>;
+        constexpr int N2 = MODE == SHInputMode::RAW_FLOAT ? 7 : 4;  // uint4 loads for degree 2
+        constexpr int N3 = MODE == SHInputMode::RAW_FLOAT ? 12 : 6; // uint4 loads for degree 3
+
+        const T *elem_coeffs = static_cast<const T *>(input_data) + static_cast<int64_t>(idx) * (16 * 3);
+
+        switch (degrees_to_use)
+        {
+        case 0:
+            LoadSHCoeffs<T, VEC_SMALL, 1>(elem_coeffs, sh_coeffs);
+            EvalSHAndPack<0>(dir_n, sh_coeffs, bias, min_value, pixel);
+            return;
+        case 1:
+            LoadSHCoeffs<T, VEC_SMALL, 3>(elem_coeffs, sh_coeffs);
+            EvalSHAndPack<1>(dir_n, sh_coeffs, bias, min_value, pixel);
+            return;
+        case 2:
+            LoadSHCoeffs<T, uint4, N2>(elem_coeffs, sh_coeffs);
+            EvalSHAndPack<2>(dir_n, sh_coeffs, bias, min_value, pixel);
+            return;
+        default:
+            LoadSHCoeffs<T, uint4, N3>(elem_coeffs, sh_coeffs);
+            EvalSHAndPack<3>(dir_n, sh_coeffs, bias, min_value, pixel);
+            return;
+        }
+    }
+
+    if constexpr (MODE == SHInputMode::COMPRESS_32B || MODE == SHInputMode::COMPRESS_16B)
+    {
+        const auto *packed = static_cast<const uint4 *>(input_data);
+        __half2 out_coeffs[3][8];
+
+        if constexpr (MODE == SHInputMode::COMPRESS_32B)
+        {
+            // load 2 × uint4 at stride N
+            uint32_t block[8];
+            uint4 b0 = packed[idx];
+            uint4 b1 = packed[static_cast<int64_t>(N) + idx];
+            AssignAs<uint4>(block[0], b0);
+            AssignAs<uint4>(block[4], b1);
+            sh_decode_32b(block, out_coeffs, decode_params.scales);
+        }
+        else
+        {
+            // load 1 × uint4 per gaussian
+            uint32_t block[4];
+            uint4 b = packed[idx];
+            AssignAs<uint4>(block[0], b);
+            sh_decode_16b(block, out_coeffs, decode_params.scales);
+        }
+
+        // flatten to [K, 3] float layout expected by sh_coeffs_to_color_fast
+#pragma unroll
+        for (int c = 0; c < 3; c++)
+        {
+#pragma unroll
+            for (int p = 0; p < 8; p++)
+            {
+                float2 pair                    = __half22float2(out_coeffs[c][p]);
+                sh_coeffs[(p * 2 + 0) * 3 + c] = pair.x;
+                sh_coeffs[(p * 2 + 1) * 3 + c] = pair.y;
+            }
+        }
+
+        EvalSHAndPack<3>(dir_n, sh_coeffs, bias, min_value, pixel);
+    }
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCompression.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCompression.cu
@@ -1,0 +1,235 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CUDA kernel wrappers for SH compression encode/decode (32B and 16B modes).
+// The actual encode/decode device functions live in SHCompression.h.
+//
+// 32B packed memory layout: [2, N] uint4 — two 16-byte blocks per gaussian,
+// stored as block0 for all N gaussians followed by block1 for all N.
+// 16B packed memory layout: [N] uint4 — one 16-byte block per gaussian.
+// Both layouts ensure fully coalesced 16-byte warp transactions.
+
+#include "SHCommon.h"
+#include "SHCompression.h"
+
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/from_blob.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <type_traits>
+
+namespace higs {
+
+static constexpr int CODEC_CTA_SIZE   = 256;
+static constexpr int CODEC_MIN_BLOCKS = 4;
+
+template<SHCompressionMode MODE, typename T>
+__global__ void __launch_bounds__(CODEC_CTA_SIZE, CODEC_MIN_BLOCKS)
+    sh_encode_kernel(int32_t N, const T *__restrict__ coeffs_in, uint4 *__restrict__ packed_out,
+                     SHEncodeParams encode_params)
+{
+    const int32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N)
+    {
+        return;
+    }
+
+    // Load coefficients into channel-first local array [3][16]
+    // Input layout: [N, 16, 3] T → stride: gaussian=48, basis=3, channel=1
+    T coeffs[3][16];
+    const T *src = coeffs_in + (int64_t)idx * 48;
+#pragma unroll
+    for (int k = 0; k < 16; k++)
+    {
+        coeffs[0][k] = src[k * 3 + 0];
+        coeffs[1][k] = src[k * 3 + 1];
+        coeffs[2][k] = src[k * 3 + 2];
+    }
+
+    if constexpr (MODE == SHCompressionMode::COMPRESS_32B)
+    {
+        uint32_t block[8];
+        sh_encode_32b(coeffs, block, encode_params.inv_scales);
+
+        // store as two uint4 at stride N for coalesced warp access
+        uint4 b0, b1;
+        AssignAs<uint4>(b0, block[0]);
+        AssignAs<uint4>(b1, block[4]);
+        packed_out[idx]              = b0;
+        packed_out[(int64_t)N + idx] = b1;
+    }
+    else
+    {
+        uint32_t block[4];
+        sh_encode_16b(coeffs, block, encode_params.inv_scales);
+
+        // store one uint4 per gaussian
+        uint4 b;
+        AssignAs<uint4>(b, block[0]);
+        packed_out[idx] = b;
+    }
+}
+
+// Unified host functions
+
+at::Tensor launch_sh_encode(const at::Tensor &coeffs, const SHEncodeParams &encode_params, SHCompressionMode mode)
+{
+    TORCH_CHECK(coeffs.dim() == 3 && coeffs.size(1) == 16 && coeffs.size(2) == 3, "coeffs must be [N, 16, 3]");
+    TORCH_CHECK(coeffs.scalar_type() == at::kFloat || coeffs.scalar_type() == at::kHalf,
+                "coeffs must be float32 or float16");
+    TORCH_CHECK(coeffs.is_cuda() && coeffs.is_contiguous());
+
+    const int32_t N   = static_cast<int32_t>(coeffs.size(0));
+    const bool is_32b = (mode == SHCompressionMode::COMPRESS_32B);
+    auto packed       = at::empty({is_32b ? 2 * N : N, 4}, at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+
+    if (N > 0)
+    {
+        dim3 threads(CODEC_CTA_SIZE);
+        dim3 blocks((N + CODEC_CTA_SIZE - 1) / CODEC_CTA_SIZE);
+        auto stream = at::cuda::getCurrentCUDAStream();
+        auto *dst   = reinterpret_cast<uint4 *>(packed.data_ptr<int32_t>());
+
+        auto launch = [&](auto mode_tag) {
+            constexpr SHCompressionMode MODE = decltype(mode_tag)::value;
+            if (coeffs.scalar_type() == at::kFloat)
+            {
+                sh_encode_kernel<MODE, float>
+                    <<<blocks, threads, 0, stream>>>(N, coeffs.data_ptr<float>(), dst, encode_params);
+            }
+            else
+            {
+                sh_encode_kernel<MODE, __half><<<blocks, threads, 0, stream>>>(
+                    N, reinterpret_cast<const __half *>(coeffs.data_ptr<at::Half>()), dst, encode_params);
+            }
+        };
+
+        if (is_32b)
+        {
+            launch(std::integral_constant<SHCompressionMode, SHCompressionMode::COMPRESS_32B>{});
+        }
+        else
+        {
+            launch(std::integral_constant<SHCompressionMode, SHCompressionMode::COMPRESS_16B>{});
+        }
+    }
+
+    return packed;
+}
+
+// Full compression pipeline: fp32 coefficients → compressed + scales.
+// Computes per-basis-per-channel p99.99 scales in YCoCg space (excluding low-opacity
+// gaussians from scale computation), encodes all gaussians, and returns the packed
+// bitstream + decoder scale structure.
+SHCompressed launch_sh_compress(const at::Tensor &coeffs, const at::Tensor &opacities, SHCompressionMode mode)
+{
+    TORCH_CHECK(coeffs.dim() == 3 && coeffs.size(1) == 16 && coeffs.size(2) == 3);
+    TORCH_CHECK(opacities.dim() == 1 && opacities.size(0) == coeffs.size(0));
+    TORCH_CHECK(coeffs.is_cuda() && opacities.is_cuda());
+
+    const int64_t N   = coeffs.size(0);
+    const bool is_32b = (mode == SHCompressionMode::COMPRESS_32B);
+
+    // Convert to half for the non-compressed render path
+    auto coeffs_half = coeffs.to(at::kHalf).contiguous();
+
+    SHEncodeParams encode_params{};
+    float scales_f[3][16]{}; // [channel][basis] — raw scales for building SHDecodeParams
+
+    // Need to use scope to free unused tensors early
+    {
+        // Extract HO in float, convert to YCoCg for scale computation
+        at::Tensor Y, Co, Cg;
+        {
+            auto ho = coeffs_half.narrow(1, 1, 15).to(at::kFloat); // [N, 15, 3]
+            auto R  = ho.select(2, 0);
+            auto G  = ho.select(2, 1);
+            auto B  = ho.select(2, 2);
+            Y       = R.mul(0.25f).add(G.mul(0.5f)).add(B.mul(0.25f));
+            Co      = R.mul(0.5f).sub(B.mul(0.5f));
+            Cg      = R.mul(-0.25f).add(G.mul(0.5f)).add(B.mul(-0.25f));
+        }
+
+        // Filter to visible gaussians (opacity >= 0.5%) for scale computation.
+        // Low-opacity outliers don't visibly affect rendering but can inflate scales.
+        constexpr float OPACITY_THRESHOLD = 0.005f;
+        auto visible_mask                 = opacities.to(at::kFloat).ge(OPACITY_THRESHOLD);   // [N] bool
+        auto vis_indices                  = visible_mask.nonzero().squeeze(1); // [M] long
+
+        // Compute per-basis p99.99 scales from visible gaussians only
+        constexpr float PERCENTILE = 0.9999f;
+
+        // DC slots: 1.0 (unused by encoder's DC path, but well-defined)
+        encode_params.inv_scales[0][0] = encode_params.inv_scales[1][0] = encode_params.inv_scales[2][0] = 1.0f;
+        scales_f[0][0] = scales_f[1][0] = scales_f[2][0] = 1.0f;
+
+        at::Tensor ycocg_channels[] = {Y, Co, Cg};
+        float *inv_arrays[] = {encode_params.inv_scales[0], encode_params.inv_scales[1], encode_params.inv_scales[2]};
+        int64_t M           = vis_indices.size(0);
+
+        // When all Gaussians are below the opacity threshold, fall back to
+        // unit scales so the encoder/decoder round-trips zeros cleanly.
+        if (M == 0) {
+            for (int ch = 0; ch < 3; ch++) {
+                for (int j = 0; j < 15; j++) {
+                    scales_f[ch][j + 1] = 1.0f;
+                    encode_params.inv_scales[ch][j + 1] = 1.0f;
+                }
+            }
+        } else {
+            // For 16B mode, only Y channel scales are needed (CoCg is dropped)
+            const int n_channels = is_32b ? 3 : 1;
+
+            for (int ch = 0; ch < n_channels; ch++)
+            {
+                for (int j = 0; j < 15; j++)
+                {
+                    // Select only visible gaussians for this basis/channel
+                    auto col        = ycocg_channels[ch].select(1, j).index_select(0, vis_indices); // [M]
+                    auto abs_sorted = std::get<0>(col.abs().sort());
+                    int64_t idx     = std::min((int64_t)(PERCENTILE * M), M - 1);
+                    float scale     = abs_sorted[idx].item<float>();
+
+                    scales_f[ch][j + 1] = scale;
+                    // If scale is zero (all coefficients zero for this basis/channel), set reciprocal
+                    // to zero so val * 0 = 0 quantizes to the midpoint. Avoids inf/NaN.
+                    inv_arrays[ch][j + 1] = (scale > 0.f) ? 1.0f / scale : 0.f;
+                }
+            }
+        }
+    }
+
+    // Encode
+    auto packed = launch_sh_encode(coeffs_half, encode_params, mode);
+
+    // build decoder params: pack per-basis scales to half2
+    SHDecodeParams decode_params{};
+    for (int p = 0; p < 8; p++)
+    {
+        int k_lo                   = p * 2;
+        int k_hi                   = p * 2 + 1;
+        decode_params.scales[0][p] = __floats2half2_rn(scales_f[0][k_lo], scales_f[0][k_hi]);
+        decode_params.scales[1][p] = __floats2half2_rn(scales_f[1][k_lo], scales_f[1][k_hi]);
+        decode_params.scales[2][p] = __floats2half2_rn(scales_f[2][k_lo], scales_f[2][k_hi]);
+    }
+
+    return {packed, decode_params};
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCompression.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCompression.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "InferenceTypes.h"
+
+#include <ATen/core/Tensor.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+namespace higs {
+
+// Per-basis inverse scales for the encoder (fp32, indexed per basis).
+// Index 0 = DC, set to 1.0 (unused by encoder's DC path but keeps struct well-defined).
+// Shared by both 32B and 16B modes. For 16B mode, co[]/cg[] HO slots are set to 0.
+struct SHEncodeParams
+{
+    float inv_scales[3][16];
+};
+
+// Per-basis scales for the decoder (half2, indexed per pair for SIMD).
+// Pair layout: {k=0, k=1}, {k=2, k=3}, ..., {k=14, k=15}.
+// Pair 0 low lane (DC) = 1.0 so the decoder can apply a uniform multiply.
+// Shared by both 32B and 16B modes. For 16B mode, co[]/cg[] HO slots are 0.
+struct SHDecodeParams
+{
+    __half2 scales[3][8];
+};
+
+// Full compression result returned by launch_sh_compress.
+// packed tensor shape depends on mode: [2*N, 4] for 32B, [N, 4] for 16B.
+struct SHCompressed
+{
+    at::Tensor packed;            // packed SH bitstream (int32)
+    SHDecodeParams decode_params; // per-basis decoder scales
+};
+
+at::Tensor launch_sh_encode(const at::Tensor &coeffs, const SHEncodeParams &encode_params, SHCompressionMode mode);
+// opacities: [N] float — per-gaussian opacity (sigmoid-applied). Gaussians with opacity
+// below the internal threshold are excluded from percentile scale computation so their
+// SH outliers don't inflate the quantization range for visible gaussians.
+SHCompressed launch_sh_compress(const at::Tensor &coeffs, const at::Tensor &opacities, SHCompressionMode mode);
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SegmentedSort.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SegmentedSort.cu
@@ -1,0 +1,1079 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmath>
+#include <cub/block/block_radix_rank.cuh>
+#include "SegmentedSort.h"
+
+// terminology used throughout this file:
+//
+//   segment    — a top-level contiguous range of items in the input array,
+//                defined by offsets[i] to offsets[i+1]. each segment is
+//                sorted independently.
+//
+//   block      — a fixed-size (CAPACITY = CTA_SIZE * ITEMS_PER_THREAD) chunk
+//                of an overflow segment. when a segment exceeds the largest
+//                cascade tier's capacity, it is split into blocks that are
+//                independently sorted before being merged back together.
+//
+//   partition  — a fixed-size (MERGE_PARTITION_SIZE) chunk of work within a
+//                merge operation. each CTA processes one partition of a merge
+//                tree node, reading from one ping-pong buffer and writing to
+//                the other.
+
+namespace higs {
+
+namespace seg_sort {
+
+// block sort (cascade) — shared by all tiers
+static constexpr int BLOCK_SORT_ITEMS_PER_THREAD = 16;
+static constexpr int BLOCK_SORT_RADIX_BITS       = 8;
+
+template<int CTA_SIZE>
+using BlockSortRankT = cub::BlockRadixRankMatch<CTA_SIZE, BLOCK_SORT_RADIX_BITS, false, cub::BLOCK_SCAN_WARP_SCANS>;
+
+template<int CTA_SIZE>
+union BlockSortSmem
+{
+    typename BlockSortRankT<CTA_SIZE>::TempStorage rank;
+    int32_t raw[CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD];
+};
+
+// cascade tier configuration: CTA size and min segment size
+static constexpr int BLOCK_SORT_T0_CTA_SIZE = 64;
+static constexpr int BLOCK_SORT_T0_MIN_SIZE = 0;
+static constexpr int BLOCK_SORT_T1_CTA_SIZE = 128;
+static constexpr int BLOCK_SORT_T1_MIN_SIZE = BLOCK_SORT_T0_CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+static constexpr int BLOCK_SORT_T2_CTA_SIZE = 256;
+static constexpr int BLOCK_SORT_T2_MIN_SIZE = BLOCK_SORT_T1_CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+static constexpr int BLOCK_SORT_T3_CTA_SIZE = 512;
+static constexpr int BLOCK_SORT_T3_MIN_SIZE = BLOCK_SORT_T2_CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+static constexpr int BLOCK_SORT_T3_CAPACITY = BLOCK_SORT_T3_CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+
+// merge kernel configuration
+static constexpr int MERGE_CTA_SIZE         = 256;
+static constexpr int MERGE_ITEMS_PER_THREAD = 15;
+static constexpr int MERGE_PARTITION_SIZE   = MERGE_CTA_SIZE * MERGE_ITEMS_PER_THREAD;
+static constexpr int MERGE_MIN_BLOCKS       = 3;
+
+// pairs a typed pointer member with an element count and alignment.
+// the template constructor deduces sizeof(T) so callers specify counts,
+// not bytes. alignment controls the start offset of this entry within
+// the scratch buffer: 32 for structs containing L2-sector-padded atomic
+// counters, 256 for bulk arrays (cache-line alignment).
+struct ScratchEntry
+{
+    void **ptr;
+    size_t elem_size;
+    size_t alignment;
+    int count;
+
+    template<typename T>
+    ScratchEntry(T *&p, int c, size_t align)
+        : ptr(reinterpret_cast<void **>(&p))
+        , elem_size(sizeof(T))
+        , alignment(align)
+        , count(c)
+    {
+    }
+};
+
+// device-scope relaxed load. compiles to ld.relaxed.gpu.b32 which goes
+// through the regular L2 cache path — unlike atomicAdd(&v, 0) which uses
+// the L2 atomic RMW pipeline. use for spin-wait polling where only
+// visibility (not ordering) is needed.
+__device__ __forceinline__ int LoadRelaxedGpu(const int *addr)
+{
+    int val;
+    asm volatile("ld.relaxed.gpu.b32 %0, [%1];" : "=r"(val) : "l"(addr));
+    return val;
+}
+
+// tiled merge-path for one MERGE_PARTITION_SIZE chunk of a 2-way merge.
+// the int4 descriptor encodes {a_begin, a_end, b_end, diagonal | direction_flag}.
+// sign bit of desc.w selects the ping-pong direction.
+//
+// two-level merge-path: CTA-level partitions global data into
+// smem, then thread-level partitions smem into per-thread work.
+// output is scattered blocked->striped for coalesced writes.
+// smem_pairs is caller-provided so the allocation can be aliased (e.g. with
+// the persistent merge kernel's queue-position broadcast slot).
+__device__ void MergePartition(int4 desc, int32_t *keys_a, int32_t *vals_a, int32_t *keys_b, int32_t *vals_b,
+                               int2 *smem_pairs)
+{
+    const int a_begin        = desc.x;
+    const int a_end          = desc.y;
+    const int b_end          = desc.z;
+    const bool swap_buffers  = (desc.w < 0);
+    const int partition_diag = desc.w & 0x7FFFFFFF;
+
+    // uniform branch: all threads in the block read from the same buffer
+    const int32_t *keys_in = swap_buffers ? keys_b : keys_a;
+    const int32_t *vals_in = swap_buffers ? vals_b : vals_a;
+    int32_t *keys_out      = swap_buffers ? keys_a : keys_b;
+    int32_t *vals_out      = swap_buffers ? vals_a : vals_b;
+
+    const int a_len       = a_end - a_begin;
+    const int b_len       = b_end - a_end;
+    const int merge_total = a_len + b_len;
+    const int out_end     = min(partition_diag + MERGE_PARTITION_SIZE, merge_total);
+    const int out_count   = out_end - partition_diag;
+
+    if (out_count <= 0)
+    {
+        return;
+    }
+
+    // degenerate copy node (odd leftover, empty B run): skip merge-path
+    // and just copy A → output with coalesced accesses
+    if (b_len == 0)
+    {
+#pragma unroll 1
+        for (int i = threadIdx.x; i < out_count; i += MERGE_CTA_SIZE)
+        {
+            keys_out[a_begin + partition_diag + i] = keys_in[a_begin + partition_diag + i];
+            vals_out[a_begin + partition_diag + i] = vals_in[a_begin + partition_diag + i];
+        }
+        return;
+    }
+
+    const int32_t *a_keys = keys_in + a_begin;
+    const int32_t *b_keys = keys_in + a_end;
+    const int32_t *a_vals = vals_in + a_begin;
+    const int32_t *b_vals = vals_in + a_end;
+
+    constexpr int2 SENTINEL = {INT_MAX, 0};
+
+    // CTA-level merge-path: warp-cooperative binary search on DRAM.
+    // warp 0 finds mp_start (at partition_diag), warp 1 finds mp_stop (at out_end)
+    // in parallel. 32 probes per round divide [lo,hi) into 33 sub-intervals,
+    // __popc on the ballot locates the crossover, narrowing by ~33x per round.
+    // completes in ~3 rounds for 8K-element runs vs ~13 scalar iterations.
+    constexpr int MP_BROADCAST_IDX = MERGE_PARTITION_SIZE + 2;
+    if (threadIdx.x < 64)
+    {
+        const int lane    = threadIdx.x & 31;
+        const int warp_id = threadIdx.x >> 5;
+        const int diag    = warp_id == 0 ? partition_diag : out_end;
+
+        // exact a * b / 33 without 64-bit math; b must be in [1, 32].
+        // the /33 literals are compile-time constants so the compiler emits
+        // multiply-high + shift, not actual division.
+        auto div33 = [](int a, int b) {
+            const int q = a / 33;
+            const int r = a - q * 33;
+            return q * b + r * b / 33;
+        };
+
+        int lo = max(0, diag - b_len);
+        int hi = min(diag, a_len);
+        while (lo < hi)
+        {
+            const int range        = hi - lo;
+            const int probe        = lo + div33(range, lane + 1);
+            const bool take_more_a = (a_keys[probe] <= b_keys[diag - probe - 1]);
+            const uint32_t ballot  = __ballot_sync(0xFFFFFFFF, take_more_a);
+            const int n_true       = __popc(ballot);
+
+            // 32 probes create 33 sub-intervals. n_true tells us which one
+            // contains the crossover. the general formula narrows to
+            // [probe[n_true-1]+1, probe[n_true]], but the edge cases need
+            // special handling: n_true=0 has no "last true probe" so lo must
+            // stay put, and n_true=32 has no "first false probe" so hi stays.
+            if (n_true == 32)
+            {
+                lo = lo + div33(range, 32) + 1;
+            }
+            else if (n_true == 0)
+            {
+                hi = lo + div33(range, 1);
+            }
+            else
+            {
+                hi = lo + div33(range, n_true + 1);
+                lo = lo + div33(range, n_true) + 1;
+            }
+        }
+
+        if (lane == 0)
+        {
+            reinterpret_cast<int *>(&smem_pairs[MP_BROADCAST_IDX])[warp_id] = lo;
+        }
+    }
+
+    __syncthreads();
+    const int a_start = smem_pairs[MP_BROADCAST_IDX].x;
+    const int a_count = smem_pairs[MP_BROADCAST_IDX].y - a_start;
+    const int b_start = partition_diag - a_start;
+    const int b_count = out_count - a_count;
+    const int b_base  = a_count + 1;
+
+    // fused coalesced loads: key+val packed into smem with sentinel gap
+#pragma unroll 1
+    for (int i = threadIdx.x; i < a_count; i += MERGE_CTA_SIZE)
+    {
+        smem_pairs[i] = make_int2(a_keys[a_start + i], a_vals[a_start + i]);
+    }
+#pragma unroll 1
+    for (int i = threadIdx.x; i < b_count; i += MERGE_CTA_SIZE)
+    {
+        smem_pairs[b_base + i] = make_int2(b_keys[b_start + i], b_vals[b_start + i]);
+    }
+    if (threadIdx.x == 0)
+    {
+        smem_pairs[a_count]          = SENTINEL;
+        smem_pairs[b_base + b_count] = SENTINEL;
+    }
+    __syncthreads();
+
+    // thread-level merge-path on smem: binary search for the split between
+    // A and B at this thread's diagonal. uses <= for stability (equal keys prefer A).
+    const int t_diag = min((int)threadIdx.x * MERGE_ITEMS_PER_THREAD, out_count);
+    int ta_lo        = max(0, t_diag - b_count);
+    int ta_hi        = min(t_diag, a_count);
+    while (ta_lo < ta_hi)
+    {
+        const int mid = (ta_lo + ta_hi) / 2;
+        if (smem_pairs[mid].x <= smem_pairs[b_base + t_diag - mid - 1].x)
+        {
+            ta_lo = mid + 1;
+        }
+        else
+        {
+            ta_hi = mid;
+        }
+    }
+
+    // sequential merge into packed registers. prefetch both pairs;
+    // unconditional reload — smem has IPT padding slots past the
+    // sentinels so reads are safe even for partial-tile threads.
+    const int2 *a_pair_ptr = &smem_pairs[ta_lo];
+    const int2 *b_pair_ptr = &smem_pairs[b_base + t_diag - ta_lo];
+    int2 a_pair            = *a_pair_ptr;
+    int2 b_pair            = *b_pair_ptr;
+    int2 r_kv[MERGE_ITEMS_PER_THREAD];
+
+#pragma unroll
+    for (int i = 0; i < MERGE_ITEMS_PER_THREAD; i++)
+    {
+        if (a_pair.x <= b_pair.x)
+        {
+            r_kv[i] = a_pair;
+            a_pair  = *(++a_pair_ptr);
+        }
+        else
+        {
+            r_kv[i] = b_pair;
+            b_pair  = *(++b_pair_ptr);
+        }
+    }
+    __syncthreads();
+
+    // blocked scatter then striped read+store through smem.
+    // IPT=15 gives stride 15 int2 between lanes; GCD(15, 16 wide banks) = 1,
+    // so all lanes hit different bank pairs (optimal 2-way conflict).
+#pragma unroll
+    for (int i = 0; i < MERGE_ITEMS_PER_THREAD; i++)
+    {
+        const int blocked = threadIdx.x * MERGE_ITEMS_PER_THREAD + i;
+        if (blocked < out_count)
+        {
+            smem_pairs[blocked] = r_kv[i];
+        }
+    }
+    __syncthreads();
+#pragma unroll
+    for (int i = 0; i < MERGE_ITEMS_PER_THREAD; i++)
+    {
+        const int striped = threadIdx.x + i * MERGE_CTA_SIZE;
+        if (striped < out_count)
+        {
+            const int2 pair                              = smem_pairs[striped];
+            keys_out[a_begin + partition_diag + striped] = pair.x;
+            vals_out[a_begin + partition_diag + striped] = pair.y;
+        }
+    }
+}
+
+// strictly out-of-place: each partition reads from one buffer pair and writes
+// to the other (selected by the per-partition direction flag). the input and
+// output buffer pairs must not alias.
+__global__ void __launch_bounds__(MERGE_CTA_SIZE, MERGE_MIN_BLOCKS) MergeKernel(const MergeArgs args)
+{
+    // smem layout: [A(a_count) | sentinel | B(b_count) | sentinel | padding]
+    // IPT extra slots past data guarantee unconditional merge reloads are
+    // safe even for partial-tile threads (no bounds checks in the loop).
+    __shared__ int2 smem_pairs[MERGE_PARTITION_SIZE + MERGE_ITEMS_PER_THREAD];
+    MergePartition(args.partitions[blockIdx.x], args.keys_a, args.vals_a, args.keys_b, args.vals_b, smem_pairs);
+}
+
+// signal partition completion and enqueue the parent node when all children
+// are done. warp-cooperative: must be called by warp 0 (threadIdx.x < 32).
+// lane 0 handles atomics and conditionals, all lanes cooperate on writing
+// queue entries via a strided loop.
+__device__ void UpdateMergeQueue(const PersistentMergeArgs &args, const MergeWorkItem &work_item,
+                                 const MergeTreeNode &node)
+{
+    const int lane         = threadIdx.x & 31;
+    const int n_partitions = (node.end - node.begin + MERGE_PARTITION_SIZE - 1) / MERGE_PARTITION_SIZE;
+    const int parent       = node.parent_idx;
+
+    // speculative read of the parent node — one L2 transaction (all lanes
+    // read the same 16B address). skipped for root nodes (parent < 0).
+    int parent_n_partitions = 0;
+    if (parent >= 0)
+    {
+        const MergeTreeNode parent_node = args.tree_nodes[parent];
+        parent_n_partitions = (parent_node.end - parent_node.begin + MERGE_PARTITION_SIZE - 1) / MERGE_PARTITION_SIZE;
+    }
+
+    // lane 0 handles the atomic completion chain and reserves queue slots.
+    // q_base < 0 signals "nothing to enqueue" to the rest of the warp.
+    int q_base = -1;
+    if (lane == 0)
+    {
+        const int done = atomicAdd(&args.node_done_counts[work_item.node_idx], 1) + 1;
+        if (done == n_partitions && parent >= 0)
+        {
+            const int prev = atomicAdd(&args.node_done_counts[parent], 1);
+            if (prev == -1)
+            {
+                q_base = atomicAdd(&args.queue_state->queue_reserved, parent_n_partitions);
+            }
+        }
+    }
+
+    q_base = __shfl_sync(0xFFFFFFFF, q_base, 0);
+    if (q_base < 0)
+    {
+        return;
+    }
+
+#pragma unroll 1
+    for (int t = lane; t < parent_n_partitions; t += 32)
+    {
+        args.work_items[q_base + t] = {parent, t};
+    }
+
+    __syncwarp();
+    if (lane == 0)
+    {
+        __threadfence(); // release: entry writes visible before queue_tail commit
+        while (atomicCAS(&args.queue_state->queue_tail, q_base, q_base + parent_n_partitions) != q_base)
+        {
+            __nanosleep(32);
+        }
+    }
+}
+
+// persistent-CTA merge kernel driven by a device-side FIFO queue.
+// each CTA loops: claim a queue slot, spin until committed, merge
+// the partition, signal completion, and enqueue parent nodes when
+// both children are done. terminates when all queue items are consumed.
+//
+// strictly out-of-place per partition (same semantics as MergeKernel):
+// the two buffer pairs (a and b) must not alias.
+__global__ void __launch_bounds__(MERGE_CTA_SIZE, MERGE_MIN_BLOCKS)
+    MergePersistentKernel(const PersistentMergeArgs args)
+{
+    const int total = args.queue_state->total_queue_items;
+    if (total == 0)
+    {
+        return;
+    }
+
+    // smem layout: [A(a_count) | sentinel | B(b_count) | sentinel | padding]
+    // IPT extra slots past data guarantee unconditional merge reloads are
+    // safe even for partial-tile threads (no bounds checks in the loop).
+    // the first int is aliased as the queue-position broadcast slot, safe
+    // because it is consumed into registers before MergePartition overwrites smem.
+    __shared__ int2 smem_pairs[MERGE_PARTITION_SIZE + MERGE_ITEMS_PER_THREAD];
+
+    while (true)
+    {
+        if (threadIdx.x == 0)
+        {
+            reinterpret_cast<int *>(smem_pairs)[0] = atomicAdd(&args.queue_state->queue_head, 1);
+        }
+        __syncthreads(); // broadcast pos to all threads
+        const int pos = reinterpret_cast<int *>(smem_pairs)[0];
+        if (pos >= total)
+        {
+            return;
+        }
+
+        // spin until queue_tail has advanced past our slot (producer committed)
+        if (threadIdx.x == 0)
+        {
+            while (pos >= LoadRelaxedGpu(&args.queue_state->queue_tail))
+            {
+                __nanosleep(32);
+            }
+        }
+        __syncthreads(); // broadcast spin completion to all threads
+        __threadfence(); // acquire: see producer's entry + data writes
+
+        const MergeWorkItem work_item = args.work_items[pos];
+        const MergeTreeNode node      = args.tree_nodes[work_item.node_idx];
+        const int merge_stride        = node.stride_and_flag & 0x7FFFFFFF;
+        const int flag                = node.stride_and_flag & 0x80000000;
+        const int a_end               = min(node.begin + merge_stride, node.end);
+        const int4 desc =
+            make_int4(node.begin, a_end, node.end, (work_item.partition_idx * MERGE_PARTITION_SIZE) | flag);
+
+        MergePartition(desc, args.keys_a, args.vals_a, args.keys_b, args.vals_b, smem_pairs);
+
+        __threadfence(); // release: per-thread, flush this thread's output writes
+        __syncthreads(); // ensure all threads have fenced before warp 0 signals
+
+        if (threadIdx.x < 32)
+        {
+            UpdateMergeQueue(args, work_item, node);
+        }
+        // no __syncthreads() needed: next iteration's s_pos broadcast synchronizes
+    }
+}
+
+// emit CAPACITY-chunked overflow blocks for T3 overflow re-sort.
+// sign bit of the block descriptor's begin field tells the overflow kernel
+// which ping-pong buffer to write to: k-odd segments start from B, k-even
+// from A, so that after all merge passes every segment's result lands in
+// buffer A.
+// CTA-cooperative: must be called by all CTA_SIZE threads.
+template<int CTA_SIZE>
+__device__ void WriteOverflowBlocks(const BlockSortArgs &args, int seg_start, int seg_end, int seg_size,
+                                    int n_merge_passes, int32_t *smem)
+{
+    constexpr int CAPACITY = CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+    const int flag         = (n_merge_passes & 1) << 31;
+    const int n_blocks     = (seg_size + CAPACITY - 1) / CAPACITY;
+    if (threadIdx.x == 0)
+    {
+        smem[0] = atomicAdd(&args.overflow_state->block_count, n_blocks);
+    }
+    __syncthreads();
+    const int base_idx = smem[0];
+#pragma unroll 1
+    for (int c = threadIdx.x; c < n_blocks; c += CTA_SIZE)
+    {
+        args.overflow_blocks[base_idx + c] =
+            make_int2((seg_start + c * CAPACITY) | flag, min(seg_start + (c + 1) * CAPACITY, seg_end));
+    }
+}
+
+// build a binary merge tree for one overflow segment and enqueue leaf-level
+// partitions into the FIFO queue.
+//
+// the segment was pre-sorted into sorted_run_count = ceil(seg_size / CAPACITY)
+// fixed-size runs by the block-sort phase. the merge tree groups adjacent runs
+// at each level, doubling the merged run size until one sorted run remains:
+//
+//   level 0 (leaves): nodes merging 1x-capacity runs  → 2x-capacity merged runs
+//   level 1:          nodes merging 2x-capacity runs  → 4x-capacity merged runs
+//   ...
+//   level n_merge_passes-1 (root): final merge covering the entire segment
+//
+// every level includes copy nodes for odd leftovers (degenerate node with
+// empty B run) so all runs land in the correct ping-pong buffer.
+//
+// the tree is laid out contiguously in the global tree_nodes array starting
+// at tree_base_idx (reserved via atomicAdd). leaf-level partitions are
+// enqueued into the FIFO queue with a single batched atomicAdd on queue_tail.
+//
+// CTA-cooperative: must be called by all CTA_SIZE threads.
+template<int CTA_SIZE>
+__device__ void WriteMergeTree(const BlockSortArgs &args, int seg_start, int seg_end, int seg_size, int n_merge_passes,
+                               int32_t *smem)
+{
+    constexpr int CAPACITY             = CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+    constexpr int FULL_LEAF_NODE_SIZE  = 2 * CAPACITY;
+    constexpr int FULL_LEAF_PARTITIONS = (FULL_LEAF_NODE_SIZE + MERGE_PARTITION_SIZE - 1) / MERGE_PARTITION_SIZE;
+
+    const int sorted_run_count = (seg_size + CAPACITY - 1) / CAPACITY;
+    const int leaf_node_count  = (sorted_run_count + 1) / 2;
+
+    // ping-pong direction flag for leaf level: ensures the final merge pass
+    // writes to buffer A regardless of how many passes there are
+    const int leaf_ping_pong_flag = (n_merge_passes & 1) << 31;
+
+    // total tree nodes via Legendre's formula (p=2):
+    // sum_{k=1}^{P} ceil(n/2^k) = (n-1) - popcount(n-1) + P
+    const int total_node_count = (sorted_run_count - 1) - __popc(sorted_run_count - 1) + n_merge_passes;
+
+    // every leaf node except the last covers exactly FULL_LEAF_NODE_SIZE items
+    // and produces exactly FULL_LEAF_PARTITIONS merge partitions. the last
+    // node may be smaller (partial second run or single-run copy node).
+    const int last_leaf_begin = seg_start + (leaf_node_count - 1) * FULL_LEAF_NODE_SIZE;
+    const int last_leaf_end   = min(min(last_leaf_begin + CAPACITY, seg_end) + CAPACITY, seg_end);
+    const int last_leaf_partitions =
+        (last_leaf_end - last_leaf_begin + MERGE_PARTITION_SIZE - 1) / MERGE_PARTITION_SIZE;
+    const int leaf_partition_count = (leaf_node_count - 1) * FULL_LEAF_PARTITIONS + last_leaf_partitions;
+
+    // batch all global reservations in one thread-0 block, broadcast via smem.
+    //   smem[0]: queue_base  — starting index in the FIFO queue for leaf entries
+    //   smem[1]: tree_base   — starting index in the tree_nodes array for this tree
+    //   smem[2]: accumulator — per-thread internal partition counts (smem atomic)
+    int *smem_queue_base     = &smem[0];
+    int *smem_tree_base      = &smem[1];
+    int *smem_internal_parts = &smem[2];
+    if (threadIdx.x == 0)
+    {
+        atomicAdd(&args.merge_queue_state->queue_reserved, leaf_partition_count);
+        *smem_queue_base     = atomicAdd(&args.merge_queue_state->queue_tail, leaf_partition_count);
+        *smem_tree_base      = atomicAdd(&args.merge_queue_state->total_tree_nodes, total_node_count);
+        *smem_internal_parts = 0;
+    }
+    __syncthreads();
+
+    const int tree_base_idx = *smem_tree_base;
+
+    // -- leaf level (d=0) --
+    // write node metadata and done counters. leaf nodes at indices
+    // [tree_base_idx, tree_base_idx + leaf_node_count). each leaf's parent
+    // is at the next level: leaf p's parent is the (p/2)-th node at level 1.
+#pragma unroll 1
+    for (int p = threadIdx.x; p < leaf_node_count; p += CTA_SIZE)
+    {
+        const int node_begin = seg_start + p * FULL_LEAF_NODE_SIZE;
+        const int node_end   = (p < leaf_node_count - 1) ? node_begin + FULL_LEAF_NODE_SIZE : last_leaf_end;
+        const int node_idx   = tree_base_idx + p;
+        const int parent     = (n_merge_passes > 1) ? tree_base_idx + leaf_node_count + p / 2 : -1;
+
+        args.tree_nodes[node_idx]       = {.begin           = node_begin,
+                                           .end             = node_end,
+                                           .stride_and_flag = leaf_ping_pong_flag | CAPACITY,
+                                           .parent_idx      = parent};
+        args.node_done_counts[node_idx] = 0;
+    }
+
+    // enqueue leaf partitions into the FIFO queue. flat CTA-strided loop over
+    // all leaf_partition_count entries. node index and partition index within
+    // the node are derived from the flat index via constexpr division by
+    // FULL_LEAF_PARTITIONS (compiler emits multiply-high, no actual division).
+    // the last node may have fewer partitions, handled by the else branch.
+#pragma unroll 1
+    for (int i = threadIdx.x; i < leaf_partition_count; i += CTA_SIZE)
+    {
+        int leaf_node_idx;
+        int partition_idx;
+        if (i < (leaf_node_count - 1) * FULL_LEAF_PARTITIONS)
+        {
+            leaf_node_idx = i / FULL_LEAF_PARTITIONS;
+            partition_idx = i - leaf_node_idx * FULL_LEAF_PARTITIONS;
+        }
+        else
+        {
+            leaf_node_idx = leaf_node_count - 1;
+            partition_idx = i - (leaf_node_count - 1) * FULL_LEAF_PARTITIONS;
+        }
+        args.work_items[*smem_queue_base + i] = {.node_idx      = tree_base_idx + leaf_node_idx,
+                                                 .partition_idx = partition_idx};
+    }
+
+    // -- internal levels (d=1 .. n_merge_passes-1) --
+    // internal nodes are numbered 0..internal_node_count-1 across all levels:
+    //   [0, count_at_level_1)                                  → level 1
+    //   [count_at_level_1, count_at_level_1 + count_at_level_2) → level 2
+    //   ...
+    // each thread locates its level by scanning cumulative counts in registers.
+    // node count at level k: ((sorted_run_count - 1) >> (k + 1)) + 1
+    const int internal_node_count = total_node_count - leaf_node_count;
+    int local_internal_parts      = 0;
+
+#pragma unroll 1
+    for (int flat_idx = threadIdx.x; flat_idx < internal_node_count; flat_idx += CTA_SIZE)
+    {
+        // scan cumulative node counts to find which level this node belongs to
+        int tree_level  = 1;
+        int level_start = 0;
+        int cumulative  = 0;
+#pragma unroll 1
+        for (int k = 1; k < n_merge_passes - 1; k++)
+        {
+            cumulative += ((sorted_run_count - 1) >> (k + 1)) + 1;
+            if (flat_idx >= cumulative)
+            {
+                tree_level  = k + 1;
+                level_start = cumulative;
+            }
+        }
+        const int pos_in_level = flat_idx - level_start;
+
+        // merge node geometry: at level d, each node merges two runs of
+        // (CAPACITY << d) items, starting at seg_start + pos * 2 * stride
+        const int merge_stride = CAPACITY << tree_level;
+        const int node_begin   = seg_start + pos_in_level * 2 * merge_stride;
+        const int node_end     = min(min(node_begin + merge_stride, seg_end) + merge_stride, seg_end);
+        const int n_partitions = (node_end - node_begin + MERGE_PARTITION_SIZE - 1) / MERGE_PARTITION_SIZE;
+        local_internal_parts += n_partitions;
+
+        // position of this node within the segment's tree
+        const int tree_offset = leaf_node_count + level_start + pos_in_level;
+        const int node_idx    = tree_base_idx + tree_offset;
+
+        // parent is at the next level, position pos_in_level / 2
+        int parent = -1;
+        if (tree_level + 1 < n_merge_passes)
+        {
+            const int nodes_at_this_level = ((sorted_run_count - 1) >> (tree_level + 1)) + 1;
+            const int next_level_start    = tree_offset - pos_in_level + nodes_at_this_level;
+            parent                        = tree_base_idx + next_level_start + pos_in_level / 2;
+        }
+
+        const int ping_pong_flag  = ((tree_level & 1) ^ (n_merge_passes & 1)) << 31;
+        args.tree_nodes[node_idx] = {.begin           = node_begin,
+                                     .end             = node_end,
+                                     .stride_and_flag = ping_pong_flag | merge_stride,
+                                     .parent_idx      = parent};
+
+        // child count: 2 if both child nodes exist at the level below,
+        // 1 if this is a copy node (odd leftover at the end of that level)
+        const int child_node_count      = ((sorted_run_count - 1) >> tree_level) + 1;
+        const int n_children            = (2 * pos_in_level + 1 < child_node_count) ? 2 : 1;
+        args.node_done_counts[node_idx] = -n_children;
+    }
+
+    // reduce per-thread internal partition counts via smem atomic,
+    // then thread 0 commits the total to the global queue state
+    if (local_internal_parts > 0)
+    {
+        atomicAdd(smem_internal_parts, local_internal_parts);
+    }
+    __syncthreads();
+    if (threadIdx.x == 0)
+    {
+        atomicAdd(&args.merge_queue_state->total_queue_items, leaf_partition_count + *smem_internal_parts);
+    }
+}
+
+// radix sort one segment in-CTA: load warp-striped, rank, scatter, write coalesced.
+// warp-striped arrangement is required by BlockRadixRankMatch for stability:
+// the ranking loop processes items in ITEM-major order (all lanes' ITEM=0,
+// then ITEM=1, ...). for equal-digit items to preserve original order, ITEM=0
+// across lanes must map to logically earlier positions than ITEM=1. warp-striped
+// satisfies this (lane l's ITEM=i → position w*WS*IPT + l + i*WS, monotone in i).
+template<int CTA_SIZE>
+__device__ void BlockRadixSortSegment(BlockSortSmem<CTA_SIZE> &smem, const int32_t *keys_in, const int32_t *values_in,
+                                      int32_t *out_keys, int32_t *out_vals, int seg_start, int seg_size)
+{
+    constexpr int WARP_THREADS = 32;
+    constexpr int END_BIT      = 32;
+
+    const int warp_id     = threadIdx.x / WARP_THREADS;
+    const int lane        = threadIdx.x % WARP_THREADS;
+    const int warp_offset = warp_id * WARP_THREADS * BLOCK_SORT_ITEMS_PER_THREAD;
+
+    // load in warp-striped order: thread (warp w, lane l) owns logical positions
+    //   [w*WS*IPT + l, w*WS*IPT + l+WS, w*WS*IPT + l+2*WS, ...].
+    // blocked arrangement would break stability because lane l's ITEM=i maps to
+    // l*IPT + i, so lane 1's ITEM=0 (= IPT) can be logically after lane 0's
+    // ITEM=1 (= 1), yet it would be ranked first.
+    // the layout is also naturally coalesced: consecutive lanes access consecutive
+    // addresses within each warp.
+    uint32_t keys[BLOCK_SORT_ITEMS_PER_THREAD];
+    int32_t vals[BLOCK_SORT_ITEMS_PER_THREAD];
+
+#pragma unroll
+    for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+    {
+        const int idx = warp_offset + lane + i * WARP_THREADS;
+        if (idx < seg_size)
+        {
+            keys[i] = static_cast<uint32_t>(keys_in[seg_start + idx]) ^ 0x80000000u;
+            vals[i] = values_in[seg_start + idx];
+        }
+        else
+        {
+            keys[i] = 0xFFFFFFFFu;
+            vals[i] = 0;
+        }
+    }
+
+    int begin_bit = 0;
+    while (true)
+    {
+        const int pass_bits = min(BLOCK_SORT_RADIX_BITS, END_BIT - begin_bit);
+        const cub::BFEDigitExtractor<uint32_t> extractor(begin_bit, pass_bits);
+
+        int ranks[BLOCK_SORT_ITEMS_PER_THREAD];
+        BlockSortRankT<CTA_SIZE>(smem.rank).RankKeys(keys, ranks, extractor);
+        begin_bit += BLOCK_SORT_RADIX_BITS;
+        __syncthreads();
+
+        if (begin_bit >= END_BIT)
+        {
+            // last pass: no further ranking, so no need to maintain warp-striped.
+            // scatter vals to striped (thread t gets positions [t, t+BT, t+2*BT, ...])
+            // for coalesced output writes. if keys_out is requested, scatter keys too.
+#pragma unroll
+            for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+            {
+                smem.raw[ranks[i]] = vals[i];
+            }
+            __syncthreads();
+#pragma unroll
+            for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+            {
+                vals[i] = smem.raw[threadIdx.x + i * CTA_SIZE];
+            }
+
+            if (out_keys)
+            {
+                __syncthreads();
+#pragma unroll
+                for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+                {
+                    smem.raw[ranks[i]] = static_cast<int32_t>(keys[i] ^ 0x80000000u);
+                }
+                __syncthreads();
+#pragma unroll
+                for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+                {
+                    keys[i] = static_cast<uint32_t>(smem.raw[threadIdx.x + i * CTA_SIZE]);
+                }
+            }
+            break;
+        }
+
+        // scatter items to their ranked positions, then read back in warp-striped
+        // order to re-establish the arrangement for the next ranking pass.
+        auto scatterWarpStriped = [&](auto &items, const int(&ranks)[BLOCK_SORT_ITEMS_PER_THREAD]) {
+#pragma unroll
+            for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+            {
+                smem.raw[ranks[i]] = items[i];
+            }
+            __syncthreads();
+#pragma unroll
+            for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+            {
+                items[i] = smem.raw[warp_offset + lane + i * WARP_THREADS];
+            }
+            __syncthreads();
+        };
+
+        scatterWarpStriped(keys, ranks);
+        scatterWarpStriped(vals, ranks);
+    }
+
+    // write output in striped arrangement (coalesced: consecutive threads write
+    // consecutive addresses).
+#pragma unroll
+    for (int i = 0; i < BLOCK_SORT_ITEMS_PER_THREAD; i++)
+    {
+        const int idx = threadIdx.x + i * CTA_SIZE;
+        if (idx < seg_size)
+        {
+            out_vals[seg_start + idx] = vals[i];
+            if (out_keys)
+            {
+                out_keys[seg_start + idx] = static_cast<int32_t>(keys[i]);
+            }
+        }
+    }
+}
+
+// Block-level segmented sort kernel.
+// All tiers target 512 threads/SM occupancy: min_blocks = 512 / CTA_SIZE.
+// This constrains the compiler's register allocation uniformly across tiers.
+//
+// supports in-place operation (keys_in == keys_out and/or values_in == values_out
+// for the same segment range) because each CTA loads its entire segment into
+// registers before writing any output. different segments occupy disjoint
+// index ranges, so no cross-CTA aliasing hazard exists.
+//
+// IS_PERSISTENT: persistent-CTA mode for overflow block sorting.
+// a fixed grid of CTAs loops, claiming block indices from an atomic
+// counter until all work is consumed. avoids host sync to read the count.
+template<int CTA_SIZE, int MIN_SIZE = 0, bool IS_EPILOG = false, bool IS_PERSISTENT = false>
+__global__ void __launch_bounds__(CTA_SIZE, 512 / CTA_SIZE) BlockSortKernel(const BlockSortArgs args)
+{
+#if __CUDA_ARCH__ >= 900
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+
+    constexpr int CAPACITY = CTA_SIZE * BLOCK_SORT_ITEMS_PER_THREAD;
+    __shared__ BlockSortSmem<CTA_SIZE> smem;
+
+    if constexpr (IS_PERSISTENT)
+    {
+        const int n_blocks = args.overflow_state->block_count;
+
+        while (true)
+        {
+            if (threadIdx.x == 0)
+            {
+                smem.raw[0] = atomicAdd(&args.overflow_state->claim_counter, 1);
+            }
+            __syncthreads();
+            const int block_idx = smem.raw[0];
+            if (block_idx >= n_blocks)
+            {
+                return;
+            }
+
+            const int2 block_desc = args.overflow_blocks[block_idx];
+            const bool to_b       = (block_desc.x < 0);
+            const int block_begin = block_desc.x & 0x7FFFFFFF;
+            const int block_size  = block_desc.y - block_begin;
+
+            int32_t *out_vals = to_b ? args.values_out_b : args.values_out;
+            int32_t *out_keys = to_b ? args.keys_out_b : args.keys_out;
+
+            BlockRadixSortSegment<CTA_SIZE>(smem, args.keys_in, args.values_in, out_keys, out_vals, block_begin,
+                                            block_size);
+            // no __syncthreads() needed here: the barrier at the top of the
+            // next iteration (broadcasting smem.raw[0]) synchronizes all threads.
+            // BlockRadixSortSegment's last smem accesses are reads into registers;
+            // the subsequent DRAM output writes don't touch smem.
+        }
+    }
+    else
+    {
+        const int seg_idx = blockIdx.x;
+        int seg_start, seg_end;
+
+        // when offsets == nullptr this is the standalone overflow block-sort
+        // path; the sign bit of the block descriptor's begin field selects
+        // which ping-pong buffer to write to (set by the epilog based on
+        // n_merge_passes parity so that all segments converge to buffer A
+        // after the merge passes).
+        int32_t *out_vals = args.values_out;
+        int32_t *out_keys = args.keys_out;
+        if (args.offsets)
+        {
+            seg_start = args.offsets[seg_idx];
+            seg_end   = args.offsets[seg_idx + 1];
+        }
+        else
+        {
+            const int2 block_desc = args.overflow_blocks[seg_idx];
+            const bool to_b       = (block_desc.x < 0);
+            seg_start             = block_desc.x & 0x7FFFFFFF;
+            seg_end               = block_desc.y;
+            if (to_b)
+            {
+                out_vals = args.values_out_b;
+                out_keys = args.keys_out_b;
+            }
+        }
+        const int seg_size = seg_end - seg_start;
+
+        if (seg_size <= MIN_SIZE || seg_size > CAPACITY)
+        {
+            if constexpr (IS_EPILOG)
+            {
+                if (seg_size > CAPACITY)
+                {
+                    const int n_merge_passes = 32 - __clz((seg_size - 1) / CAPACITY);
+
+                    WriteOverflowBlocks<CTA_SIZE>(args, seg_start, seg_end, seg_size, n_merge_passes, smem.raw);
+
+                    if (args.merge_queue_state)
+                    {
+                        WriteMergeTree<CTA_SIZE>(args, seg_start, seg_end, seg_size, n_merge_passes, smem.raw);
+                    }
+                }
+            }
+            return;
+        }
+
+        BlockRadixSortSegment<CTA_SIZE>(smem, args.keys_in, args.values_in, out_keys, out_vals, seg_start, seg_size);
+    }
+}
+
+} // namespace seg_sort
+
+// two-pass setup for the segmented sort scratch buffer.
+// pass 1 (scratch == nullptr): computes and returns the required byte count.
+// pass 2 (scratch != nullptr): lays out sub-regions within the provided buffer
+//   and populates the state struct. always returns the total size.
+//
+// capacities are worst-case upper bounds assuming any single overflow segment
+// could span all n_items. each entry has an explicit alignment: 32 bytes for
+// structs containing L2-sector-padded atomic counters, 256 bytes for bulk
+// arrays.
+size_t SegmentedSortSetup(SegmentedSortState &s, int32_t n_segments, int32_t n_items, void *scratch)
+{
+    using namespace seg_sort;
+
+    // max merge passes for one segment
+    const int n_max_merge_passes = (int)std::ceil(std::log2(std::fmax((double)n_items / BLOCK_SORT_T3_CAPACITY, 1.0)));
+    // upper bound on overflow block descriptors across all segments
+    const int overflow_blocks_cap = n_items / BLOCK_SORT_T3_CAPACITY + n_segments;
+    // upper bound on tree nodes across all overflow segments.
+    // per-segment node count via Legendre: nodes(r) = (r-1) - popcount(r-1) + P.
+    // the ratio nodes(r)/r peaks at ~1.25 for small r and approaches 1.0 for
+    // large r. 3/2 is a proven upper bound: nodes(r) ≤ r + ceil(log2(r)) - 1 ≤ 3r/2.
+    const int max_tree_nodes = overflow_blocks_cap + overflow_blocks_cap / 2;
+    // upper bound on total merge queue items across all tree levels
+    const int merge_pass_stride = n_items / MERGE_PARTITION_SIZE + 1;
+    const int max_merge_queue   = n_max_merge_passes * merge_pass_stride;
+
+    // zero-init fields MUST come first: they are zeroed with a single memset
+    // from the scratch base before each sort run. changing their order or
+    // moving non-zero-init fields before them will break the memset.
+    //
+    // alignment = 32 for structs whose members are individually padded to
+    // 32-byte L2 sector boundaries (OverflowState, MergeQueueState), so
+    // concurrent atomics to different counters never share an L2 sector.
+    // alignment = 256 for bulk arrays (cache-line alignment).
+    constexpr int N_ZERO_INIT       = 2;
+    constexpr int N_ENTRIES         = 6;
+    ScratchEntry entries[N_ENTRIES] = {
+        {s.overflow_state, 1, 32},
+        {s.merge_queue_state, 1, 32},
+        {s.node_done_counts, max_tree_nodes, 256},
+        {s.work_items, max_merge_queue, 256},
+        {s.overflow_blocks, overflow_blocks_cap, 256},
+        {s.tree_nodes, max_tree_nodes, 256},
+    };
+
+    auto alignUp = [](size_t x, size_t a) -> size_t { return (x + a - 1) & ~(a - 1); };
+
+    size_t offsets[N_ENTRIES];
+    size_t total = 0;
+    for (int i = 0; i < N_ENTRIES; i++)
+    {
+        total      = alignUp(total, entries[i].alignment);
+        offsets[i] = total;
+        total += entries[i].elem_size * entries[i].count;
+    }
+    total = alignUp(total, 256);
+
+    if (!scratch)
+    {
+        return total;
+    }
+
+    s.n_segments         = n_segments;
+    s.n_items            = n_items;
+    s.n_max_merge_passes = n_max_merge_passes;
+
+    char *base = static_cast<char *>(scratch);
+    for (int i = 0; i < N_ENTRIES; i++)
+    {
+        *entries[i].ptr = entries[i].count > 0 ? base + offsets[i] : nullptr;
+    }
+
+    s.run_init_ptr  = scratch;
+    s.run_init_size = offsets[N_ZERO_INIT];
+
+    if (!s.sm_count)
+    {
+        cudaDeviceGetAttribute(&s.sm_count, cudaDevAttrMultiProcessorCount, 0);
+    }
+
+    return total;
+}
+
+int SegmentedSortAsync(const SegmentedSortState &st, const int32_t *d_offsets, int32_t *const *d_keys,
+                       int32_t *const *d_values, cudaStream_t s)
+{
+    using namespace seg_sort;
+
+    if (st.n_segments <= 0 || st.n_items <= 0)
+    {
+        return 0;
+    }
+
+    cudaMemsetAsync(st.run_init_ptr, 0, st.run_init_size, s);
+
+    // buffer A = caller's index 0 (input + final result)
+    // buffer B = caller's index 1 (working space)
+
+    // cascade tiers T0-T2: sort segments that fit within their capacity.
+    // values are written in-place back to buffer A (safe: single CTA per
+    // segment loads all items into registers before writing).
+    const BlockSortArgs cascade_args = {.n_segments = st.n_segments,
+                                        .n_items    = st.n_items,
+                                        .offsets    = d_offsets,
+                                        .keys_in    = d_keys[0],
+                                        .values_in  = d_values[0],
+                                        .values_out = d_values[0]};
+
+    // cascade tier T3 (epilog): sorts T3-sized segments and emits overflow
+    // descriptors (blocks, merge tree) for segments that exceed T3 capacity
+    const BlockSortArgs cascade_epilog_args = {.n_segments        = st.n_segments,
+                                               .n_items           = st.n_items,
+                                               .offsets           = d_offsets,
+                                               .keys_in           = d_keys[0],
+                                               .values_in         = d_values[0],
+                                               .values_out        = d_values[0],
+                                               .overflow_blocks   = st.overflow_blocks,
+                                               .overflow_state    = st.overflow_state,
+                                               .merge_queue_state = st.merge_queue_state,
+                                               .tree_nodes        = st.tree_nodes,
+                                               .node_done_counts  = st.node_done_counts,
+                                               .work_items        = st.work_items};
+
+    // persistent overflow: re-sorts oversized segments in T3-capacity blocks.
+    // fixed grid reads block_count on-device; each CTA claims overflow blocks
+    // via atomic counter until all are processed.
+    // if there are no overflow segments, all CTAs exit immediately.
+    const BlockSortArgs overflow_args = {.n_items         = st.n_items,
+                                         .keys_in         = d_keys[0],
+                                         .values_in       = d_values[0],
+                                         .values_out      = d_values[0],
+                                         .keys_out        = d_keys[0],
+                                         .overflow_blocks = st.overflow_blocks,
+                                         .overflow_state  = st.overflow_state,
+                                         .values_out_b    = d_values[1],
+                                         .keys_out_b      = d_keys[1]};
+
+    // PDL attribute: allows the driver to overlap consecutive tier launches on
+    // SM 9.0+. on older hardware the attribute is silently ignored and the
+    // kernels execute with normal stream serialization.
+    cudaLaunchAttribute pdl_attr;
+    pdl_attr.id                                         = cudaLaunchAttributeProgrammaticStreamSerialization;
+    pdl_attr.val.programmaticStreamSerializationAllowed = 1;
+
+    auto launchPdl = [&](auto kernel_fn, int block_threads, const BlockSortArgs &args) {
+        cudaLaunchConfig_t config = {};
+        config.gridDim            = dim3(st.n_segments);
+        config.blockDim           = dim3(block_threads);
+        config.stream             = s;
+        config.attrs              = &pdl_attr;
+        config.numAttrs           = 1;
+        cudaLaunchKernelEx(&config, kernel_fn, args);
+    };
+
+    // T0: first in chain, normal launch
+    BlockSortKernel<BLOCK_SORT_T0_CTA_SIZE, BLOCK_SORT_T0_MIN_SIZE>
+        <<<st.n_segments, BLOCK_SORT_T0_CTA_SIZE, 0, s>>>(cascade_args);
+    // T1-T3: PDL secondaries — can overlap with the preceding tier
+    launchPdl(BlockSortKernel<BLOCK_SORT_T1_CTA_SIZE, BLOCK_SORT_T1_MIN_SIZE>, BLOCK_SORT_T1_CTA_SIZE, cascade_args);
+    launchPdl(BlockSortKernel<BLOCK_SORT_T2_CTA_SIZE, BLOCK_SORT_T2_MIN_SIZE>, BLOCK_SORT_T2_CTA_SIZE, cascade_args);
+    launchPdl(BlockSortKernel<BLOCK_SORT_T3_CTA_SIZE, BLOCK_SORT_T3_MIN_SIZE, true>, BLOCK_SORT_T3_CTA_SIZE,
+              cascade_epilog_args);
+
+    BlockSortKernel<BLOCK_SORT_T3_CTA_SIZE, BLOCK_SORT_T0_MIN_SIZE, false, true>
+        <<<st.sm_count, BLOCK_SORT_T3_CTA_SIZE, 0, s>>>(overflow_args);
+
+    // persistent merge: a single kernel launch processes the entire merge tree.
+    // the T3 epilog has already built the tree and seeded the FIFO queue with
+    // leaf-level partitions. the kernel dynamically enqueues parent nodes as
+    // children complete. exits when total_queue_items are consumed.
+    const PersistentMergeArgs merge_args = {
+        st.merge_queue_state, st.tree_nodes, st.node_done_counts, st.work_items, d_keys[0],
+        d_values[0],          d_keys[1],     d_values[1]};
+    MergePersistentKernel<<<MERGE_MIN_BLOCKS * st.sm_count, MERGE_CTA_SIZE, 0, s>>>(merge_args);
+
+    return 0;
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SegmentedSort.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SegmentedSort.h
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace higs {
+
+// internal API for the segmented sort pipeline.
+//
+// the sort handles variable-length segments via a cascade of block-sort
+// kernels followed by a merge phase for the largest segments.
+//
+// block-sort cascade:
+//   four tiers handle progressively larger segments. each tier sorts
+//   segments up to its capacity and skips the rest. the highest tier
+//   also acts as an epilog: segments exceeding its capacity are split
+//   into fixed-size blocks and queued for the overflow + merge phases.
+//
+// overflow block sort:
+//   sorts each overflow block independently. the persistent variant
+//   claims work from a GPU-side atomic counter.
+//
+// merge phase:
+//   iterative 2-way merge-path passes double the sorted run length each
+//   pass, ping-ponging between the caller's two buffer pairs (A and B)
+//   until all overflow segments are fully merged. parity flags ensure the
+//   final pass always writes to buffer A (index 0).
+namespace seg_sort {
+
+// one node in the binary merge tree. describes a 2-way merge of two
+// adjacent sorted runs within an overflow segment. the split point
+// (a_end) and partition count are derived at use:
+//   a_end        = min(begin + (stride_and_flag & 0x7FFFFFFF), end)
+//   n_partitions = (end - begin + MERGE_PARTITION_SIZE - 1) / MERGE_PARTITION_SIZE
+//   flag         = stride_and_flag & 0x80000000
+struct __align__(16) MergeTreeNode
+{
+    int begin;           // start of merge range
+    int end;             // end of merge range
+    int stride_and_flag; // sign bit = ping-pong direction, lower 31 bits = merge stride
+    int parent_idx;      // index in tree_nodes array, -1 for root
+};
+
+// one work item in the FIFO merge queue. aligned to 8 bytes so the
+// compiler uses a single 64-bit load/store for the pair.
+struct __align__(8) MergeWorkItem
+{
+    int32_t node_idx;
+    int32_t partition_idx;
+};
+
+// scalar counters for the overflow block-sort phase. zero-init before each
+// sort run. each field is padded to a 32-byte L2 sector boundary so that
+// concurrent atomics from different kernels never serialize on the same
+// L2 atomic unit.
+struct __align__(32) OverflowState
+{
+    alignas(32) int32_t block_count;   // number of overflow blocks (T3 epilog atomicAdd)
+    alignas(32) int32_t claim_counter; // persistent overflow kernel work-claim counter (atomicAdd)
+};
+
+// scalar counters shared between the T3 epilog (producer) and the
+// persistent merge kernel (consumer). zero-init before each sort run.
+// each field is padded to a 32-byte L2 sector boundary so that concurrent
+// atomics to different counters never serialize on the same L2 atomic unit.
+//
+// queue_tail is the commit counter: consumers may read slots with
+// index < queue_tail. the T3 epilog uses queue_tail as both reservation
+// and commit (safe via stream ordering). the merge kernel reserves via
+// queue_reserved and commits to queue_tail with an ordered CAS.
+struct __align__(32) MergeQueueState
+{
+    alignas(32) int32_t total_tree_nodes;  // tree node allocator (T3 epilog atomicAdd)
+    alignas(32) int32_t total_queue_items; // total partitions across all tree levels (termination bound)
+    alignas(32) int32_t queue_head;        // consumer cursor (merge kernel atomicAdd)
+    alignas(32) int32_t queue_tail;        // commit counter: items at [0, tail) are readable
+    alignas(32) int32_t queue_reserved;    // reservation counter for dynamic enqueue during merge
+};
+
+struct PersistentMergeArgs
+{
+    MergeQueueState *queue_state;
+    MergeTreeNode *tree_nodes;
+    int32_t *node_done_counts;
+    MergeWorkItem *work_items;
+    int32_t *keys_a;
+    int32_t *vals_a;
+    int32_t *keys_b;
+    int32_t *vals_b;
+};
+
+struct MergeArgs
+{
+    const int4 *partitions;
+    int32_t *keys_a;
+    int32_t *vals_a;
+    int32_t *keys_b;
+    int32_t *vals_b;
+};
+
+struct BlockSortArgs
+{
+    int32_t n_segments;
+    int32_t n_items;
+    const int32_t *offsets;
+    const int32_t *keys_in;
+    const int32_t *values_in;
+
+    int32_t *values_out;
+    int32_t *keys_out;
+
+    int2 *overflow_blocks;
+    OverflowState *overflow_state;
+
+    MergeQueueState *merge_queue_state;
+    MergeTreeNode *tree_nodes;
+    int32_t *node_done_counts;
+    MergeWorkItem *work_items;
+
+    int32_t *values_out_b;
+    int32_t *keys_out_b;
+};
+
+struct PipelineState
+{
+    // host-side layout parameters, set by SegmentedSortSetup
+    int32_t n_segments     = 0;
+    int32_t n_items        = 0;
+    int n_max_merge_passes = 0;
+    int sm_count           = 0;
+
+    // overflow bookkeeping (device); written by T3 epilog, consumed by
+    // the persistent overflow kernel
+    struct OverflowState *overflow_state = nullptr;
+    int2 *overflow_blocks                = nullptr;
+
+    // merge tree + FIFO queue (device); the T3 epilog builds a binary merge
+    // tree and seeds the queue with leaf-level work. the persistent merge
+    // kernel consumes items, tracks per-node completion, and dynamically
+    // enqueues parent nodes as their children finish.
+    struct MergeQueueState *merge_queue_state = nullptr;
+    struct MergeTreeNode *tree_nodes          = nullptr;
+    int32_t *node_done_counts                 = nullptr;
+    struct MergeWorkItem *work_items          = nullptr;
+
+    // range within scratch that must be zeroed before each sort run
+    void *run_init_ptr   = nullptr;
+    size_t run_init_size = 0;
+};
+
+} // namespace seg_sort
+
+using SegmentedSortState = seg_sort::PipelineState;
+
+// two-pass setup for the sort pipeline scratch memory.
+//   pass 1: scratch = nullptr  -> computes and returns required byte count
+//   pass 2: scratch != nullptr -> lays out sub-regions within the provided buffer
+// returns the total scratch size in bytes (256-aligned).
+size_t SegmentedSortSetup(SegmentedSortState &s, int32_t n_segments, int32_t n_items, void *scratch);
+
+// sort values by key within each segment defined by d_offsets[0..n_segments].
+// segment i spans items [d_offsets[i], d_offsets[i+1]).
+// n_segments and n_items are read from the state set by SegmentedSortSetup.
+//
+// d_keys and d_values are host arrays of 2 device pointers each (double
+// buffers). input is expected in d_keys[0] / d_values[0]. both buffer
+// pairs are used as working space and may be modified. only sorted values
+// are guaranteed; key buffers contain intermediate merge data.
+//
+// returns the buffer index (0 or 1) where the sorted values reside.
+// the result is deterministic and requires no device synchronization.
+int SegmentedSortAsync(const SegmentedSortState &st, const int32_t *d_offsets, int32_t *const *d_keys,
+                       int32_t *const *d_values, cudaStream_t s);
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.cu
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/core/Tensor.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_fp16.h>
+#include <type_traits>
+
+#include "Common.h"
+#include "SHCommon.h"
+#include "SHCompression.h"
+#include "SphericalHarmonics.h"
+#include "Utils.h"
+
+namespace higs {
+
+static constexpr bool SHEVAL_COMPACTION = true;
+static constexpr int SHEVAL_CTA_SIZE    = 256;
+static constexpr int SHEVAL_MIN_CTAS    = 4;
+
+static_assert(SHEVAL_CTA_SIZE % 32 == 0 && SHEVAL_CTA_SIZE <= 1024,
+              "SHEVAL_CTA_SIZE must be a multiple of 32 and at most 1024");
+
+// Compact valid gaussian indices for SHEVAL_CTA_SIZE bits of the mask.
+// Warp 0 loads mask words and computes exclusive prefix offsets via Kogge-Stone,
+// then all warps scatter set-bit indices into smem_compact[] using a single __popc
+// per active lane (no serial loop). Returns the total valid count.
+// All threads must call this (two barriers inside).
+__device__ int32_t CompactMask(const uint32_t *__restrict__ masks, int32_t N, int32_t block_base,
+                               int32_t *__restrict__ smem_compact, int32_t &smem_total)
+{
+    constexpr int32_t NUM_WARPS = SHEVAL_CTA_SIZE / 32;
+
+    // let NVCC know that warp_id is a warp uniform (doh!)
+    const int32_t warp_id = __shfl_sync(~0u, threadIdx.x >> 5, 0);
+    const int32_t lane_id = threadIdx.x & 31;
+
+    // broadcast arrays: warp 0 writes, all warps read after barrier
+    __shared__ uint32_t smem_words[NUM_WARPS];
+    __shared__ int32_t smem_offsets[NUM_WARPS];
+
+    if (warp_id == 0)
+    {
+        // All 32 lanes participate to keep the warp converged; lanes >= NUM_WARPS
+        // contribute count=0 so the prefix sum for lanes 0..NUM_WARPS-1 is correct.
+        // This avoids partial-mask __shfl_up_sync which causes codegen issues.
+        const int32_t first_bit = block_base + lane_id * 32;
+        const uint32_t word     = (lane_id < NUM_WARPS && first_bit < N) ? masks[first_bit >> 5] : 0u;
+        const int32_t count     = __popc(word);
+
+        // inclusive Kogge-Stone prefix sum — full warp mask, clean codegen
+        int32_t prefix = count;
+#pragma unroll
+        for (int32_t delta = 1; delta < NUM_WARPS; delta <<= 1)
+        {
+            const int32_t n = __shfl_up_sync(~0u, prefix, delta);
+            if (lane_id >= delta)
+            {
+                prefix += n;
+            }
+        }
+
+        // only lanes with real data write to smem
+        if (lane_id < NUM_WARPS)
+        {
+            smem_words[lane_id]   = word;
+            smem_offsets[lane_id] = prefix - count; // exclusive prefix
+        }
+
+        if (lane_id == NUM_WARPS - 1)
+        {
+            smem_total = prefix; // total valid count
+        }
+    }
+    __syncthreads();
+
+    // all warps: read own word + offset, scatter with popc
+    const uint32_t word       = smem_words[warp_id];
+    const int32_t warp_offset = smem_offsets[warp_id];
+
+    if (word & (1u << lane_id))
+    {
+        smem_compact[warp_offset + __popc(word & ((1u << lane_id) - 1))] = block_base + warp_id * 32 + lane_id;
+    }
+
+    __syncthreads();
+    return smem_total;
+}
+
+__global__ void spherical_harmonics_fwd_kernel(const int N, const int K, const int degrees_to_use,
+                                               const float *__restrict__ means, // [3, N] planar
+                                               const float cam_x, const float cam_y, const float cam_z,
+                                               const float *__restrict__ coeffs,   // [N, K, 3]
+                                               const uint32_t *__restrict__ masks, // [(N+31)/32] packed bitfield
+                                               float bias, float min_value,
+                                               __half *__restrict__ colors // [N, 4] half {R,G,B,0}
+)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N * 3)
+    {
+        return;
+    }
+    const int elem_id = idx / 3;
+    const int c       = idx % 3;
+    if (masks != nullptr && !(masks[elem_id >> 5] & (1u << (elem_id & 0x1fu))))
+    {
+        return;
+    }
+    float3 dir_n{};
+    if (degrees_to_use > 0)
+    {
+        dir_n = GetViewDir(means, N, elem_id, cam_x, cam_y, cam_z);
+    }
+    float val;
+    EvaluteSHCoeffs(degrees_to_use, c, dir_n, coeffs + elem_id * K * 3, bias, min_value, val);
+    colors[elem_id * 4 + c] = __float2half(val);
+}
+
+// Unified K=16 SH forward kernel for raw (float/half) and compressed (32B/16B) inputs.
+// Uses compile-time SHInputMode to select the coefficient loading path; all other logic
+// (compaction, SH evaluation, output packing) is shared.
+template<SHInputMode MODE>
+__global__ void __launch_bounds__(SHEVAL_CTA_SIZE, SHEVAL_MIN_CTAS)
+    spherical_harmonics_fwd_kernel_k16(int N, int degrees_to_use,
+                                       const float *__restrict__ means, // [3, N] planar
+                                       float cam_x, float cam_y, float cam_z, const void *__restrict__ input_data,
+                                       const uint32_t *__restrict__ masks, // [(N+31)/32] packed bitfield
+                                       float bias, float min_value, SHDecodeParams decode_params,
+                                       __half *__restrict__ colors // [N, 4] half {R,G,B,0}
+    )
+{
+    const int idx = blockIdx.x * SHEVAL_CTA_SIZE + threadIdx.x;
+
+    int work_idx;
+
+    if constexpr (SHEVAL_COMPACTION)
+    {
+        if (masks != nullptr)
+        {
+            __shared__ int32_t smem_compact[SHEVAL_CTA_SIZE];
+            __shared__ int32_t smem_total;
+
+            const int32_t total = CompactMask(masks, N, blockIdx.x * SHEVAL_CTA_SIZE, smem_compact, smem_total);
+            if ((int32_t)threadIdx.x >= total)
+            {
+                return;
+            }
+            work_idx = smem_compact[threadIdx.x];
+        }
+        else
+        {
+            if (idx >= N)
+            {
+                return;
+            }
+            work_idx = idx;
+        }
+    }
+    else
+    {
+        if (idx >= N)
+        {
+            return;
+        }
+        if (masks != nullptr && !(masks[idx >> 5] & (1u << (idx & 0x1fu))))
+        {
+            return;
+        }
+        work_idx = idx;
+    }
+
+    const float3 dir_n = GetViewDir(means, N, work_idx, cam_x, cam_y, cam_z);
+    EvalSHForGaussian<MODE>(dir_n, work_idx, N, degrees_to_use, input_data, bias, min_value, decode_params, colors);
+}
+
+void launch_spherical_harmonics_fwd_kernel(
+    // inputs
+    int32_t degrees_to_use,
+    const at::Tensor means, // [3, N] float — gaussian centers (planar)
+    float cam_x, float cam_y, float cam_z,
+    const at::Tensor coeffs,              // [..., K, 3] OR packed int32 when compressed
+    const at::optional<at::Tensor> masks, // [...]
+    const float bias, const float min_value,
+    // outputs
+    at::Tensor colors, // [..., 4] half {R,G,B,0}
+    SHCompressionMode mode, const SHDecodeParams *decode_params)
+{
+    const int N = means.numel() / 3;
+
+    if (N == 0)
+    {
+        return;
+    }
+
+    const float *means_ptr = means.data_ptr<float>();
+    const uint32_t *masks_ptr =
+        masks.has_value() ? reinterpret_cast<const uint32_t *>(masks.value().data_ptr<int32_t>()) : nullptr;
+    __half *colors_ptr = reinterpret_cast<__half *>(colors.data_ptr<at::Half>());
+    auto stream        = at::cuda::getCurrentCUDAStream();
+
+    const bool compressed = (mode != SHCompressionMode::NONE);
+    const int K           = compressed ? 16 : static_cast<int>(coeffs.size(-2));
+
+    if (K == 16)
+    {
+        if (compressed)
+        {
+            TORCH_CHECK(decode_params != nullptr, "compressed SH requires non-null decode_params pointer");
+            TORCH_CHECK(degrees_to_use == 3, "compressed SH requires degrees_to_use=3, got ", degrees_to_use);
+            TORCH_CHECK(coeffs.dim() == 2 && coeffs.size(1) == 4 && coeffs.scalar_type() == at::kInt,
+                        "compressed SH expects [M, 4] int32 tensor, got shape ", coeffs.sizes());
+            TORCH_CHECK(colors.scalar_type() == at::kHalf, "compressed SH requires fp16 output, got ",
+                        colors.scalar_type());
+            const int64_t expected_rows = (mode == SHCompressionMode::COMPRESS_32B) ? 2 * N : N;
+            TORCH_CHECK(coeffs.size(0) == expected_rows, "compressed SH packed tensor row count mismatch: expected ",
+                        expected_rows, ", got ", coeffs.size(0));
+        }
+
+        const dim3 threads(SHEVAL_CTA_SIZE);
+        const dim3 grid((N + SHEVAL_CTA_SIZE - 1) / SHEVAL_CTA_SIZE);
+        const SHDecodeParams dp = decode_params ? *decode_params : SHDecodeParams{};
+
+        if (mode == SHCompressionMode::COMPRESS_32B)
+        {
+            spherical_harmonics_fwd_kernel_k16<SHInputMode::COMPRESS_32B>
+                <<<grid, threads, 0, stream>>>(N, degrees_to_use, means_ptr, cam_x, cam_y, cam_z,
+                                               coeffs.data_ptr<int32_t>(), masks_ptr, bias, min_value, dp, colors_ptr);
+        }
+        else if (mode == SHCompressionMode::COMPRESS_16B)
+        {
+            spherical_harmonics_fwd_kernel_k16<SHInputMode::COMPRESS_16B>
+                <<<grid, threads, 0, stream>>>(N, degrees_to_use, means_ptr, cam_x, cam_y, cam_z,
+                                               coeffs.data_ptr<int32_t>(), masks_ptr, bias, min_value, dp, colors_ptr);
+        }
+        else if (coeffs.scalar_type() == at::kFloat)
+        {
+            spherical_harmonics_fwd_kernel_k16<SHInputMode::RAW_FLOAT>
+                <<<grid, threads, 0, stream>>>(N, degrees_to_use, means_ptr, cam_x, cam_y, cam_z,
+                                               coeffs.data_ptr<float>(), masks_ptr, bias, min_value, dp, colors_ptr);
+        }
+        else if (coeffs.scalar_type() == at::kHalf)
+        {
+            spherical_harmonics_fwd_kernel_k16<SHInputMode::RAW_HALF>
+                <<<grid, threads, 0, stream>>>(N, degrees_to_use, means_ptr, cam_x, cam_y, cam_z,
+                                               coeffs.data_ptr<at::Half>(), masks_ptr, bias, min_value, dp, colors_ptr);
+        }
+        else
+        {
+            TORCH_CHECK(false, "spherical_harmonics_fwd_kernel_k16: unsupported dtype ", coeffs.scalar_type());
+        }
+    }
+    else
+    {
+        TORCH_CHECK(coeffs.scalar_type() == at::kFloat,
+                    "spherical_harmonics_fwd_kernel: generic path only supports float, got ", coeffs.scalar_type());
+        const int32_t n_elements = N * 3;
+        const dim3 threads(256);
+        const dim3 grid((n_elements + threads.x - 1) / threads.x);
+        spherical_harmonics_fwd_kernel<<<grid, threads, 0, stream>>>(N, K, degrees_to_use, means_ptr, cam_x, cam_y,
+                                                                     cam_z, coeffs.data_ptr<float>(), masks_ptr, bias,
+                                                                     min_value, colors_ptr);
+    }
+}
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "InferenceTypes.h"
+
+#include <ATen/core/Tensor.h>
+#include <cstdint>
+
+namespace higs {
+
+struct SHDecodeParams; // forward declaration (defined in SHCompression.h)
+
+void launch_spherical_harmonics_fwd_kernel(
+    // inputs
+    int32_t degrees_to_use,
+    const at::Tensor means, // [3, N] float — gaussian centers (planar)
+    float cam_x, float cam_y, float cam_z,
+    const at::Tensor coeffs,              // [..., K, 3] OR packed int32 when compressed
+    const at::optional<at::Tensor> masks, // [...]
+    float bias, float min_value,
+    // outputs
+    at::Tensor colors, // [..., 4] half {R,G,B,0}
+    // compressed-SH path: mode != NONE activates on-the-fly decode (requires degree 3, K=16).
+    SHCompressionMode mode = SHCompressionMode::NONE, const SHDecodeParams *decode_params = nullptr);
+
+} // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/Utils.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/Utils.h
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cstdint>
+
+// Type-punning helper: reinterpret the bits of v as type T and assign to u.
+template<typename T, typename U, typename V>
+__device__ __forceinline__ void AssignAs(U &u, const V &v)
+{
+    reinterpret_cast<T &>(u) = reinterpret_cast<const T &>(v);
+}
+
+// Round-to-nearest (ties away from zero) __half2 pair to the M bits of mantissa
+template<uint M, bool MASK_OUT_OUTPUT = true>
+__device__ __forceinline__ __half2 RoundToNearest(const __half2 &v)
+{
+    constexpr uint MANTISSA_MASK = 0x03ff03ff;
+    constexpr uint TRUNC_MASK    = ~(((1u << (10 - M)) - 1) * 0x10001u);
+    // get rounding offset scale s*2^e (input float with mantissa zeroed out)
+    const uint vn    = reinterpret_cast<const uint &>(v) & ~MANTISSA_MASK;
+    const __half2 vb = reinterpret_cast<const __half2 &>(vn);
+    // get rounding offset
+    const __half2 vs = __float2half2_rn((1 << (10 - M)) / 2048.0f);
+    // add to float a scaled rounding offset
+    const __half2 v_r = __hfma2(vb, vs, v);
+    // return masked __half2
+    const uint vi_r =
+        MASK_OUT_OUTPUT ? (reinterpret_cast<const uint &>(v_r) & TRUNC_MASK) : reinterpret_cast<const uint &>(v_r);
+    return reinterpret_cast<const __half2 &>(vi_r);
+}
+
+template<typename T>
+__device__ __forceinline__ T __select(const uint32_t &cond, const T &a, const T &b)
+{
+    static_assert(sizeof(T) == 4, "Select only works on 32-bit types");
+    int rval;
+    asm volatile("lop3.b32 %0, %1, %2, %3, 202;"
+                 : "=r"(rval)
+                 : "r"(reinterpret_cast<const uint32_t &>(cond)), "r"(reinterpret_cast<const uint32_t &>(a)),
+                   "r"(reinterpret_cast<const uint32_t &>(b)));
+    return reinterpret_cast<const T &>(rval);
+}
+
+__device__ __forceinline__ __half2 __h2_copy_sign(const __half2 &v, const __half2 &sign)
+{
+    return __select(0x80008000u, sign, v);
+}
+
+__device__ __forceinline__ __half __h_copy_sign(const __half &v, const __half &sign)
+{
+    return __low2half(
+        __h2_copy_sign(__halves2half2(v, __float2half_rn(0.0f)), __halves2half2(sign, __float2half_rn(0.0f))));
+}
+
+// Approximate exp2 on packed half2 via PTX ex2.approx.f16x2.
+__forceinline__ __device__ __half2 __h2exp2_approx(__half2 v)
+{
+    uint32_t rval;
+    asm volatile("ex2.approx.f16x2 %0, %1;\n" : "=r"(rval) : "r"(reinterpret_cast<const uint32_t &>(v)));
+    return reinterpret_cast<const half2 &>(rval);
+}
+
+// Bitwise select on packed half2: result = cond ? a : b (per-bit, via lop3 truth table 202).
+__device__ __forceinline__ __half2 __h2if(const uint32_t &cond, const __half2 &a, const __half2 &b)
+{
+    uint32_t rval;
+    asm("lop3.b32 %0, %1, %2, %3, 202;"
+        : "=r"(rval)
+        : "r"(cond), "r"(reinterpret_cast<const uint32_t &>(a)), "r"(reinterpret_cast<const uint32_t &>(b)));
+    return reinterpret_cast<const __half2 &>(rval);
+}
+
+// PTX prmt.b32 — byte-permute instruction.
+__forceinline__ __device__ uint32_t __prmt_idx(uint32_t src0, uint32_t src1, uint32_t mask)
+{
+    uint32_t rval;
+    asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(rval) : "r"(src0), "r"(src1), "r"(mask));
+    return rval;
+}
+
+// Convert 4 unsigned uint8 values packed in a uint32 to 4 fp16 values.
+// Uses prmt.b32 to construct fp16 bit patterns directly in registers.
+__forceinline__ __device__ void __uint8x4_to_half4(half *dst, uint32_t src)
+{
+    constexpr int FP16_BASE_LOG2 = 10;
+    constexpr float FP16_BASE_FP = 1 << FP16_BASE_LOG2;
+    constexpr int FP16_BASE      = (15 + FP16_BASE_LOG2) << 10; // 1024.0f in fp16.
+
+    union
+    {
+        uint32_t i;
+        half2 f;
+    } dp[2];
+    dp[0].i = __prmt_idx(src, FP16_BASE, 0x5150);
+    dp[1].i = __prmt_idx(src, FP16_BASE, 0x5352);
+    dp[0].f = __hsub2(dp[0].f, __float2half2_rn(FP16_BASE_FP));
+    dp[1].f = __hsub2(dp[1].f, __float2half2_rn(FP16_BASE_FP));
+    AssignAs<uint2>(dst[0], dp);
+}
+
+// Convert 2 unsigned uint8 values (low 16 bits of src) to half2.
+// Same technique as __uint8x4_to_half4 but only the lower two bytes.
+__forceinline__ __device__ __half2 __uint8x2_to_half2(uint32_t src)
+{
+    constexpr int FP16_BASE_LOG2 = 10;
+    constexpr float FP16_BASE_FP = 1 << FP16_BASE_LOG2;
+    constexpr int FP16_BASE      = (15 + FP16_BASE_LOG2) << 10;
+
+    union
+    {
+        uint32_t i;
+        half2 f;
+    } dp;
+    dp.i = __prmt_idx(src, FP16_BASE, 0x5150);
+    dp.f = __hsub2(dp.f, __float2half2_rn(FP16_BASE_FP));
+    return dp.f;
+}
+
+__forceinline__ __device__ uint __cvt_pack_sat_u8_f32(float a0, float a1, float a2, float a3)
+{
+    uint rval;
+    asm volatile(
+        "{.reg .u32 tmp, i0, i1;\n"
+        "cvt.rni.s32.f32 i0, %1;\n"
+        "cvt.rni.s32.f32 i1, %2;\n"
+        "cvt.pack.sat.u8.s32.b32 tmp, i0, i1, 0;\n"
+        "cvt.rni.s32.f32 i0, %3;\n"
+        "cvt.rni.s32.f32 i1, %4;\n"
+        "cvt.pack.sat.u8.s32.b32 %0, i0, i1, tmp;}\n"
+        : "=r"(rval)
+        : "f"(a3), "f"(a2), "f"(a1), "f"(a0));
+    return rval;
+}
+
+__forceinline__ __device__ uint __cvt_pack_sat_u8_f32(const float4 &a)
+{
+    return __cvt_pack_sat_u8_f32(a.x, a.y, a.z, a.w);
+}

--- a/experimental/render/kernels/cuda/ext.cpp
+++ b/experimental/render/kernels/cuda/ext.cpp
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <torch/extension.h>
+
+#include "csrc/gaussian_inference/GaussianRenderInferenceScene.h"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    py::class_<gsplat::gaussian_render_inference_scene::GaussianInferenceRenderer>(m, "GaussianInferenceRenderer")
+        .def(py::init<const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, int64_t>(),
+             py::arg("means_planar"), py::arg("qso_packed"), py::arg("colors_packed"),
+             py::arg("sh_degree"), py::arg("sh_compression_mode"))
+        .def("render", &gsplat::gaussian_render_inference_scene::GaussianInferenceRenderer::render,
+             py::arg("means_planar"), py::arg("qso_packed"), py::arg("colors_packed"),
+             py::arg("viewmat"), py::arg("K"),
+             py::arg("width"), py::arg("height"),
+             py::arg("tile_size"),
+             py::arg("near_plane"), py::arg("far_plane"),
+             py::arg("radius_clip"), py::arg("eps2d"),
+             py::arg("sh_degree"), py::arg("sh_compression_mode"),
+             py::arg("background"), py::arg("out_rgbt"))
+        .def("release", &gsplat::gaussian_render_inference_scene::GaussianInferenceRenderer::release)
+        .def("num_gaussians", &gsplat::gaussian_render_inference_scene::GaussianInferenceRenderer::numGaussians)
+        .def("is_released", &gsplat::gaussian_render_inference_scene::GaussianInferenceRenderer::isReleased);
+}
+
+TORCH_LIBRARY(experimental, m) {
+    m.def("gaussian_render_inference_only(Tensor means_planar, Tensor qso_packed, Tensor colors_packed, Tensor viewmat, Tensor K, int width, int height, int sh_degree, int tile_size, float near_plane, float far_plane, float radius_clip, float eps2d, int sh_compression_mode, Tensor? background, *, Tensor(a!)? out_renders=None, Tensor(b!)? out_alphas=None) -> (Tensor renders, Tensor alphas)");
+}
+
+TORCH_LIBRARY_IMPL(experimental, CUDA, m) {
+    m.impl("gaussian_render_inference_only", &gsplat::gaussian_render_inference_scene::gaussian_render_inference_only);
+}
+
+// Explicitly suppress AutogradCUDA for gaussian_render_inference_only: it is
+// inference-only and has no backward kernel. Without this, PyTorch ≥ 2.x
+// auto-registers an AutogradCUDA entry that wraps outputs in a grad_fn even
+// when no backward is available, which confuses callers that check grad_fn is None.
+TORCH_LIBRARY_IMPL(experimental, Autograd, m) {
+    m.impl("gaussian_render_inference_only", torch::CppFunction::makeFallthrough());
+}

--- a/experimental/render/kernels/gaussian_inference_ops.py
+++ b/experimental/render/kernels/gaussian_inference_ops.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Accelerated Gaussian Inference render entry points."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from . import _backend
+
+
+def _require_backend():
+    if _backend._C is None:
+        raise RuntimeError(
+            "Inference CUDA backend is not available. "
+            "Ensure CUDA toolkit is installed and the extension compiled."
+        )
+    return _backend._C
+
+
+def create_native_gaussian_inference_renderer(
+    means_planar: Tensor,
+    qso_packed: Tensor,
+    colors_packed: Tensor,
+    sh_degree: int,
+    sh_compression_mode: int,
+):
+    """Create the pybind stateful renderer wrapper."""
+    backend = _require_backend()
+    return backend.GaussianInferenceRenderer(
+        means_planar,
+        qso_packed,
+        colors_packed,
+        sh_degree,
+        sh_compression_mode,
+    )
+
+
+def gaussian_render_inference_only(
+    means_planar: Tensor,
+    qso_packed: Tensor,
+    colors_packed: Tensor,
+    viewmat: Tensor,
+    K: Tensor,
+    width: int,
+    height: int,
+    sh_degree: int,
+    tile_size: int,
+    near_plane: float,
+    far_plane: float,
+    radius_clip: float,
+    eps2d: float,
+    sh_compression_mode: int,
+    background: Optional[Tensor],
+    *,
+    out_renders: Optional[Tensor] = None,
+    out_alphas: Optional[Tensor] = None,
+) -> tuple[Tensor, Tensor]:
+    """Dispatch to the registered CUDA torch op."""
+    _require_backend()
+    return torch.ops.experimental.gaussian_render_inference_only(
+        means_planar,
+        qso_packed,
+        colors_packed,
+        viewmat,
+        K,
+        width,
+        height,
+        sh_degree,
+        tile_size,
+        near_plane,
+        far_plane,
+        radius_clip,
+        eps2d,
+        sh_compression_mode,
+        background,
+        out_renders=out_renders,
+        out_alphas=out_alphas,
+    )
+
+
+__all__ = [
+    "create_native_gaussian_inference_renderer",
+    "gaussian_render_inference_only",
+]

--- a/experimental/render/kernels/test_gaussian_render_inference_only_op.py
+++ b/experimental/render/kernels/test_gaussian_render_inference_only_op.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``gaussian_render_inference_only`` torch op.
+
+Covers output correctness when called with Python-packed scene data, validates
+pre-allocated output buffers, and confirms the op's dispatch table properties.
+"""
+
+import pytest
+import torch
+
+
+def _make_gaussians(N=100, sh_degree=None, device="cuda"):
+    torch.manual_seed(12345)
+    means = torch.randn(N, 3, device=device)
+    quats = torch.randn(N, 4, device=device)
+    quats = quats / quats.norm(dim=1, keepdim=True)
+    scales = torch.rand(N, 3, device=device) * 0.1 + 0.01
+    opacities = torch.rand(N, device=device)
+    if sh_degree is not None and sh_degree >= 0:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K, 3, device=device)
+    else:
+        colors = torch.rand(N, 3, device=device)
+    return means, quats, scales, opacities, colors
+
+
+def _make_camera(device="cuda"):
+    viewmat = torch.eye(4, device=device)
+    viewmat[2, 3] = 3.0  # camera at z=3 looking at origin
+    K = torch.tensor(
+        [
+            [500.0, 0.0, 128.0],
+            [0.0, 500.0, 128.0],
+            [0.0, 0.0, 1.0],
+        ],
+        device=device,
+    )
+    return viewmat, K
+
+
+def _pack_scene(
+    means, quats, scales, opacities, colors, sh_degree, sh_compression="none"
+):
+    """Pack scene in Python matching the C++ packing logic."""
+    N = means.size(0)
+    means_planar = means.t().contiguous()
+    inference = torch.empty(N, 8, dtype=torch.float16, device=means.device)
+    inference[:, 0:4] = quats.half()
+    inference[:, 4:7] = scales.half()
+    inference[:, 7:8] = opacities.unsqueeze(1).half()
+
+    sh_deg = -1 if sh_degree is None else sh_degree
+    K_sh = colors.size(1) if colors.dim() == 3 else 0
+    if sh_deg >= 0 and K_sh == 16:
+        if sh_compression == "none":
+            colors_packed = colors.half()
+        elif sh_compression == "32b":
+            colors_packed = colors.contiguous().view(N, 48)
+        else:
+            colors_packed = colors.half().view(N, 48)
+    elif sh_deg >= 0 and K_sh > 0:
+        colors_packed = colors.contiguous()
+    else:
+        c = torch.zeros(N, 4, dtype=torch.float16, device=means.device)
+        c[:, 0:3] = colors.half()
+        colors_packed = c
+    return means_planar, inference, colors_packed
+
+
+# ------------------------------------------------------------------ #
+#  Forward parity: wrapper API vs native op                           #
+# ------------------------------------------------------------------ #
+
+_PARITY_CASES = [
+    # (sh_degree, sh_compression)
+    (None, "none"),  # pre-activated RGB
+    (0, "none"),  # SH degree 0
+    (1, "none"),  # SH degree 1
+    (2, "none"),  # SH degree 2
+    (3, "none"),  # SH degree 3, no compression
+    (3, "32b"),  # SH degree 3, 32b compression
+    (3, "16b"),  # SH degree 3, 16b compression
+]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("sh_degree,sh_compression", _PARITY_CASES)
+def test_forward_parity(sh_degree, sh_compression):
+    """Python-packed scene and C++-packed scene render bit-exact via gaussian_render_inference_only."""
+    from experimental.render.kernels._backend import _C  # noqa: F401
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    width, height = 256, 256
+    means, quats, scales, opacities, colors = _make_gaussians(
+        N=200, sh_degree=sh_degree
+    )
+    viewmat, K = _make_camera()
+
+    sh_deg = -1 if sh_degree is None else sh_degree
+    _SH_COMPRESSION_MAP = {"none": 0, "32b": 1, "16b": 2}
+    sh_compression_mode = _SH_COMPRESSION_MAP[sh_compression]
+
+    # Python-packed path
+    means_planar_py, inference_py, colors_packed_py = _pack_scene(
+        means, quats, scales, opacities, colors, sh_degree, sh_compression
+    )
+
+    with torch.no_grad():
+        renders_py, alphas_py = torch.ops.experimental.gaussian_render_inference_only(
+            means_planar_py,
+            inference_py,
+            colors_packed_py,
+            viewmat,
+            K,
+            width,
+            height,
+            sh_deg,
+            16,  # tile_size
+            0.01,  # near_plane
+            1e10,  # far_plane
+            0.0,  # radius_clip
+            0.3,  # eps2d
+            sh_compression_mode,
+            None,  # background
+        )
+
+    # C++-packed path (via gsplat_scene_cuda.pack_gaussian_inference_scene)
+    mp_cpp, inference_cpp, cp_cpp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means, quats, scales, opacities, colors, sh_deg, sh_compression_mode
+    )
+
+    with torch.no_grad():
+        renders_cpp, alphas_cpp = torch.ops.experimental.gaussian_render_inference_only(
+            mp_cpp,
+            inference_cpp,
+            cp_cpp,
+            viewmat,
+            K,
+            width,
+            height,
+            sh_deg,
+            16,
+            0.01,
+            1e10,
+            0.0,
+            0.3,
+            sh_compression_mode,
+            None,
+        )
+
+    torch.testing.assert_close(
+        renders_cpp, renders_py, atol=0, rtol=0, msg="renders mismatch"
+    )
+    torch.testing.assert_close(
+        alphas_cpp, alphas_py, atol=0, rtol=0, msg="alphas mismatch"
+    )
+
+
+# ------------------------------------------------------------------ #
+#  out_renders / out_alphas pre-allocated buffer test                  #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_out_renders_out_alphas():
+    """Pre-allocated buffers must be written in-place and match the no-buffer call."""
+    from experimental.render.kernels._backend import _C  # noqa: F401
+
+    width, height = 256, 256
+    means, quats, scales, opacities, colors = _make_gaussians(N=150, sh_degree=None)
+    viewmat, K = _make_camera()
+    means_planar, inference, colors_packed = _pack_scene(
+        means, quats, scales, opacities, colors, None
+    )
+
+    sh_deg = -1
+    sh_compression_mode = 0
+
+    # Reference call (no pre-allocated buffers)
+    with torch.no_grad():
+        renders_ref, alphas_ref = torch.ops.experimental.gaussian_render_inference_only(
+            means_planar,
+            inference,
+            colors_packed,
+            viewmat,
+            K,
+            width,
+            height,
+            sh_deg,
+            16,
+            0.01,
+            1e10,
+            0.0,
+            0.3,
+            sh_compression_mode,
+            None,
+        )
+
+    # Pre-allocated buffers
+    buf_r = torch.empty(height, width, 3, dtype=torch.float32, device="cuda")
+    buf_a = torch.empty(height, width, 1, dtype=torch.float32, device="cuda")
+
+    with torch.no_grad():
+        ret_r, ret_a = torch.ops.experimental.gaussian_render_inference_only(
+            means_planar,
+            inference,
+            colors_packed,
+            viewmat,
+            K,
+            width,
+            height,
+            sh_deg,
+            16,
+            0.01,
+            1e10,
+            0.0,
+            0.3,
+            sh_compression_mode,
+            None,
+            out_renders=buf_r,
+            out_alphas=buf_a,
+        )
+
+    # Verify returned tensors share storage with pre-allocated buffers
+    assert ret_r.data_ptr() == buf_r.data_ptr(), "out_renders not written in-place"
+    assert ret_a.data_ptr() == buf_a.data_ptr(), "out_alphas not written in-place"
+
+    # Verify numerical match
+    torch.testing.assert_close(
+        ret_r, renders_ref, atol=0, rtol=0, msg="out_renders content mismatch"
+    )
+    torch.testing.assert_close(
+        ret_a, alphas_ref, atol=0, rtol=0, msg="out_alphas content mismatch"
+    )
+
+
+# ------------------------------------------------------------------ #
+#  Runtime smoke test: op existence + dispatch table properties        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_op_smoke():
+    """The new op must exist, have a CUDA dispatch key, and NOT have AutogradCUDA."""
+    from experimental.render.kernels._backend import _C  # noqa: F401
+
+    # Confirm the op exists
+    assert hasattr(
+        torch.ops.experimental, "gaussian_render_inference_only"
+    ), "gaussian_render_inference_only op not found"
+
+    # Get the op's overload packet and inspect its dispatch table
+    op = torch.ops.experimental.gaussian_render_inference_only
+    # The default overload is callable; its _dispatch_cache or _schema
+    # gives us dispatch info. We check via the operator's dispatch table.
+    schema = op.default._schema
+    assert schema is not None, "Op schema not found"
+
+    # Verify CUDA dispatch key is present by running on CUDA data
+    # (if it weren't registered, the call would fail with a dispatch error)
+    means_planar = torch.zeros(3, 1, device="cuda")
+    inference = torch.zeros(1, 8, dtype=torch.float16, device="cuda")
+    colors_packed = torch.zeros(1, 4, dtype=torch.float16, device="cuda")
+    viewmat = torch.eye(4, device="cuda")
+    viewmat[2, 3] = 3.0
+    K = torch.tensor(
+        [[500.0, 0.0, 64.0], [0.0, 500.0, 64.0], [0.0, 0.0, 1.0]],
+        device="cuda",
+    )
+
+    # This call exercises the CUDA dispatch key
+    renders, alphas = torch.ops.experimental.gaussian_render_inference_only(
+        means_planar,
+        inference,
+        colors_packed,
+        viewmat,
+        K,
+        128,
+        128,
+        -1,
+        16,
+        0.01,
+        1e10,
+        0.0,
+        0.3,
+        0,
+        None,
+    )
+    assert renders.shape == (128, 128, 3)
+    assert alphas.shape == (128, 128, 1)
+
+    # Verify AutogradCUDA is NOT registered by confirming direct op call
+    # with grad-tracked inputs runs the forward kernel and produces no grad_fn.
+    # If AutogradCUDA were registered, the output would have a grad_fn.
+    means_grad = torch.zeros(3, 5, device="cuda", requires_grad=True)
+    inference_grad = torch.zeros(5, 8, dtype=torch.float16, device="cuda")
+    colors_grad = torch.zeros(5, 4, dtype=torch.float16, device="cuda")
+    viewmat_grad = torch.eye(4, device="cuda")
+    viewmat_grad[2, 3] = 3.0
+    K_grad = torch.tensor(
+        [[500.0, 0.0, 64.0], [0.0, 500.0, 64.0], [0.0, 0.0, 1.0]],
+        device="cuda",
+    )
+
+    # This should succeed (no AutogradCUDA to intercept and fail)
+    renders_g, alphas_g = torch.ops.experimental.gaussian_render_inference_only(
+        means_grad,
+        inference_grad,
+        colors_grad,
+        viewmat_grad,
+        K_grad,
+        128,
+        128,
+        -1,
+        16,
+        0.01,
+        1e10,
+        0.0,
+        0.3,
+        0,
+        None,
+    )
+    # No backward kernel exists, so grad_fn should be None
+    assert (
+        renders_g.grad_fn is None
+    ), "renders has grad_fn — AutogradCUDA should not be registered"
+    assert (
+        alphas_g.grad_fn is None
+    ), "alphas has grad_fn — AutogradCUDA should not be registered"

--- a/experimental/render/test_gaussian_inference_integration.py
+++ b/experimental/render/test_gaussian_inference_integration.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration-level verification suite for the Inference render path.
+
+Covers:
+1. Full-matrix cross-path (Inference vs direct rasterization) parity at N=1000+.
+2. Vanilla-branch rejection (render_scene raises TypeError for GaussianScene).
+3. Standard rasterization regression (shapes, finiteness).
+4. Dispatcher/autograd verification (dispatch keys, grad-mode gate).
+5. Viewer smoke test (toggle Inference on/off).
+6. Benchmark timing comparison (informational, not pass/fail).
+"""
+
+import math
+import statistics
+
+import pytest
+import torch
+import torch.nn as nn
+
+_CUDA = torch.cuda.is_available()
+skipif_no_cuda = pytest.mark.skipif(not _CUDA, reason="CUDA required")
+
+W, H = 256, 256
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_psnr(a, b):
+    mse = ((a.float() - b.float()) ** 2).mean().item()
+    if mse == 0:
+        return float("inf")
+    peak = max(a.abs().max().item(), b.abs().max().item(), 1.0)
+    return 10 * math.log10(peak**2 / mse)
+
+
+def _make_test_gaussians(N=100, sh_degree=None, device="cuda"):
+    """Create random Gaussians in *log/logit* space for GaussianScene."""
+    torch.manual_seed(12345)
+    means = torch.randn(N, 3, device=device)
+    quats = torch.randn(N, 4, device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = torch.rand(N, 3, device=device) * 0.1 + 0.01  # log-space
+    opacities = torch.randn(N, device=device)  # logit-space
+    if sh_degree is not None:
+        K = (sh_degree + 1) ** 2
+        colors = torch.randn(N, K, 3, device=device) * 0.1
+    else:
+        colors = torch.rand(N, 3, device=device)
+    return means, quats, scales, opacities, colors
+
+
+def _make_camera(device="cuda"):
+    viewmat = torch.eye(4, device=device, dtype=torch.float32)
+    viewmat[2, 3] = 5.0
+    K = torch.tensor(
+        [[500.0, 0, 128.0], [0, 500.0, 128.0], [0, 0, 1]],
+        device=device,
+        dtype=torch.float32,
+    )
+    return viewmat, K
+
+
+def _make_gaussian_scene(
+    N=100,
+    sh_degree=None,
+    device="cuda",
+    *,
+    requires_grad=False,
+):
+    """Build a GaussianScene with raw (log/logit-space) splats."""
+    from libs.scene import GaussianScene
+
+    means, quats, scales, opacities, colors = _make_test_gaussians(N, sh_degree, device)
+    splats = nn.ParameterDict(
+        {
+            "means": nn.Parameter(means, requires_grad=requires_grad),
+            "quats": nn.Parameter(quats, requires_grad=requires_grad),
+            "scales": nn.Parameter(scales, requires_grad=requires_grad),
+            "opacities": nn.Parameter(opacities, requires_grad=requires_grad),
+            "colors": nn.Parameter(colors, requires_grad=requires_grad),
+        }
+    )
+    return GaussianScene.from_splats(splats, id="test")
+
+
+def _make_inference_scene(
+    N=100, sh_degree=None, sh_compression="none", device="cuda", *, requires_grad=False
+):
+    """Build a GaussianInferenceScene from a GaussianScene."""
+    from experimental import GaussianInferenceScene
+
+    gs = _make_gaussian_scene(N, sh_degree, device, requires_grad=requires_grad)
+    return GaussianInferenceScene.from_gaussian_scene(
+        gs, id="test", sh_compression=sh_compression
+    )
+
+
+def _common_request(device="cuda"):
+    """Return the minimal valid Inference request dict."""
+    viewmat, K = _make_camera(device)
+    return dict(viewmat=viewmat, K=K, width=W, height=H)
+
+
+# ======================================================================
+# 1. Full Integration Cross-Path Parity (Full Matrix)
+# ======================================================================
+
+# Compression modes "32b" and "16b" are only valid for SH degree 3.
+_FULL_PARITY_MATRIX = [
+    (None, "none"),
+    (0, "none"),
+    (1, "none"),
+    (2, "none"),
+    (3, "none"),
+    (3, "32b"),
+    (3, "16b"),
+]
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize("sh_degree,sh_compression", _FULL_PARITY_MATRIX)
+def test_full_cross_path_parity(sh_degree, sh_compression):
+    """Inference and vanilla (direct rasterization) paths produce close results at N=1000+ (PSNR >= 30 dB)."""
+    from experimental import render_scene, GaussianInferenceScene
+    from gsplat.rendering import rasterization
+
+    N = 1000
+    gs = _make_gaussian_scene(N=N, sh_degree=sh_degree)
+    inference = GaussianInferenceScene.from_gaussian_scene(
+        gs, id="parity_inference", sh_compression=sh_compression
+    )
+
+    viewmat, K = _make_camera()
+
+    # Vanilla path via direct rasterization (render_scene no longer accepts GaussianScene)
+    splats = gs.splats
+    vanilla_req = dict(viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+    if sh_degree is not None:
+        vanilla_req["sh_degree"] = sh_degree
+    with torch.no_grad():
+        vanilla_renders, vanilla_alphas, _info = rasterization(
+            splats["means"],
+            splats["quats"],
+            splats["scales"].exp(),
+            splats["opacities"].sigmoid(),
+            splats.get("colors", splats.get("sh0")),
+            **vanilla_req,
+        )
+
+    # Inference path
+    inference_req = dict(viewmat=viewmat, K=K, width=W, height=H)
+    with torch.inference_mode():
+        inference_ret = render_scene(inference, **inference_req)
+
+    # Verify inference render_path tag
+    assert (
+        inference_ret.metadata["render_path"] == "inference"
+    ), "Inference path not tagged correctly"
+
+    # PSNR check
+    psnr = _compute_psnr(vanilla_renders, inference_ret.frame)
+    # 16b SH compression drops CoCg for higher-order terms (k≥1), making it
+    # inherently lossy for scenes with significant HO color variation; use a
+    # lower floor. 32b and no-compression paths target ≥ 40 dB.
+    psnr_floor = 20.0 if sh_compression == "16b" else 40.0
+    assert psnr >= psnr_floor, (
+        f"PSNR {psnr:.1f} dB below {psnr_floor} dB for "
+        f"sh_degree={sh_degree}, sh_compression={sh_compression}"
+    )
+
+    # Alpha max-abs tolerance
+    alpha_diff = (vanilla_alphas - inference_ret.metadata["alpha"]).abs()
+    assert alpha_diff.max().item() < 0.1, (
+        f"Alpha max diff {alpha_diff.max().item():.4f} >= 0.1 for "
+        f"sh_degree={sh_degree}, sh_compression={sh_compression}"
+    )
+
+
+# ======================================================================
+# 2. Vanilla-Branch Rejection (render_scene raises TypeError)
+# ======================================================================
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize("sh_degree", [None, 0, 1, 3])
+@pytest.mark.parametrize("packed", [False, True])
+def test_vanilla_passthrough_raises_typeerror(sh_degree, packed):
+    """render_scene(gaussian_scene, ...) raises TypeError (vanilla path removed)."""
+    from experimental import render_scene
+
+    gs = _make_gaussian_scene(N=500, sh_degree=sh_degree)
+    viewmat, K = _make_camera()
+    viewmats = viewmat[None]
+    Ks = K[None]
+    req = dict(
+        viewmats=viewmats,
+        Ks=Ks,
+        width=W,
+        height=H,
+        render_mode="RGB",
+        packed=packed,
+    )
+    if sh_degree is not None:
+        req["sh_degree"] = sh_degree
+
+    with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+        render_scene(gs, **req)
+
+
+# ======================================================================
+# 3. Standard Rasterization Unchanged
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_standard_rasterization_regression():
+    """Direct gsplat.rasterization(...) produces correct shapes and finite values."""
+    from gsplat.rendering import rasterization
+
+    N = 200
+    torch.manual_seed(9999)
+    means = torch.randn(N, 3, device="cuda")
+    quats = torch.randn(N, 4, device="cuda")
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = (torch.rand(N, 3, device="cuda") * 0.1 + 0.01).exp()
+    opacities = torch.rand(N, device="cuda")
+    colors = torch.rand(N, 3, device="cuda")
+
+    viewmat, K = _make_camera()
+    viewmats = viewmat[None]
+    Ks = K[None]
+
+    with torch.no_grad():
+        renders, alphas, info = rasterization(
+            means=means,
+            quats=quats,
+            scales=scales,
+            opacities=opacities,
+            colors=colors,
+            viewmats=viewmats,
+            Ks=Ks,
+            width=W,
+            height=H,
+        )
+
+    assert renders.shape == (1, H, W, 3), f"Unexpected shape: {renders.shape}"
+    assert alphas.shape == (1, H, W, 1), f"Unexpected alpha shape: {alphas.shape}"
+    assert renders.isfinite().all(), "renders contain non-finite values"
+    assert alphas.isfinite().all(), "alphas contain non-finite values"
+    assert isinstance(info, dict), "info should be a dict"
+
+
+# ======================================================================
+# 4. Dispatcher/Autograd Verification
+# ======================================================================
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+class TestGradModeGateIntegration:
+    """Grad-mode gate verification across both entry points."""
+
+    def _get_fn(self, entry):
+        import experimental as exp
+
+        return getattr(exp, entry)
+
+    def test_inference_mode_ok(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=100)
+        req = _common_request()
+        with torch.inference_mode():
+            ret = fn(inference, **req)
+        assert ret.frame.shape == (1, H, W, 3)
+
+    def test_no_grad_ok(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=100)
+        req = _common_request()
+        with torch.no_grad():
+            ret = fn(inference, **req)
+        assert ret.frame.shape == (1, H, W, 3)
+
+    def test_bare_grad_raises(self, entry):
+        fn = self._get_fn(entry)
+        inference = _make_inference_scene(N=100)
+        req = _common_request()
+        with pytest.raises(RuntimeError, match="requires torch.inference_mode"):
+            fn(inference, **req)
+
+
+@skipif_no_cuda
+def test_dispatch_keys_rasterize_op():
+    """gaussian_render_inference_only has CUDA dispatch, no AutogradCUDA."""
+    from experimental.render.kernels._backend import _C  # noqa: F401
+
+    assert hasattr(torch.ops.experimental, "gaussian_render_inference_only")
+
+    op = torch.ops.experimental.gaussian_render_inference_only
+    schema = op.default._schema
+    assert schema is not None, "Op schema not found"
+
+    # Verify CUDA dispatch works: if not registered the call below would fail.
+    means_planar = torch.zeros(3, 1, device="cuda")
+    inference = torch.zeros(1, 8, dtype=torch.float16, device="cuda")
+    colors_packed = torch.zeros(1, 4, dtype=torch.float16, device="cuda")
+    viewmat = torch.eye(4, device="cuda")
+    viewmat[2, 3] = 3.0
+    K = torch.tensor(
+        [[500.0, 0.0, 64.0], [0.0, 500.0, 64.0], [0.0, 0.0, 1.0]],
+        device="cuda",
+    )
+
+    renders, alphas = torch.ops.experimental.gaussian_render_inference_only(
+        means_planar,
+        inference,
+        colors_packed,
+        viewmat,
+        K,
+        128,
+        128,
+        -1,
+        16,
+        0.01,
+        1e10,
+        0.0,
+        0.3,
+        0,
+        None,
+    )
+    assert renders.shape == (128, 128, 3)
+
+    # AutogradCUDA absent: grad-tracked input produces no grad_fn.
+    means_grad = torch.zeros(3, 5, device="cuda", requires_grad=True)
+    inference_g = torch.zeros(5, 8, dtype=torch.float16, device="cuda")
+    cp_g = torch.zeros(5, 4, dtype=torch.float16, device="cuda")
+    renders_g, _ = torch.ops.experimental.gaussian_render_inference_only(
+        means_grad,
+        inference_g,
+        cp_g,
+        viewmat,
+        K,
+        128,
+        128,
+        -1,
+        16,
+        0.01,
+        1e10,
+        0.0,
+        0.3,
+        0,
+        None,
+    )
+    assert (
+        renders_g.grad_fn is None
+    ), "AutogradCUDA should NOT be registered for gaussian_render_inference_only"
+
+
+@skipif_no_cuda
+def test_dispatch_keys_pack_op():
+    """pack_gaussian_inference_scene is callable via gsplat_scene_cuda and produces no grad_fn."""
+    from gsplat_scene.kernels._backend import _SCENE_CUDA  # noqa: F401
+
+    assert callable(_SCENE_CUDA.pack_gaussian_inference_scene)
+
+    # Verify CUDA dispatch
+    means = torch.randn(10, 3, device="cuda")
+    quats = torch.randn(10, 4, device="cuda")
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = torch.rand(10, 3, device="cuda") * 0.1 + 0.01
+    opacities = torch.rand(10, device="cuda")
+    colors = torch.rand(10, 3, device="cuda")
+
+    mp, inference, cp = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means, quats, scales, opacities, colors, -1, 0
+    )
+    assert mp.shape == (3, 10)
+    assert inference.dtype == torch.float16
+
+    # No grad_fn on outputs (torch::NoGradGuard in C++)
+    means_g = means.clone().requires_grad_(True)
+    mp_g, inference_g, cp_g = _SCENE_CUDA.pack_gaussian_inference_scene(
+        means_g, quats, scales, opacities, colors, -1, 0
+    )
+    assert (
+        mp_g.grad_fn is None
+    ), "pack_gaussian_inference_scene outputs should not have grad_fn"
+
+
+# ======================================================================
+# 4b. Request-subset validation re-run
+# ======================================================================
+
+
+@skipif_no_cuda
+@pytest.mark.parametrize(
+    "entry",
+    ["rasterize_gaussian_inference_scene", "render_scene"],
+)
+@pytest.mark.parametrize(
+    "bad_kwarg,match",
+    [
+        ({"render_mode": "D"}, "render_mode='RGB' only"),
+        ({"with_ut": True}, "Inference branch does not support with_ut"),
+        ({"absgrad": True}, "Inference branch does not support absgrad"),
+        ({"tile_size": 32}, "tile_size in {8, 16}"),
+        ({"sh_degree": 3}, "sh_degree/sh_compression_mode"),
+        (
+            {"backgrounds": torch.zeros(1, 3)},
+            "unexpected keyword argument 'backgrounds'",
+        ),
+        ({"bogus_kwarg": 1}, "unexpected keyword argument 'bogus_kwarg'"),
+    ],
+)
+def test_request_validation_integration(entry, bad_kwarg, match):
+    """Unsupported Inference request features are rejected at integration level."""
+    import experimental as exp
+
+    fn = getattr(exp, entry)
+    inference = _make_inference_scene(N=100)
+    req = _common_request()
+    req.update(bad_kwarg)
+
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match=match):
+            fn(inference, **req)
+
+
+# ======================================================================
+# 4c. out= buffer contract re-run
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_out_buffer_numerical_match_integration():
+    """out= produces same numbers as freshly-allocated path."""
+    from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+    inference = _make_inference_scene(N=500)
+    req = _common_request()
+
+    with torch.inference_mode():
+        fresh = rasterize_gaussian_inference_scene(inference, **req)
+
+    buf = RenderReturn(
+        frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+        metadata={"alpha": torch.empty(1, H, W, 1, device="cuda", dtype=torch.float32)},
+    )
+
+    with torch.inference_mode():
+        reused = rasterize_gaussian_inference_scene(inference, out=buf, **req)
+
+    assert reused is buf
+    torch.testing.assert_close(reused.frame, fresh.frame, atol=0, rtol=0)
+    torch.testing.assert_close(
+        reused.metadata["alpha"], fresh.metadata["alpha"], atol=0, rtol=0
+    )
+
+
+@skipif_no_cuda
+def test_out_buffer_identity_stability_integration():
+    """out= data_ptr stability across multiple calls."""
+    from experimental import rasterize_gaussian_inference_scene, RenderReturn
+
+    inference = _make_inference_scene(N=100)
+    req = _common_request()
+
+    buf = RenderReturn(
+        frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+        metadata={"alpha": torch.empty(1, H, W, 1, device="cuda", dtype=torch.float32)},
+    )
+    frame_ptr = buf.frame.data_ptr()
+
+    with torch.inference_mode():
+        for i in range(3):
+            ret = rasterize_gaussian_inference_scene(inference, out=buf, **req)
+            assert ret is buf
+            assert buf.frame.data_ptr() == frame_ptr
+
+
+@skipif_no_cuda
+def test_out_buffer_vanilla_rejection_integration():
+    """render_scene(GaussianScene, out=...) raises TypeError."""
+    from experimental import render_scene, RenderReturn
+
+    gs = _make_gaussian_scene(N=50)
+    viewmat, K = _make_camera()
+
+    buf = RenderReturn(
+        frame=torch.empty(1, H, W, 3, device="cuda", dtype=torch.float32),
+        metadata={},
+    )
+
+    with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+        render_scene(gs, out=buf, viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+
+
+# ======================================================================
+# 5. Viewer Smoke Test
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_viewer_toggle_inference_on():
+    """Inference on: GaussianInferenceScene -> render_scene -> valid RenderReturn."""
+    from experimental import GaussianInferenceScene, render_scene, RenderReturn
+
+    gs = _make_gaussian_scene(N=200, sh_degree=3)
+    inference = GaussianInferenceScene.from_gaussian_scene(
+        gs, id="viewer_inference", sh_compression="32b"
+    )
+    viewmat, K = _make_camera()
+
+    with torch.inference_mode():
+        ret = render_scene(inference, viewmat=viewmat, K=K, width=W, height=H)
+
+    assert isinstance(ret, RenderReturn)
+    assert ret.frame.shape == (1, H, W, 3)
+    assert ret.metadata["alpha"].shape == (1, H, W, 1)
+    assert ret.metadata["render_path"] == "inference"
+    assert ret.frame.isfinite().all()
+
+
+@skipif_no_cuda
+def test_viewer_toggle_inference_off_raises():
+    """Inference off: vanilla GaussianScene -> render_scene -> TypeError (vanilla path removed)."""
+    from experimental import render_scene
+
+    gs = _make_gaussian_scene(N=200)
+    viewmat, K = _make_camera()
+
+    with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+        render_scene(gs, viewmats=viewmat[None], Ks=K[None], width=W, height=H)
+
+
+@skipif_no_cuda
+def test_viewer_both_paths_produce_expected_shapes():
+    """Both viewer paths (direct rasterization + inference) produce matching output shapes."""
+    from experimental import GaussianInferenceScene, render_scene
+    from gsplat.rendering import rasterization
+
+    gs = _make_gaussian_scene(N=300, sh_degree=1)
+    viewmat, K = _make_camera()
+
+    # Vanilla via direct rasterization (render_scene no longer accepts GaussianScene)
+    splats = gs.splats
+    with torch.no_grad():
+        vanilla_renders, vanilla_alphas, _info = rasterization(
+            splats["means"],
+            splats["quats"],
+            splats["scales"].exp(),
+            splats["opacities"].sigmoid(),
+            splats.get("colors", splats.get("sh0")),
+            viewmats=viewmat[None],
+            Ks=K[None],
+            width=W,
+            height=H,
+            sh_degree=1,
+        )
+
+    # Inference
+    inference = GaussianInferenceScene.from_gaussian_scene(
+        gs, id="viewer_both", sh_compression="none"
+    )
+    with torch.inference_mode():
+        inference_ret = render_scene(inference, viewmat=viewmat, K=K, width=W, height=H)
+
+    # Both shapes match
+    assert vanilla_renders.shape == inference_ret.frame.shape == (1, H, W, 3)
+    assert vanilla_alphas.shape == inference_ret.metadata["alpha"].shape
+
+    # Inference tag
+    assert inference_ret.metadata["render_path"] == "inference"
+
+
+@skipif_no_cuda
+def test_unsupported_scene_type_integration():
+    """render_scene rejects unknown scene types."""
+    from experimental import render_scene
+
+    class FakeScene:
+        pass
+
+    req = _common_request()
+    with torch.inference_mode():
+        with pytest.raises(TypeError, match="requires a GaussianInferenceScene"):
+            render_scene(FakeScene(), **req)
+
+
+# ======================================================================
+# 6. Benchmark Timing Comparison (informational)
+# ======================================================================
+
+
+@skipif_no_cuda
+def test_benchmark_timing_comparison():
+    """Collect and print timing data for Inference vs vanilla paths.
+
+    This is NOT a pass/fail test. It runs a small benchmark (N=10000,
+    10 frames) and reports median frame times in ms.
+    """
+    from experimental import (
+        GaussianInferenceScene,
+        rasterize_gaussian_inference_scene,
+        render_scene,
+    )
+    from gsplat.rendering import rasterization
+
+    N = 10000
+    NUM_FRAMES = 10
+    device = "cuda"
+
+    # Build activated Gaussians for both paths
+    torch.manual_seed(42)
+    means = torch.randn(N, 3, device=device)
+    quats = torch.randn(N, 4, device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales_raw = torch.rand(N, 3, device=device) * 0.1 + 0.01  # log-space
+    opacities_raw = torch.randn(N, device=device)  # logit-space
+    colors = torch.rand(N, 3, device=device)
+
+    scales_act = scales_raw.exp()
+    opacities_act = opacities_raw.sigmoid()
+
+    viewmat, K = _make_camera()
+
+    # Build Inference scene (from activated tensors)
+    inference = GaussianInferenceScene.from_gaussian_tensors(
+        means,
+        quats,
+        scales_act,
+        opacities_act,
+        colors,
+        sh_degree=None,
+        sh_compression="none",
+        id="bench",
+    )
+
+    # Helper: time a rendering closure for NUM_FRAMES
+    def _bench(render_fn, label):
+        # Warmup
+        for _ in range(3):
+            render_fn()
+        torch.cuda.synchronize()
+
+        times_ms = []
+        for _ in range(NUM_FRAMES):
+            start_ev = torch.cuda.Event(enable_timing=True)
+            end_ev = torch.cuda.Event(enable_timing=True)
+            start_ev.record()
+            render_fn()
+            end_ev.record()
+            torch.cuda.synchronize()
+            times_ms.append(start_ev.elapsed_time(end_ev))
+
+        median = statistics.median(times_ms)
+        return median, times_ms
+
+    # 1. Inference via rasterize_gaussian_inference_scene
+    def _inference_functional():
+        with torch.inference_mode():
+            rasterize_gaussian_inference_scene(
+                inference, viewmat=viewmat, K=K, width=W, height=H
+            )
+
+    med_func, _ = _bench(_inference_functional, "Inference functional")
+
+    # 2. Inference via render_scene
+    def _inference_unified():
+        with torch.inference_mode():
+            render_scene(inference, viewmat=viewmat, K=K, width=W, height=H)
+
+    med_unified, _ = _bench(_inference_unified, "Inference unified")
+
+    # 3. Vanilla via gsplat.rasterization under no_grad
+    viewmats = viewmat[None]
+    Ks = K[None]
+
+    def _vanilla():
+        with torch.no_grad():
+            rasterization(
+                means=means,
+                quats=quats,
+                scales=scales_act,
+                opacities=opacities_act,
+                colors=colors,
+                viewmats=viewmats,
+                Ks=Ks,
+                width=W,
+                height=H,
+            )
+
+    med_vanilla, _ = _bench(_vanilla, "Vanilla")
+
+    # Print results (visible in pytest -v -s output)
+    print("\n" + "=" * 60)
+    print("  Inference Benchmark Timing (N=10000, 10 frames)")
+    print("=" * 60)
+    print(
+        f"  Inference functional  (rasterize_gaussian_inference_scene) : {med_func:.3f} ms"
+    )
+    print(
+        f"  Inference unified     (render_scene)                 : {med_unified:.3f} ms"
+    )
+    print(f"  Vanilla         (gsplat.rasterization)         : {med_vanilla:.3f} ms")
+    print("=" * 60)
+
+    # No assertion -- this is informational only.
+    # We just verify the test ran to completion without errors.

--- a/experimental/render/types.py
+++ b/experimental/render/types.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Shared render API types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from torch import Tensor
+
+
+@dataclass
+class RenderReturn:
+    """Container returned by render surface entry points."""
+
+    frame: Tensor
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["RenderReturn"]

--- a/gsplat/exporter.py
+++ b/gsplat/exporter.py
@@ -432,6 +432,104 @@ def splat2ply_bytes(
     return buffer.getvalue()
 
 
+def load_ply_to_splats(path: str) -> dict:
+    """Read a 3D Gaussian Splatting PLY file into splat parameter tensors.
+
+    Inverse of :func:`splat2ply_bytes`. Reads the standard 3DGS PLY format
+    used by the INRIA 3DGS authors and trained models from gsplat and other
+    splat trainers. The ``f_rest_*`` properties are interpreted in
+    channel-major order (the INRIA-3DGS convention): first all R basis
+    coefficients (1..K-1), then all G, then all B, where K = (sh_degree+1)^2
+    and the DC term (k=0) lives in ``f_dc_0..f_dc_2`` separately.
+
+    Parsing adapted from FastGS (MIT License) - see
+    https://github.com/fastgs/FastGS/blob/main/scene/gaussian_model.py.
+
+    Args:
+        path: Path to the PLY file.
+
+    Returns:
+        Dict with float32 CPU tensors:
+            - ``means``: ``(N, 3)`` xyz positions.
+            - ``scales``: ``(N, 3)`` log-scales.
+            - ``quats``: ``(N, 4)`` quaternions as stored (unnormalized).
+            - ``opacities``: ``(N,)`` logit-opacities.
+            - ``sh0``: ``(N, 1, 3)`` DC SH coefficient (RGB).
+            - ``shN``: ``(N, K-1, 3)`` higher-order SH coefficients
+              (basis-major). Empty along dim 1 when the file only stores
+              the DC term (SH degree 0).
+    """
+    try:
+        from plyfile import PlyData
+    except ImportError as exc:
+        raise ImportError(
+            "load_ply_to_splats requires the 'plyfile' package. "
+            "Install it with `pip install plyfile`."
+        ) from exc
+
+    ply = PlyData.read(str(path))
+    vertex = ply.elements[0]
+    n_splats = len(vertex)
+
+    means = np.stack(
+        [
+            np.asarray(vertex["x"]),
+            np.asarray(vertex["y"]),
+            np.asarray(vertex["z"]),
+        ],
+        axis=1,
+    )
+    opacities = np.asarray(vertex["opacity"])
+    sh0 = np.stack(
+        [
+            np.asarray(vertex["f_dc_0"]),
+            np.asarray(vertex["f_dc_1"]),
+            np.asarray(vertex["f_dc_2"]),
+        ],
+        axis=1,
+    )  # (N, 3) DC term
+
+    f_rest_names = sorted(
+        (p.name for p in vertex.properties if p.name.startswith("f_rest_")),
+        key=lambda s: int(s.split("_")[-1]),
+    )
+    if f_rest_names:
+        if len(f_rest_names) % 3 != 0:
+            raise ValueError(
+                f"f_rest property count ({len(f_rest_names)}) is not a "
+                "multiple of 3 (RGB channels); cannot reshape SH coefficients."
+            )
+        f_rest = np.stack(
+            [np.asarray(vertex[name]) for name in f_rest_names], axis=1
+        )  # (N, 3 * (K - 1)) channel-major
+        k_minus_1 = len(f_rest_names) // 3
+        f_rest = f_rest.reshape(n_splats, 3, k_minus_1).swapaxes(1, 2)
+        # Now (N, K - 1, 3) in (basis, channel) order.
+    else:
+        f_rest = np.zeros((n_splats, 0, 3), dtype=np.float32)
+
+    scale_names = sorted(
+        (p.name for p in vertex.properties if p.name.startswith("scale_")),
+        key=lambda s: int(s.split("_")[-1]),
+    )
+    scales = np.stack([np.asarray(vertex[name]) for name in scale_names], axis=1)
+
+    rot_names = sorted(
+        (p.name for p in vertex.properties if p.name.startswith("rot_")),
+        key=lambda s: int(s.split("_")[-1]),
+    )
+    quats = np.stack([np.asarray(vertex[name]) for name in rot_names], axis=1)
+
+    return {
+        "means": torch.from_numpy(np.ascontiguousarray(means)).float(),
+        "scales": torch.from_numpy(np.ascontiguousarray(scales)).float(),
+        "quats": torch.from_numpy(np.ascontiguousarray(quats)).float(),
+        "opacities": torch.from_numpy(np.ascontiguousarray(opacities)).float(),
+        "sh0": torch.from_numpy(np.ascontiguousarray(sh0[:, None, :])).float(),
+        "shN": torch.from_numpy(np.ascontiguousarray(f_rest)).float(),
+    }
+
+
 def splat2splat_bytes(
     means: torch.Tensor,
     scales: torch.Tensor,

--- a/libs/scene/design.md
+++ b/libs/scene/design.md
@@ -1,103 +1,5 @@
 # Scene Design
 
-## Scene Types
-
-`GaussianScene` is the training-oriented Gaussian container. It owns the
-parameter dictionary used by optimizer and strategy code (`means`, `quats`,
-`scales`, `opacities`, and either RGB or SH color tensors) and keeps those
-tensors in the source representation expected by training paths. Topology hooks
-mutate this owned state when gaussians are duplicated, split, removed,
-relocated, sampled, or permuted.
-
-`GaussianInferenceScene` is the packed QSO inference container. It owns detached
-render-time tensors in viewer/kernel layout: planar means, packed
-quaternion/scale/opacity (`qso_packed`), packed colors, SH metadata, and
-component indexing. It can be built from a `GaussianScene` or from already
-activated tensors, then used by inference render paths that expect packed
-storage. The conversion boundary is one-way: training code owns the
-editable Gaussian parameters, while inference scenes own compact packed tensors
-and do not participate in autograd.
-
-### Scene Type Summary
-
-| Scene Type                 | Representation           | Tensor Layout                         | Typical Use                  |
-| -------------------------- | ------------------------ | ------------------------------------- | ---------------------------- |
-| `GaussianScene`            | Raw log-space parameters | `splats` ParameterDict, row-aligned N | Training, optimization       |
-| `GaussianInferenceScene`   | Activated, packed QSO    | `means_planar` [3,N], `qso_packed` [N,8] fp16, `colors_packed` varies | Inference rendering  |
-
-Supported conversions:
-
-- `GaussianScene` → `GaussianInferenceScene` via `from_gaussian_scene()` (one-way, single-component only)
-- Raw tensors → `GaussianInferenceScene` via `from_gaussian_tensors()` (pre-activated inputs)
-- `GaussianInferenceScene` → training scene: not supported (the conversion boundary is one-way)
-
-## Module Layout
-
-```text
-libs/scene/
-  design.md
-  __init__.py
-  pyproject.toml
-  sh_compression.py
-  test_package_imports.py
-  kernels/
-    __init__.py
-    _backend.py
-    gaussian_inference_ops.py
-    cuda/
-      __init__.py
-      build.py
-      ext.cpp
-      csrc/
-        gaussian_scene_pack.cpp
-        gaussian_scene_pack.cuh
-  functional/
-    __init__.py
-    gaussian_inference.py
-    test_gaussian_inference.py
-  components/
-    __init__.py
-    base.py
-    gaussian_scene.py
-    gaussian_inference_scene.py
-    test_gaussian_scene.py
-    test_gaussian_inference_scene.py
-```
-
-## Package Roles
-
-### `functional/`
-
-`functional/` is the public Python surface of the scene module.
-
-It exports scene operators such as `pack_gaussian_inference_scene` and defines the
-API-level contract for arguments, shapes, dtypes, and return values.  Downstream
-code should import from `gsplat_scene.functional`.
-
-### `kernels/`
-
-`kernels/` is the backend implementation layer.
-
-- `_backend.py` loads the `gsplat_scene_cuda` extension (prebuilt then JIT).
-- `gaussian_inference_ops.py` owns Python-level input validation and native dispatch.
-- `kernels/cuda/` contains `build.py`, `ext.cpp` (PYBIND11), and `csrc/*.cu`.
-
-`kernels/` is not a curated user-facing API.
-
-### `components/`
-
-Scene class implementations (`Scene`, `GaussianScene`, `GaussianInferenceScene`) and
-their tests.  Components call into `kernels/` for CUDA work.
-
-### Dependency direction
-
-```text
-functional/  ->  kernels/  ->  kernels/cuda/
-components/  ->  kernels/
-```
-
-Scene CUDA ops live in `libs/scene/kernels/`.
-
 ## Goal
 
 Provide a minimal shared scene abstraction for the current Gaussian-based paths in:
@@ -118,8 +20,7 @@ The scene code lives under:
 The package exports:
 
 ```python
-from gsplat_scene import Scene, GaussianScene, GaussianInferenceScene, SHCompressionMode
-from gsplat_scene.functional import pack_gaussian_inference_scene
+from gsplat_scene import Scene, GaussianScene
 ```
 
 ## Base `Scene`
@@ -290,11 +191,18 @@ class GaussianScene(Scene):
     def on_permute(self, order: torch.Tensor) -> None: ...
 ```
 
+Notably absent from the current implementation:
+
+- `set_component()`
+- `names()`
+- `items()`
+- a separate radiance API
+
 ### `put(name, splats)`
 
 `put()` adds a named component backed by a `torch.nn.ParameterDict`.
 
-Behavior:
+Current behavior:
 
 - the first `put()` stores the passed `ParameterDict` directly
 - later `put()` calls append rows by concatenating the existing splat tensors with the new component tensors
@@ -309,7 +217,7 @@ Errors raised:
 - `ValueError("component splats must not be empty")` if the `ParameterDict` is empty or missing `"means"`
 - the splat-key concatenation iterates over keys of the *existing* `splats`; new keys present in `component` but not in `self.splats` are silently dropped, and missing keys raise `KeyError` from the underlying `torch.cat`
 
-Limitations:
+Current limitations:
 
 - `put()` only accepts splats; signal cannot be added per-component (callers seed it via `from_splats(..., signal=...)`)
 - appended components must match the existing splat-key layout
@@ -335,60 +243,6 @@ Notes:
 - `GaussianScene` extends that by also accepting integer component ids
 - this is a selected subset, not a zero-copy writable scene view
 
-## `GaussianInferenceScene`
-
-`GaussianInferenceScene` is the packed inference container.
-
-```python
-class GaussianInferenceScene(Scene):
-    def __init__(self, id: str) -> None: ...
-
-    means_planar: Optional[Tensor]        # [3, N] float32 CUDA
-    qso_packed: Optional[Tensor]          # [N, 8] float16 CUDA
-    colors_packed: Optional[Tensor]       # varies by sh_degree/compression
-    sh_degree: Optional[int]
-    sh_compression_mode: Optional[SHCompressionMode]
-    num_gaussians: int
-    component_names: list[str]
-    component_index: Tensor
-```
-
-### `from_gaussian_scene(scene, *, id, sh_compression="none")`
-
-Builds an inference scene from a training `GaussianScene`. Applies activations
-automatically (`F.normalize` on quaternions, `.exp()` on scales, `.sigmoid()` on
-opacities). Rejects appearance-optimized scenes (those with `"features"` in
-splats) and multi-component scenes. Not supported under `torch.distributed` with
-`world_size > 1`.
-
-### `from_gaussian_tensors(means, quats, scales, opacities, colors, sh_degree, sh_compression, *, id)`
-
-Builds an inference scene from pre-activated tensors. Validates activation
-contracts: quaternions must be unit-norm (wxyz order), scales positive, opacities
-in `[0, 1]`, all values finite.
-
-### `put(name, component)`
-
-Adds a pre-packed component dict with keys `means_planar`, `qso_packed`,
-`colors_packed`, `sh_degree`, `sh_compression_mode`. Validates shapes, dtypes,
-devices, and consistency with existing components.
-
-### `get(component)`
-
-Returns a component view by name or integer index, including a boolean `mask`
-for indexing into the concatenated tensors.
-
-### `is_empty()` / `release()`
-
-`is_empty()` returns `True` when the scene has no packed tensors or zero
-gaussians. `release()` clears all packed state and resets to empty.
-
-Out of scope for this API:
-
-- topology mutation hooks
-- scene-owned rendering helpers
-- scene-owned optimizer logic
-
 ## Validation Rules
 
 `validate()` checks:
@@ -400,11 +254,11 @@ Out of scope for this API:
 - `component_names` is non-empty when `splats` is non-empty
 - `component_index` stays within `[0, len(component_names))`
 
-Validation relies on assertions for most invariant checks.
+The implementation currently relies on assertions for most invariant checks.
 
 ## Scene Serialization
 
-`GaussianScene.state_dict()` returns:
+`GaussianScene.state_dict()` currently returns:
 
 ```python
 {
@@ -429,7 +283,7 @@ Validation relies on assertions for most invariant checks.
 5. `component_index`
 6. validation
 
-Compatibility defaults:
+Legacy behavior supported today:
 
 - missing `component_names` defaults to `["scene"]`
 - missing `component_index` defaults to all zeros
@@ -479,7 +333,7 @@ Key points:
 - simple trainer also does not save `scene.state_dict()`
 - on checkpoint load, it rebuilds the scene as `GaussianScene.from_splats(runner.splats, id=...)`
 
-> Trainer checkpoints store only `splats + scene_id`, **not** `scene.state_dict()`. Restored scenes therefore lose:
+> ⚠️ **Persistence trade-off**: trainer checkpoints currently store only `splats + scene_id`, **not** `scene.state_dict()`. Restored scenes therefore lose:
 >
 > - any custom `signal` rows the trainer added during training
 > - multi-component bookkeeping (`component_names`, `component_index`)
@@ -490,7 +344,7 @@ Key points:
 
 `GaussianScene` provides hooks so `component_index` and `signal` stay aligned with `splats` during topology-changing operations.
 
-Update rules:
+Current update rules are:
 
 ### Duplicate
 
@@ -550,30 +404,9 @@ The trainer and render paths remain responsible for:
 
 That keeps the scene object focused on storage and bookkeeping.
 
-## Gaussian Inference SH Packing
+## Current Scope
 
-`GaussianInferenceScene` stores packed geometry in `qso_packed`: an `[N, 8]`
-float16 tensor with quaternion in columns 0-3, scale in columns 4-6, and opacity
-in column 7.
-
-`GaussianInferenceScene` stores the public `sh_compression` string as
-`SHCompressionMode` metadata: `NONE` = `"none"`, `PACKED_32B` = `"32b"`, and
-`PACKED_16B` = `"16b"`. Nonzero compression modes are valid only for SH degree
-3. The Python wrappers require this enum; the native C++ ABI still receives the
-corresponding integer value and validates it before casting to its local enum.
-
-For SH3, scene packing uses distinct `colors_packed` layouts:
-
-- `NONE` (`"none"`): `[N, 16, 3]` float16, preserving raw SH layout
-- `PACKED_32B` (`"32b"`): `[N, 48]` float32, flattening coefficients into 32-bit lanes
-- `PACKED_16B` (`"16b"`): `[N, 48]` float16, flattening coefficients into fp16 lanes
-
-RGB remains `[N, 4]` float16 with an alignment pad, and SH0-SH2 remain
-`[N, K, 3]` float32.
-
-## Supported Surface
-
-Standardized scene APIs:
+Included today:
 
 - minimal abstract `Scene`
 - concrete `GaussianScene`
@@ -582,17 +415,11 @@ Standardized scene APIs:
 - exclusive components via `component_index`
 - sidecar update hooks for topology changes
 - AV checkpoint evaluation support from saved splats
-- concrete `GaussianInferenceScene` with packed QSO layout
-- `SHCompressionMode` enum (`NONE`, `PACKED_32B`, `PACKED_16B`)
-- `pack_gaussian_inference_scene` functional operator
-- `put`/`get` multi-component assembly for inference scenes
 
-Out of scope:
+Explicitly not standardized yet:
 
 - hierarchical scene access
 - scene-owned rendering helpers
 - scene-owned optimizer logic
 - generalized component mutation APIs like `set_component()`
 - trainer checkpoint persistence of full `GaussianScene.state_dict()`
-- appearance-optimized (`features`) conversion to inference scenes
-- inference-to-training scene conversion (the one-way boundary)

--- a/setup.py
+++ b/setup.py
@@ -47,17 +47,21 @@ def get_extensions():
     # the module directly from build.py.
     import importlib.util
 
-    spec = importlib.util.spec_from_file_location(
-        "gsplat_cuda_build", os.path.join("gsplat", "cuda", "build.py")
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    params = module.get_build_parameters()
+    def _load_build_module(module_name, build_py_path):
+        spec = importlib.util.spec_from_file_location(module_name, build_py_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
 
     setup_dir = os.path.dirname(os.path.abspath(__file__))
-    sources = [os.path.relpath(s, setup_dir) for s in params.sources]
 
-    extension = CUDAExtension(
+    # --- gsplat main extension ---
+    gsplat_build = _load_build_module(
+        "gsplat_cuda_build", os.path.join("gsplat", "cuda", "build.py")
+    )
+    params = gsplat_build.get_build_parameters()
+    sources = [os.path.relpath(s, setup_dir) for s in params.sources]
+    gsplat_ext = CUDAExtension(
         "gsplat.csrc",
         sources=sources,
         include_dirs=params.extra_include_paths,
@@ -67,7 +71,28 @@ def get_extensions():
         },
         extra_link_args=params.extra_ldflags,
     )
-    return [extension]
+
+    # --- experimental Inference render extension ---
+    inference_build = _load_build_module(
+        "experimental_gaussian_render_inference_scene_build",
+        os.path.join("experimental", "render", "kernels", "cuda", "build.py"),
+    )
+    inference_params = inference_build.get_build_parameters()
+    inference_sources = [
+        os.path.relpath(s, setup_dir) for s in inference_params.sources
+    ]
+    inference_ext = CUDAExtension(
+        "experimental.render.kernels.csrc",
+        sources=inference_sources,
+        include_dirs=inference_params.extra_include_paths,
+        extra_compile_args={
+            "cxx": inference_params.extra_cflags,
+            "nvcc": inference_params.extra_cuda_cflags,
+        },
+        extra_link_args=inference_params.extra_ldflags,
+    )
+
+    return [gsplat_ext, inference_ext]
 
 
 setup(


### PR DESCRIPTION
## Summary

Adds an experimental inference-only Gaussian rendering path built around packed `GaussianInferenceScene` data and a CUDA macro-tile rasterization backend.

This PR introduces:

- `experimental.render` APIs for stateless rendering, unified `render_scene(...)` dispatch, and a stateful `GaussianInferenceRenderer` that reuses GPU buffers across frames.
- A CUDA inference renderer extension with projection, SH evaluation/compression, macro-tile intersection, segmented sorting, and RGBT rasterization.
- Viewer, benchmark, docs, and test coverage for the inference path, including PLY loading and an inference toggle in `simple_viewer.py`.

## Data Flow

```text
Raw Gaussian data
  - checkpoint splats
  - PLY splats
  - GaussianScene
        |
        v
GaussianInferenceScene.from_gaussian_scene(...)
        |
        v
Packed inference scene tensors
  means_planar  [3, N]   fp32
  qso_packed    [N, 8]   fp16  (quat, scale, opacity)
  colors_packed varies by RGB / SH / SH compression
        |
        v
Python render APIs
  rasterize_gaussian_inference_scene(...)
  render_scene(...)
  GaussianInferenceRenderer.render(...)
        |
        v
CUDA inference backend
  projection
  SH decode / evaluation
  macro-tile intersection
  segmented sort
  macro-tile rasterization
        |
        v
Output frame
  [1, H, W, 4] fp16 RGBT
  RGB = frame[..., :3]
  alpha = 1 - transmittance