### PR TITLE
Vcauxbrisebo/higs perf patch

### DIFF
--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.cu
@@ -250,10 +250,8 @@ at::Tensor render_gaussian_inference_scene(
             compression, decode_params,
             state.visible, state.means2d, state.depths, state.conics, state.colors, {});
 
-    } else if (state.sh_coeffs_per_channel > 0) {
-        // ---- Uncompressed SH — fused projection + SH for any degree ----
-        // The fused kernel handles all SH degrees; only compressed mode
-        // is restricted to degree 3.
+    } else if (state.sh_coeffs_per_channel == 16) {
+        // ---- Uncompressed SH3 — fused projection + SH fast path ----
         higs::launch_projection_sh_fused_kernel(
             means, {}, qso_packed, viewmat_4d, K_4d,
             static_cast<uint32_t>(width), static_cast<uint32_t>(height),
@@ -263,6 +261,20 @@ at::Tensor render_gaussian_inference_scene(
             static_cast<int32_t>(sh_degree), colors_packed, SH_ACTIVATION_SCALE, SH_ACTIVATION_SHIFT,
             SHCompressionMode::NONE, nullptr,
             state.visible, state.means2d, state.depths, state.conics, state.colors, {});
+
+    } else if (state.sh_coeffs_per_channel > 0) {
+        // ---- Generic lower-degree SH (K != 16): projection first, then float32 SH ----
+        higs::launch_projection_fwd_kernel(
+            means, {}, qso_packed, viewmat_4d, K_4d,
+            static_cast<uint32_t>(width), static_cast<uint32_t>(height),
+            static_cast<float>(eps2d), static_cast<float>(near_plane),
+            static_cast<float>(far_plane), static_cast<float>(radius_clip),
+            gsplat::CameraModelType::PINHOLE,
+            state.visible, state.means2d, state.depths, state.conics, {});
+
+        higs::launch_spherical_harmonics_viewmat_fwd_kernel(
+            static_cast<int32_t>(sh_degree), means, viewmat, colors_packed, state.visible,
+            SH_ACTIVATION_SCALE, SH_ACTIVATION_SHIFT, state.colors);
 
     } else {
         // ---- Pre-activated RGB: projection only + copy colors ----

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/GaussianRenderInferenceScene.cu
@@ -91,10 +91,10 @@ std::unique_ptr<InferenceRenderState> create_gaussian_render_inference_scene_sta
         "sh_compression_mode requires SH degree 3 (K==16); got K=",
         state->sh_coeffs_per_channel);
     if (state->sh_coeffs_per_channel == 16 && sh_compression_mode != 0) {
-        auto sh_float = scene.colors_packed.contiguous().to(at::kFloat);
+        auto sh_coeffs = scene.colors_packed.contiguous();
         auto opacities_float = scene.qso_packed.contiguous().narrow(1, 7, 1).squeeze(1).to(at::kFloat);
         auto compressed = higs::launch_sh_compress(
-            sh_float, opacities_float, static_cast<SHCompressionMode>(sh_compression_mode));
+            sh_coeffs, opacities_float, static_cast<SHCompressionMode>(sh_compression_mode));
         state->shCompressed = compressed.packed;
         state->shDecodeParams = std::make_unique<higs::SHDecodeParams>(compressed.decode_params);
         torch::cuda::synchronize();

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.cu
@@ -214,17 +214,15 @@ void IntersectMTFused::execute(const at::Tensor &means2d, const at::Tensor &dept
 
     if (m_nMacroIsects > 0)
     {
+        // High-water-mark allocation: all four sort ping-pong buffers grow
+        // together, sharing m_mtIsectCapacity.
         if (m_nMacroIsects > m_mtIsectCapacity)
         {
             m_mtDepthKeys     = at::empty({m_nMacroIsects}, opts_i32);
             m_mtGaussIds      = at::empty({m_nMacroIsects}, opts_i32);
+            m_mtTmpDepthKeys  = at::empty({m_nMacroIsects}, opts_i32);
+            m_mtTmpGaussIds   = at::empty({m_nMacroIsects}, opts_i32);
             m_mtIsectCapacity = m_nMacroIsects;
-        }
-        if (m_nMacroIsects > m_mtSortedCapacity)
-        {
-            m_mtDepthKeysSorted = at::empty({m_nMacroIsects}, opts_i32);
-            m_mtGaussIdsSorted  = at::empty({m_nMacroIsects}, opts_i32);
-            m_mtSortedCapacity  = m_nMacroIsects;
         }
 
         // Stage 4: Macro-tile fill
@@ -235,9 +233,10 @@ void IntersectMTFused::execute(const at::Tensor &means2d, const at::Tensor &dept
             m_mtDepthKeys.data_ptr<int32_t>(), m_mtGaussIds.data_ptr<int32_t>(), m_mtChunkMetaWords.data_ptr<int32_t>(),
             m_mtChunkTileCarry.data_ptr<int32_t>(), m_numMtTiles);
 
-        // Stage 5: Macro-tile segmented sort
-        launch_mt_segmented_sort(m_nMacroIsects, m_nMacroTiles, m_mtGaussOffsets, m_mtDepthKeys, m_mtGaussIds,
-                                 m_mtDepthKeysSorted, m_mtGaussIdsSorted);
+        // Stage 5: Macro-tile segmented sort. The sort returns the buffer that
+        // actually holds the sorted gaussian IDs; rasterize() reads it.
+        m_mtGaussIdsSorted = launch_mt_segmented_sort(m_nMacroIsects, m_nMacroTiles, m_mtGaussOffsets, m_mtDepthKeys,
+                                                      m_mtGaussIds, m_mtTmpDepthKeys, m_mtTmpGaussIds);
         m_numRasterBatches = m_mtBatchOffsets[-1].item<int32_t>();
     }
     else

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectMTFused.h
@@ -63,11 +63,12 @@ private:
     at::Tensor m_mtChunkTileCarry;                  // [n_chunk_tiles*n_mt_tiles*MT_META_TILE] int32 chunk-tile carries
     at::Tensor m_mtDepthKeys;                       // [n_mt_isects] int32 — depth as bit-reinterpreted int32
     at::Tensor m_mtGaussIds;                        // [n_mt_isects] int32 — gaussian indices
-    at::Tensor m_mtDepthKeysSorted;                 // [n_mt_isects] int32 — sorted depth keys
-    at::Tensor m_mtGaussIdsSorted;                  // [n_mt_isects] int32 — gaussian IDs sorted by depth per macro-tile
+    at::Tensor m_mtTmpDepthKeys;                    // [n_mt_isects] int32 — scratch double-buffer for the sort
+    at::Tensor m_mtTmpGaussIds;                     // [n_mt_isects] int32 — scratch double-buffer for the sort
+    at::Tensor m_mtGaussIdsSorted;                  // sorted gaussian IDs — zero-copy handle returned by the sort
+                                                    // (aliases m_mtGaussIds or m_mtTmpGaussIds; not separately allocated)
     at::Tensor m_mtBatchOffsets;                    // [n_mt+1] int32 — gaussian batch start indices per macro-tile
-    int64_t m_mtIsectCapacity    = 0;               // high-water-mark for m_mtDepthKeys/m_mtGaussIds allocation
-    int64_t m_mtSortedCapacity   = 0;               // high-water-mark for m_mtDepthKeysSorted/m_mtGaussIdsSorted
+    int64_t m_mtIsectCapacity    = 0;               // high-water-mark for the four sort ping-pong buffers
     int64_t m_nMacroIsects       = 0;               // total macro-tile intersections (from offsets readback)
     int32_t m_macroTileCols      = 0;               // macro-tile grid width
     int32_t m_nMacroTiles        = 0;               // total macro-tiles (cols × rows)

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.cu
@@ -27,23 +27,23 @@
 
 namespace higs {
 
-void launch_mt_segmented_sort(int64_t n_macro_isects,
-                              int32_t n_macro_tiles,
-                              const at::Tensor in_mt_gauss_offsets,
-                              at::Tensor inout_mt_depth_keys,
-                              at::Tensor inout_mt_gauss_ids,
-                              at::Tensor out_mt_depth_keys_sorted,
-                              at::Tensor out_mt_gauss_ids_sorted)
+at::Tensor launch_mt_segmented_sort(int64_t n_macro_isects,
+                                    int32_t n_macro_tiles,
+                                    const at::Tensor in_mt_gauss_offsets,
+                                    at::Tensor inout_mt_depth_keys,
+                                    at::Tensor inout_mt_gauss_ids,
+                                    at::Tensor tmp_mt_depth_keys,
+                                    at::Tensor tmp_mt_gauss_ids)
 {
     if (n_macro_isects <= 0)
     {
-        return;
+        return inout_mt_gauss_ids;
     }
 
     int32_t *d_keys_in       = inout_mt_depth_keys.data_ptr<int32_t>();
-    int32_t *d_keys_out      = out_mt_depth_keys_sorted.data_ptr<int32_t>();
+    int32_t *d_keys_out      = tmp_mt_depth_keys.data_ptr<int32_t>();
     int32_t *d_vals_in       = inout_mt_gauss_ids.data_ptr<int32_t>();
-    int32_t *d_vals_out      = out_mt_gauss_ids_sorted.data_ptr<int32_t>();
+    int32_t *d_vals_out      = tmp_mt_gauss_ids.data_ptr<int32_t>();
     const int32_t *d_offsets = in_mt_gauss_offsets.data_ptr<int32_t>();
     cudaStream_t stream      = at::cuda::getCurrentCUDAStream();
 
@@ -59,18 +59,10 @@ void launch_mt_segmented_sort(int64_t n_macro_isects,
 
     int result_buf = SegmentedSortAsync(state, d_offsets, d_keys, d_values, stream);
 
-    if (result_buf == 0)
-    {
-        // copy_ instead of set_ to avoid aliasing the input and output
-        // tensors — high-water-mark reuse across frames would otherwise
-        // cause the sort's ping-pong buffers to overlap on the next frame.
-        // Narrow to n_macro_isects since the buffers may have different
-        // high-water-mark capacities.
-        out_mt_depth_keys_sorted.narrow(0, 0, n_macro_isects).copy_(
-            inout_mt_depth_keys.narrow(0, 0, n_macro_isects));
-        out_mt_gauss_ids_sorted.narrow(0, 0, n_macro_isects).copy_(
-            inout_mt_gauss_ids.narrow(0, 0, n_macro_isects));
-    }
+    // result_buf is the index of the buffer holding the sorted data: 0 = inout_*
+    // (input), 1 = tmp_* (scratch). Return that buffer's gaussian-ids tensor as a
+    // zero-copy handle so the caller reads the right one without any copy/alias.
+    return result_buf == 0 ? inout_mt_gauss_ids : tmp_mt_gauss_ids;
 }
 
 } // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/MacroTileIntersect.h
@@ -22,16 +22,18 @@
 
 namespace higs {
 
-// Sort gaussian IDs by depth key within each macro-tile segment.
-// Only sorted values (gaussian IDs) are guaranteed in the output;
-// key buffers are used as working space and their final contents
-// are undefined.
-void launch_mt_segmented_sort(int64_t n_macro_isects,
-                              int32_t n_macro_tiles,
-                              const at::Tensor in_mt_gauss_offsets,
-                              at::Tensor inout_mt_depth_keys,
-                              at::Tensor inout_mt_gauss_ids,
-                              at::Tensor out_mt_depth_keys_sorted,
-                              at::Tensor out_mt_gauss_ids_sorted);
+// Sort gaussian IDs by depth key within each macro-tile segment. The inout_*
+// and tmp_* buffers are used as ping-pong working space; their final contents
+// are otherwise undefined. RETURNS the tensor (a zero-copy handle aliasing
+// either inout_mt_gauss_ids or tmp_mt_gauss_ids) that holds the sorted gaussian
+// IDs. The returned tensor is always defined; for n_macro_isects <= 0 it is
+// inout_mt_gauss_ids unchanged. No data is copied.
+at::Tensor launch_mt_segmented_sort(int64_t n_macro_isects,
+                                    int32_t n_macro_tiles,
+                                    const at::Tensor in_mt_gauss_offsets,
+                                    at::Tensor inout_mt_depth_keys,
+                                    at::Tensor inout_mt_gauss_ids,
+                                    at::Tensor tmp_mt_depth_keys,
+                                    at::Tensor tmp_mt_gauss_ids);
 
 } // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCompression.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SHCompression.cu
@@ -133,7 +133,7 @@ at::Tensor launch_sh_encode(const at::Tensor &coeffs, const SHEncodeParams &enco
     return packed;
 }
 
-// Full compression pipeline: fp32 coefficients → compressed + scales.
+// Full compression pipeline: fp16/fp32 coefficients -> compressed + scales.
 // Computes per-basis-per-channel p99.99 scales in YCoCg space (excluding low-opacity
 // gaussians from scale computation), encodes all gaussians, and returns the packed
 // bitstream + decoder scale structure.

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.cu
@@ -131,6 +131,40 @@ __global__ void spherical_harmonics_fwd_kernel(const int N, const int K, const i
     colors[elem_id * 4 + c] = __float2half(val);
 }
 
+__global__ void spherical_harmonics_viewmat_fwd_kernel(const int N, const int K, const int degrees_to_use,
+                                                       const float *__restrict__ means,   // [3, N] planar
+                                                       const float *__restrict__ viewmat, // [4, 4] row-major
+                                                       const float *__restrict__ coeffs,  // [N, K, 3]
+                                                       const uint32_t *__restrict__ masks,
+                                                       float bias, float min_value,
+                                                       __half *__restrict__ colors)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N * 3)
+    {
+        return;
+    }
+    const int elem_id = idx / 3;
+    const int c       = idx % 3;
+    if (masks != nullptr && !(masks[elem_id >> 5] & (1u << (elem_id & 0x1fu))))
+    {
+        return;
+    }
+
+    float3 dir_n{};
+    if (degrees_to_use > 0)
+    {
+        const float cam_x = -(viewmat[0] * viewmat[3] + viewmat[4] * viewmat[7] + viewmat[8] * viewmat[11]);
+        const float cam_y = -(viewmat[1] * viewmat[3] + viewmat[5] * viewmat[7] + viewmat[9] * viewmat[11]);
+        const float cam_z = -(viewmat[2] * viewmat[3] + viewmat[6] * viewmat[7] + viewmat[10] * viewmat[11]);
+        dir_n = GetViewDir(means, N, elem_id, cam_x, cam_y, cam_z);
+    }
+
+    float val;
+    EvaluteSHCoeffs(degrees_to_use, c, dir_n, coeffs + elem_id * K * 3, bias, min_value, val);
+    colors[elem_id * 4 + c] = __float2half(val);
+}
+
 // Unified K=16 SH forward kernel for raw (float/half) and compressed (32B/16B) inputs.
 // Uses compile-time SHInputMode to select the coefficient loading path; all other logic
 // (compaction, SH evaluation, output packing) is shared.
@@ -275,6 +309,37 @@ void launch_spherical_harmonics_fwd_kernel(
                                                                      cam_z, coeffs.data_ptr<float>(), masks_ptr, bias,
                                                                      min_value, colors_ptr);
     }
+}
+
+void launch_spherical_harmonics_viewmat_fwd_kernel(
+    // inputs
+    int32_t degrees_to_use,
+    const at::Tensor means, const at::Tensor viewmat, const at::Tensor coeffs, const at::optional<at::Tensor> masks,
+    const float bias, const float min_value,
+    // outputs
+    at::Tensor colors)
+{
+    const int N = means.numel() / 3;
+
+    if (N == 0)
+    {
+        return;
+    }
+
+    TORCH_CHECK(coeffs.scalar_type() == at::kFloat,
+                "spherical_harmonics_viewmat_fwd_kernel only supports float coeffs, got ", coeffs.scalar_type());
+
+    const int K = static_cast<int>(coeffs.size(-2));
+    const int32_t n_elements = N * 3;
+    const dim3 threads(256);
+    const dim3 grid((n_elements + threads.x - 1) / threads.x);
+
+    const uint32_t *masks_ptr =
+        masks.has_value() ? reinterpret_cast<const uint32_t *>(masks.value().data_ptr<int32_t>()) : nullptr;
+
+    spherical_harmonics_viewmat_fwd_kernel<<<grid, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        N, K, degrees_to_use, means.data_ptr<float>(), viewmat.data_ptr<float>(), coeffs.data_ptr<float>(), masks_ptr,
+        bias, min_value, reinterpret_cast<__half *>(colors.data_ptr<at::Half>()));
 }
 
 } // namespace higs

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.h
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SphericalHarmonics.h
@@ -39,4 +39,16 @@ void launch_spherical_harmonics_fwd_kernel(
     // compressed-SH path: mode != NONE activates on-the-fly decode (requires degree 3, K=16).
     SHCompressionMode mode = SHCompressionMode::NONE, const SHDecodeParams *decode_params = nullptr);
 
+void launch_spherical_harmonics_viewmat_fwd_kernel(
+    // inputs
+    int32_t degrees_to_use,
+    const at::Tensor means,   // [3, N] float — gaussian centers (planar)
+    const at::Tensor viewmat, // [4, 4] float row-major world-to-camera transform
+    const at::Tensor coeffs,  // [N, K, 3] float
+    const at::optional<at::Tensor> masks,
+    float bias, float min_value,
+    // outputs
+    at::Tensor colors // [N, 4] half {R,G,B,0}
+);
+
 } // namespace higs

--- a/experimental/render/kernels/test_gaussian_render_inference_only_op.py
+++ b/experimental/render/kernels/test_gaussian_render_inference_only_op.py
@@ -68,8 +68,6 @@ def _pack_scene(
     if sh_deg >= 0 and K_sh == 16:
         if sh_compression == "none":
             colors_packed = colors.half()
-        elif sh_compression == "32b":
-            colors_packed = colors.contiguous().view(N, 48)
         else:
             colors_packed = colors.half().view(N, 48)
     elif sh_deg >= 0 and K_sh > 0:

--- a/libs/scene/components/gaussian_inference_scene.py
+++ b/libs/scene/components/gaussian_inference_scene.py
@@ -208,7 +208,7 @@ class GaussianInferenceScene(Scene):
             expected_dtype = torch.float16
         elif sh_degree == 3 and sh_compression_mode is SHCompressionMode.PACKED_32B:
             expected_shape = (n_local, 48)
-            expected_dtype = torch.float32
+            expected_dtype = torch.float16
         elif sh_degree == 3 and sh_compression_mode is SHCompressionMode.PACKED_16B:
             expected_shape = (n_local, 48)
             expected_dtype = torch.float16

--- a/libs/scene/components/test_gaussian_inference_scene.py
+++ b/libs/scene/components/test_gaussian_inference_scene.py
@@ -130,8 +130,6 @@ def _pack_scene_python(
     if sh_deg >= 0 and K_sh == 16:
         if sh_compression == "none":
             colors_packed = colors.half()
-        elif sh_compression == "32b":
-            colors_packed = colors.contiguous().view(N, 48)
         else:
             colors_packed = colors.half().view(N, 48)
     elif sh_deg >= 0 and K_sh > 0:
@@ -941,7 +939,7 @@ def test_classmethod_parity_sh3():
     "sh_compression,expected_mode,expected_dtype,expected_shape",
     [
         ("none", SHCompressionMode.NONE, torch.float16, (40, 16, 3)),
-        ("32b", SHCompressionMode.PACKED_32B, torch.float32, (40, 48)),
+        ("32b", SHCompressionMode.PACKED_32B, torch.float16, (40, 48)),
         ("16b", SHCompressionMode.PACKED_16B, torch.float16, (40, 48)),
     ],
 )
@@ -977,8 +975,6 @@ def test_sh3_compression_metadata_layout_and_values(
 
     if sh_compression == "none":
         expected = colors.half()
-    elif sh_compression == "32b":
-        expected = colors.contiguous().view(40, 48)
     else:
         expected = colors.half().view(40, 48)
     torch.testing.assert_close(scene.colors_packed, expected, atol=0, rtol=0)

--- a/libs/scene/functional/gaussian_inference.py
+++ b/libs/scene/functional/gaussian_inference.py
@@ -61,9 +61,8 @@ def pack_gaussian_inference_scene(
                              for SH mode (``sh_degree >= 0``).
         sh_degree:           ``-1`` for RGB (no SH); ``0``–``3`` for SH coefficients.
         sh_compression_mode: SH compression mode enum. ``NONE`` preserves
-                             raw SH3 layout in fp16, ``PACKED_32B`` flattens
-                             SH3 coefficients into float32 lanes, and
-                             ``PACKED_16B`` flattens them into fp16 lanes.
+                             raw SH3 layout in fp16; ``PACKED_32B`` and
+                             ``PACKED_16B`` flatten SH3 coefficients into fp16 lanes.
 
     Returns:
         A 3-tuple ``(means_planar, qso_packed, colors_packed)``:
@@ -72,8 +71,7 @@ def pack_gaussian_inference_scene(
         - ``qso_packed``: ``[N, 8]`` float16.
         - ``colors_packed``: ``[N, 4]`` float16 for RGB; ``[N, K, 3]`` float32
           for SH0–2; ``[N, 16, 3]`` float16 for SH3 ``NONE``;
-          ``[N, 48]`` float32 for SH3 ``PACKED_32B``; ``[N, 48]``
-          float16 for SH3 ``PACKED_16B``.
+          ``[N, 48]`` float16 for SH3 ``PACKED_32B`` and ``PACKED_16B``.
 
     Raises:
         TypeError: if any tensor has the wrong Python type or dtype.

--- a/libs/scene/functional/test_gaussian_inference.py
+++ b/libs/scene/functional/test_gaussian_inference.py
@@ -200,7 +200,7 @@ def test_colors_rgb_dtype_and_shape():
     "sh_compression_mode,expected_dtype,expected_shape",
     [
         (SHCompressionMode.NONE, torch.float16, (N, 16, 3)),
-        (SHCompressionMode.PACKED_32B, torch.float32, (N, 48)),
+        (SHCompressionMode.PACKED_32B, torch.float16, (N, 48)),
         (SHCompressionMode.PACKED_16B, torch.float16, (N, 48)),
     ],
 )
@@ -231,8 +231,6 @@ def test_colors_sh3_mode_values(sh_compression_mode):
 
     if sh_compression_mode is SHCompressionMode.NONE:
         expected = inp["colors"].to(torch.float16)
-    elif sh_compression_mode is SHCompressionMode.PACKED_32B:
-        expected = inp["colors"].contiguous().view(N, 48)
     else:
         expected = inp["colors"].to(torch.float16).view(N, 48)
     torch.testing.assert_close(colors_packed, expected, atol=0, rtol=0)

--- a/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cpp
+++ b/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cpp
@@ -128,20 +128,16 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> pack_gaussian_inference_scene_cud
     qso_packed.narrow(1, 7, 1).copy_(opacities.unsqueeze(1).to(at::kHalf));
 
     // Pack colors based on SH degree and compression mode.
-    int64_t K_sh = (sh_degree >= 0 && colors.dim() == 3) ? colors.size(1) : 0;
     at::Tensor colors_packed;
-    if (sh_degree >= 0 && K_sh == 16) {
+    if (sh_degree == 3) {
         if (sh_compression == ShCompressionMode::None) {
             // SH3 "none": preserve the raw SH layout in fp16 lanes.
             colors_packed = colors.clamp(-fp16_max, fp16_max).to(at::kHalf);
-        } else if (sh_compression == ShCompressionMode::Packed32B) {
-            // SH3 "32b": pack into contiguous 32-bit coefficient lanes.
-            colors_packed = colors.contiguous().view({N, 48});
         } else {
-            // SH3 "16b": pack into contiguous fp16 coefficient lanes.
+            // SH3 compressed modes: stage contiguous fp16 coefficient lanes.
             colors_packed = colors.clamp(-fp16_max, fp16_max).to(at::kHalf).view({N, 48});
         }
-    } else if (sh_degree >= 0 && K_sh > 0) {
+    } else if (sh_degree >= 0) {
         // Lower-degree SH (0-2): keep float32
         colors_packed = colors.contiguous();
     } else {

--- a/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cuh
+++ b/libs/scene/kernels/cuda/csrc/gaussian_scene_pack.cuh
@@ -45,8 +45,7 @@ namespace scene {
  *                              scale cols 4-6, opacity col 7
  *   colors_packed        [N, 4] fp16 for RGB; [N, K, 3] fp32 for SH0-2;
  *                        [N, 16, 3] fp16 for SH3 mode 0;
- *                        [N, 48] fp32 for SH3 mode 1;
- *                        [N, 48] fp16 for SH3 mode 2
+ *                        [N, 48] fp16 for SH3 modes 1 and 2
  */
 std::tuple<at::Tensor, at::Tensor, at::Tensor> pack_gaussian_inference_scene_cuda(
     const at::Tensor &means,

--- a/libs/scene/kernels/gaussian_inference_ops.py
+++ b/libs/scene/kernels/gaussian_inference_ops.py
@@ -116,8 +116,7 @@ def pack_gaussian_inference_scene(
                         scale cols 4-6, opacity col 7
         colors_packed:  [N, 4] float16 for RGB; [N, K, 3] float32 for SH0-2;
                         [N, 16, 3] float16 for SH3 NONE;
-                        [N, 48] float32 for SH3 PACKED_32B;
-                        [N, 48] float16 for SH3 PACKED_16B
+                        [N, 48] float16 for SH3 PACKED_32B and PACKED_16B
     """
     # --- scalar validation -----------------------------------------------
     if not isinstance(sh_degree, int):

--- a/libs/scene/sh_compression.py
+++ b/libs/scene/sh_compression.py
@@ -27,8 +27,8 @@ class SHCompressionMode(IntEnum):
     """
 
     NONE = 0  # [N, 16, 3] float16 — raw coefficients
-    PACKED_32B = 1  # [N, 48] float32 — flattened
-    PACKED_16B = 2  # [N, 48] float16 — flattened + quantized to fp16
+    PACKED_32B = 1  # [N, 48] float16 — flattened staging for 32B codec
+    PACKED_16B = 2  # [N, 48] float16 — flattened staging for 16B codec
 
 
 SH_COMPRESSION_MAP = {

--- a/tests/test_av_scene_wrapper.py
+++ b/tests/test_av_scene_wrapper.py
@@ -147,8 +147,11 @@ def test_av_evaluate_checkpoint_uses_saved_scene_path(monkeypatch, tmp_path) -> 
         del device
         return eval_scene
 
-    def fake_evaluate(passed_splats, loaded_scene, test_frame_ids, W, H, **_kwargs):
-        seen["splats"] = passed_splats
+    def fake_evaluate(
+        stage, passed_scene, loaded_scene, test_frame_ids, W, H, **_kwargs
+    ):
+        del stage
+        seen["splats"] = passed_scene.splats
         seen["test_frame_ids"] = test_frame_ids
         assert loaded_scene is eval_scene
         assert (W, H) == (1, 1)


### PR DESCRIPTION
This PR improves the experimental HiGS Gaussian inference rendering path by removing an extra macro-tile segmented-sort copy and restoring the intended SH dispatch behavior.
The macro-tile sort now returns the ping-pong buffer that actually contains the sorted Gaussian IDs, allowing rasterization to consume it directly without maintaining a separate sorted output allocation. This keeps the existing high-water-mark buffer reuse while avoiding the copy after segmented sort.
For spherical harmonics, the SH3 uncompressed path keeps the fused projection + SH fast path, while lower-degree SH falls back to projection followed by a float32 SH evaluation kernel. This preserves the fast path for `K == 16` and keeps non-SH3 behavior explicit.