### PR TITLE
[NV] Document scene/stage lib install for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This repo comes with a standalone script that reproduces the official Gaussian S
 ```bash
 cd examples
 pip install -r requirements.txt
+# install the scene/stage helper libraries the example trainers import
+python -m pip install -e ../libs/scene -e ../libs/stage
 # download mipnerf_360 benchmark data
 python datasets/download_dataset.py
 # run batch evaluation
@@ -72,7 +74,8 @@ bash benchmarks/basic.sh
 ## Examples
 
 We provide a set of examples to get you started! Below you can find the details about
-the examples (requires installing some extrra dependencies via `pip install -r examples/requirements.txt --no-build-isolation`)
+the examples (requires installing some extra dependencies via `pip install -r examples/requirements.txt --no-build-isolation`, plus the scene/stage helper
+libraries the trainers import via `python -m pip install -e libs/scene -e libs/stage`)
 
 - [Train a 3D Gaussian splatting model on a COLMAP capture.](https://docs.gsplat.studio/main/examples/colmap.html)
 - [Fit a 2D image with 3D Gaussians.](https://docs.gsplat.studio/main/examples/image.html)

--- a/examples/av_trainer.py
+++ b/examples/av_trainer.py
@@ -44,8 +44,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 import gsplat
-from gsplat_scene import GaussianScene
-from gsplat_stage import Stage
+
+try:
+    from gsplat_scene import GaussianScene
+    from gsplat_stage import Stage
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        f"{e.name} is not installed. The example trainers require the local "
+        "scene/stage helper libraries. Install them with:\n"
+        "    python -m pip install -e libs/scene -e libs/stage"
+    ) from e
 from gsplat.strategy import MCMCStrategy
 
 # ---------------------------------------------------------------------------

--- a/examples/sample_inference.py
+++ b/examples/sample_inference.py
@@ -42,8 +42,16 @@ from examples.av_trainer import (
 )
 from datasets.colmap import Parser as ColmapParser
 from datasets.ncore import NCoreParser
-from gsplat_scene import GaussianScene
-from gsplat_stage import Stage
+
+try:
+    from gsplat_scene import GaussianScene
+    from gsplat_stage import Stage
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        f"{e.name} is not installed. The example trainers require the local "
+        "scene/stage helper libraries. Install them with:\n"
+        "    python -m pip install -e libs/scene -e libs/stage"
+    ) from e
 
 
 def load_stage(ckpt_path: str, device: torch.device) -> tuple[Stage, str, int | None]:

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -59,8 +59,16 @@ from gsplat.compression import PngCompression
 from gsplat.distributed import cli
 from gsplat.optimizers import SelectiveAdam
 from gsplat.rendering import rasterization, RasterizeMode
-from gsplat_scene import GaussianScene
-from gsplat_stage import Stage
+
+try:
+    from gsplat_scene import GaussianScene
+    from gsplat_stage import Stage
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        f"{e.name} is not installed. The example trainers require the local "
+        "scene/stage helper libraries. Install them with:\n"
+        "    python -m pip install -e libs/scene -e libs/stage"
+    ) from e
 from gsplat.cuda._wrapper import CameraModel
 from gsplat.strategy import DefaultStrategy, MCMCStrategy
 from gsplat_viewer import GsplatViewer, GsplatRenderTabState

--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -48,8 +48,16 @@ from utils import (
 )
 from gsplat_viewer_2dgs import GsplatViewer, GsplatRenderTabState
 from gsplat.rendering import rasterization_2dgs, rasterization_2dgs_inria_wrapper
-from gsplat_scene import GaussianScene
-from gsplat_stage import Stage
+
+try:
+    from gsplat_scene import GaussianScene
+    from gsplat_stage import Stage
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        f"{e.name} is not installed. The example trainers require the local "
+        "scene/stage helper libraries. Install them with:\n"
+        "    python -m pip install -e libs/scene -e libs/stage"
+    ) from e
 from gsplat.strategy import DefaultStrategy
 from nerfview import CameraState, RenderTabState, apply_float_colormap
 


### PR DESCRIPTION
**Summary**

The example trainers import the local `gsplat_scene` / `gsplat_stage` helper libraries (`libs/scene`, `libs/stage`), but the gsplat build does not install them. A fresh source build therefore fails at import with `ModuleNotFoundError: No module named 'gsplat_scene'` (#965).

**What's new**

- README evaluation/examples setup now documents `bash libs/install.sh scene && bash libs/install.sh stage` (and fixes an "extrra" typo).
- The scene/stage imports in `simple_trainer.py`, `simple_trainer_2dgs.py`, `sample_inference.py`, and `av_trainer.py` are wrapped so a missing package raises an actionable message pointing at the install command instead of a bare `ModuleNotFoundError`.

Fixes #965