### PR TITLE
[NV] G-SHARP v0.2 port: dynamic surgical scene training pipeline

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -26,7 +26,11 @@ jobs:
         run: |
           pip install black[jupyter]==22.3.0 pytest
           pip install torch==2.0.0 --index-url https://download.pytorch.org/whl/cpu
-          BUILD_NO_CUDA=1 pip install .
+          # tests/test_dataset_endonerf.py and tests/test_dynamic_surgical_trainer.py
+          # import PIL + tqdm; install the [examples] extra so the test
+          # collection doesn't ImportError on a fresh build. The tests also
+          # have `pytest.importorskip` guards as a belt-and-braces.
+          BUILD_NO_CUDA=1 pip install .[examples]
       - name: Run Black Format Check
         run: black . gsplat/ tests/ examples/ profiling/ --check
       - name: Run Tests.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -50,9 +50,12 @@ jobs:
         if: github.event_name == 'push'
 
       - name: Sphinx build
-        # fail on warnings: "-W --keep-going"
+        # Fail on warnings (e.g. "document isn't included in any toctree" if
+        # docs/source/index.rst is ever truncated or a new page is added
+        # without wiring it in). `--keep-going` collects every warning before
+        # exiting so a single failure doesn't hide the rest.
         run: |
-          sphinx-build docs/source _build
+          sphinx-build -W --keep-going docs/source _build
 
       # Deploy to version-dependent subdirectory.
       - name: Deploy to GitHub Pages

--- a/docs/source/apis/contrib.rst
+++ b/docs/source/apis/contrib.rst
@@ -1,0 +1,25 @@
+gsplat.contrib (experimental)
+==============================
+
+.. warning::
+
+   Everything under :mod:`gsplat.contrib` is **experimental**. APIs may change
+   or be removed between releases.
+
+.. automodule:: gsplat.contrib
+   :members:
+
+Dynamic / 4D Gaussians
+----------------------
+
+.. automodule:: gsplat.contrib.dynamic.hexplane
+   :members:
+
+.. automodule:: gsplat.contrib.dynamic.deformation
+   :members:
+
+.. automodule:: gsplat.contrib.dynamic.regulation
+   :members:
+
+.. automodule:: gsplat.contrib.dynamic.strategy
+   :members:

--- a/docs/source/examples/dynamic_surgical.rst
+++ b/docs/source/examples/dynamic_surgical.rst
@@ -1,0 +1,80 @@
+Dynamic Surgical Scene Reconstruction (G-SHARP port, experimental)
+===================================================================
+
+.. note::
+
+   This pipeline is **experimental**. The G-SHARP port lives under
+   ``gsplat.contrib.dynamic`` (HexPlane field, deformation network,
+   :class:`~gsplat.contrib.dynamic.DynamicStrategy`) plus surgical-scene
+   helpers in ``gsplat.losses``, ``gsplat.regularizers``,
+   ``gsplat.init_utils``, ``gsplat.training``. APIs may change. See
+   :doc:`../proposals/gsharp_v0_2_port` for the design background.
+
+Overview
+--------
+
+This example reconstructs a dynamic surgical scene (deforming tissue plus
+moving tools) on top of the core ``gsplat.rasterization`` pipeline. It ports
+the training-time components of G-SHARP v0.2:
+
+* Depth supervision — binocular disparity L1 or monocular Pearson
+* Tool / dynamic-object masking of RGB and depth losses
+* Invisible-region targeted TV regularizer
+* Multi-frame depth unprojection for SfM-free point cloud init
+* Two-stage schedule: coarse static → fine dynamic
+* 4D Gaussians via ``gsplat.contrib.dynamic`` (HexPlane + MLP deformation)
+
+Data
+----
+
+The tutorial targets the EndoNeRF sample ("pulling"). SCARED support is
+**not yet implemented** in this MR; ``examples/datasets/`` only ships an
+EndoNeRF parser and a stub for SCARED.
+
+gsplat itself does **not** ship code for estimating depth, tool masks, or
+camera poses. If you don't already have these, you can generate them with
+any standard tool; the G-SHARP v0.2 reference implementation uses
+Depth Anything V2, MedSAM3, and VGGT-1B as an optional upstream preprocessing
+stack.
+
+Getting the data
+~~~~~~~~~~~~~~~~
+
+The EndoNeRF "pulling" sequence is hosted on the upstream
+`med-air/EndoNeRF <https://github.com/med-air/EndoNeRF>`_ project's
+Google Drive folder
+(`direct link <https://drive.google.com/drive/folders/1zTcX80c1yrbntY9c6-EK2W2UVESVEug8?usp=sharing>`_).
+Download the ``pulling_soft_tissues`` directory and rename to
+``data/EndoNeRF/pulling`` (or wherever you point ``--data_dir`` at).
+
+Expected on-disk layout::
+
+    <scene>/
+      poses_bounds.npy
+      images/ 000000.png 000001.png ...
+      depth/  000000.png 000001.png ...
+      masks/  000000.png 000001.png ...
+
+Quickstart
+----------
+
+.. code-block:: bash
+
+   python examples/dynamic_surgical_trainer.py \
+       --data_dir path/to/endonerf_pulling \
+       --output_dir output/dynamic_surgical \
+       --coarse_steps 200 --fine_steps 2500 \
+       --init_max_points 50000 \
+       --depth_mode binocular \
+       --render_gif_after_train
+
+The trainer auto-derives the HexPlane AABB from the init point cloud
+(see :func:`examples.dynamic_surgical_trainer.train`); ``--hex_bounds``
+remains a lower bound. Run ``python examples/dynamic_surgical_trainer.py
+--help`` for the complete flag list (it's a tyro dataclass surface on
+:class:`Config`).
+
+What lands next
+---------------
+
+Implementation is driven test-first.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,6 +115,14 @@ Links
    migration/*
 
 
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Proposals
+
+   proposals/*
+
+
 Citations
 -------------
 .. bibliography::

--- a/docs/source/proposals/gsharp_v0_2_port.rst
+++ b/docs/source/proposals/gsharp_v0_2_port.rst
@@ -1,0 +1,146 @@
+G-SHARP v0.2 Integration Proposal
+==================================
+
+:Status: Implemented under ``gsplat.contrib.dynamic``; experimental, APIs may change
+:Source: G-SHARP v0.2 reference implementation (``holohub/applications/surgical_scene_recon/``)
+:Destination: ``gsplat/`` (the ``nv/gsharp-v0.2-port`` branch)
+
+Goals
+-----
+
+* Port all **training-time algorithmic** contributions of G-SHARP v0.2 natively
+  into gsplat.
+* Keep the deformable / 4D Gaussian machinery behind a clearly experimental
+  ``gsplat/contrib/`` namespace.
+* Ship test-first: every ported unit has positive + negative pytest cases.
+* Provide a runnable end-to-end tutorial on the EndoNeRF sample.
+
+Non-goals
+---------
+
+* No Holoscan / HoloHub imports anywhere.
+* No Depth Anything V2 / MedSAM3 / VGGT code inside the ``gsplat/`` package.
+  These are external pretrained nets; the tutorial only *references* them as
+  optional upstream preprocessing.
+* No compression / rate-distortion work (not present in G-SHARP v0.2).
+* No camera-pose optimization (G-SHARP v0.2 doesn't do it either).
+
+Component map
+-------------
+
+Core (stable) additions:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Component
+     - New file
+     - G-SHARP source
+   * - Binocular disparity L1 loss
+     - ``gsplat/losses.py`` (added alongside existing depth losses)
+     - ``EndoRunner.compute_depth_loss``, ``training/gsplat_train.py`` 906–960
+   * - Pearson depth loss (mono)
+     - ``gsplat/losses.py`` (added alongside existing depth losses)
+     - same
+   * - Masked L1 / SSIM wrappers
+     - ``gsplat/losses.py`` (added alongside existing depth losses)
+     - ``training/gsplat_train.py`` 1059–1101
+   * - Occlusion-TV regularizer
+     - ``gsplat/regularizers.py``
+     - ``compute_tv_loss_targeted``, 1925–2028
+   * - Torch mask dilation
+     - ``gsplat/regularizers.py``
+     - OpenCV dilation replaced by max-pool
+   * - Invisible-mask builder
+     - ``gsplat/regularizers.py``
+     - ``create_invisible_mask_from_paths``
+   * - Multi-frame depth unprojection
+     - ``gsplat/init_utils.py``
+     - ``accumulate_multiframe_pointcloud``, 2036–2159
+   * - KNN scale init
+     - ``gsplat/init_utils.py``
+     - ``create_splats_with_optimizers``, 1796–1906
+   * - Two-stage scheduler
+     - ``gsplat/training/schedulers.py``
+     - ``EndoRunner._train_stage``, 1007–1050
+
+Experimental contrib additions (``gsplat.contrib.dynamic``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Component
+     - New file
+     - G-SHARP source
+   * - HexPlane field
+     - ``gsplat/contrib/dynamic/hexplane.py``
+     - ``training/scene/hexplane.py``
+   * - Deform MLP + per-Gaussian deformation table
+     - ``gsplat/contrib/dynamic/deformation.py``
+     - ``training/scene/deformation.py``, ``gsplat_train.py`` 1376–1664
+   * - Plane / time smoothness regularizers
+     - ``gsplat/contrib/dynamic/regulation.py``
+     - ``training/scene/regulation.py``, loop 1233–1272
+   * - DynamicStrategy
+     - ``gsplat/contrib/dynamic/strategy.py``
+     - ``rasterize_splats``, 864–896
+
+Examples / docs:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Deliverable
+     - Path
+   * - EndoNeRF/SCARED dataset loader
+     - ``examples/datasets/endonerf.py``
+   * - Dynamic-scene trainer recipe
+     - ``examples/dynamic_surgical_trainer.py``
+   * - Tutorial
+     - ``docs/source/examples/dynamic_surgical.rst``
+   * - Contrib API docs
+     - ``docs/source/apis/contrib.rst``
+
+Why this layout
+---------------
+
+* The core library stays pure splatting math. Depth losses / occlusion-TV /
+  multi-frame init / two-stage schedule are generic and low-risk, so they live
+  alongside existing ``losses.py``, ``rendering.py``, ``strategy/``.
+* 4D / deformable pieces add new public surfaces (``HexPlane``, ``DeformNet``,
+  ``DynamicStrategy``) that are still research-grade → ``gsplat/contrib/dynamic/``
+  signals "ships with the wheel, API may change". Pattern follows the
+  well-known ``torchvision.prototype`` convention.
+* EndoNeRF/SCARED loader is domain-specific dataset glue → belongs with
+  ``colmap.py`` / ``ncore.py`` under ``examples/datasets/``, not in the
+  library.
+* DA2 / MedSAM3 / VGGT **do not enter the tree**; the tutorial explains "get
+  ``poses_bounds.npy``, ``masks/``, ``depth/`` some way" and points at the
+  G-SHARP v0.2 reference implementation (external to this repository) for reference.
+
+Test plan
+---------
+
+Every new module gets a ``tests/test_*.py`` with both positive and negative
+cases. Tests follow the flat layout and pytest conventions already in
+``gsplat/tests/`` (``conftest.py``, seed 42, CUDA-aware).
+
+Every component has positive + negative pytest coverage; see the
+``tests/test_*.py`` files corresponding to each module above.
+
+Risks
+-----
+
+* **Deformation + ``rasterization()`` coupling.** ``gsplat.rasterization`` has
+  no time axis. Solution: ``DynamicStrategy`` applies the deform-net to
+  ``(means, quats, opacities)`` *before* ``rasterization(...)`` is called
+  (same pattern as G-SHARP's ``rasterize_splats``).
+* **CUDA-only tests.** HexPlane/DeformNet tests run on CPU for determinism;
+  GPU smoke tests are marked CUDA-only.
+* **EndoNeRF sample license.** Documented in the tutorial, not redistributed
+  in-tree.
+* **sklearn optional dep.** Pure-torch fallback for KNN init keeps the
+  required-dep list unchanged.

--- a/examples/datasets/download_dataset.py
+++ b/examples/datasets/download_dataset.py
@@ -30,6 +30,7 @@ dataset_names = Literal[
     "bilarf_data",
     "zipnerf",
     "zipnerf_undistorted",
+    "endonerf",
 ]
 
 # dataset urls
@@ -71,6 +72,23 @@ class DownloadData:
         self.dataset_download(self.dataset)
 
     def dataset_download(self, dataset: dataset_names):
+        if dataset == "endonerf":
+            # EndoNeRF lives on a Google Drive folder hosted by the upstream
+            # `med-air/EndoNeRF <https://github.com/med-air/EndoNeRF>`_
+            # project. Folder downloads need `gdown` and a manual layout
+            # rename, so we point the user at the documented path instead of
+            # trying to script around the click-through.
+            raise NotImplementedError(
+                "Automated download for `endonerf` is not wired up yet.\n"
+                "Grab the `pulling_soft_tissues` folder from\n"
+                "  https://drive.google.com/drive/folders/1zTcX80c1yrbntY9c6-EK2W2UVESVEug8\n"
+                "and place it at  data/EndoNeRF/pulling  (or wherever your\n"
+                "`--data_dir` points). Expected layout:\n"
+                "  data/EndoNeRF/pulling/poses_bounds.npy\n"
+                "  data/EndoNeRF/pulling/images/, depth/, masks/\n"
+                "See docs/source/examples/dynamic_surgical.rst for the full\n"
+                "tutorial walkthrough."
+            )
         if isinstance(urls[dataset], list):
             for url in urls[dataset]:
                 url_file_name = Path(url).name

--- a/examples/datasets/endonerf.py
+++ b/examples/datasets/endonerf.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""EndoNeRF / SCARED dataset loader (example).
+
+Public API:
+
+- :class:`EndoNeRFParser` — parses an EndoNeRF directory layout into
+  in-memory arrays (poses, intrinsics, frame paths, times, splits).
+- :class:`EndoNeRFDataset` — torch-friendly random-access view returning
+  per-frame ``{image, depth, mask, camtoworld, K, time}`` dicts.
+
+Follows the same shape as :mod:`examples.datasets.colmap` and
+:mod:`examples.datasets.ncore`. Ported from
+the G-SHARP v0.2 reference implementation
+(EndoNeRF only — SCARED has a different on-disk layout and is currently
+a stub that raises :class:`NotImplementedError`).
+
+Expected on-disk layout (``dataset_type="endonerf"``):
+
+.. code-block::
+
+    <data_dir>/
+      poses_bounds.npy
+      images/   000000.png 000001.png ...
+      depth/    000000.png 000001.png ...
+      masks/    000000.png 000001.png ...
+
+Conventions matched against G-SHARP:
+
+- ``poses_bounds.npy`` row format: 17 floats per frame — 15 = ``poses[3, 5]``
+  flattened (``[R | t | (H, W, focal)]``); last 2 = near/far bounds.
+- ``masks/`` is in **tool=255 on-disk** convention (EndoNeRF / G-SHARP:
+  white = tool, black = tissue). The dataset applies ``1 - mask/255``
+  (matching ``gsplat_train.py:2102`` and ``endo_loader.py:179`` —
+  G-SHARP's own ``# 1=tissue, 0=tool`` comment) so the returned tensor
+  is a **tissue-include mask** (``1`` = keep tissue, ``0`` = drop tool).
+  This is the convention the mask-aware loss helpers
+  (:func:`gsplat.losses.masked_l1`, :func:`masked_ssim`,
+  :func:`binocular_disparity_l1`) expect — ``mask != 0`` means "include
+  this pixel in the loss".
+- ``time = idx / n_frames`` per frame.
+- ``test_every`` controls train/test split: frame ``i`` is test if
+  ``(i - 1) % test_every == 0``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Sequence
+
+import numpy as np
+import torch
+from PIL import Image
+
+DatasetType = Literal["endonerf", "scared"]
+
+
+@dataclass
+class EndoNeRFParser:
+    """Parse an EndoNeRF directory into in-memory arrays.
+
+    Args:
+        data_dir: Path to the dataset root (contains ``poses_bounds.npy``,
+            ``images/``, ``depth/``, ``masks/``).
+        dataset_type: ``"endonerf"`` (default) or ``"scared"``. The latter
+            is a stub — it routes to a clear ``NotImplementedError`` so
+            callers can detect the unsupported path.
+        test_every: Stride used to derive ``test_idxs`` (frame ``i`` is a
+            test frame iff ``(i - 1) % test_every == 0``). Default ``8``
+            matches G-SHARP.
+
+    Populated attributes (after ``__post_init__``):
+
+    - ``height``, ``width``, ``focal``: image dimensions and focal length
+      from ``poses_bounds.npy``.
+    - ``K``: ``(3, 3)`` pinhole intrinsics.
+    - ``bounds``: ``(N, 2)`` near/far per frame.
+    - ``camtoworlds``: ``(N, 4, 4)`` camera-to-world transforms.
+    - ``times``: ``(N,)`` per-frame timestamps in ``[0, 1)``.
+    - ``image_paths`` / ``depth_paths`` / ``mask_paths``: sorted PNG paths.
+    - ``train_idxs`` / ``test_idxs`` / ``video_idxs``: split index lists.
+
+    Raises:
+        FileNotFoundError: if ``data_dir`` or ``poses_bounds.npy`` is missing.
+        ValueError: on count mismatch between poses and frames, or if the
+            first mask is non-binary (sanity check matching the
+            ``test_endonerf_parser_non_binary_mask_rejected`` contract).
+        NotImplementedError: when ``dataset_type="scared"``.
+    """
+
+    data_dir: Path
+    dataset_type: DatasetType = "endonerf"
+    test_every: int = 8
+
+    # Populated in __post_init__ — declared here so they pickle / serialize cleanly.
+    height: int = field(init=False, default=0)
+    width: int = field(init=False, default=0)
+    focal: float = field(init=False, default=0.0)
+    K: np.ndarray = field(
+        init=False, default_factory=lambda: np.zeros((3, 3), dtype=np.float32)
+    )
+    bounds: np.ndarray = field(
+        init=False, default_factory=lambda: np.zeros((0, 2), dtype=np.float32)
+    )
+    camtoworlds: np.ndarray = field(
+        init=False, default_factory=lambda: np.zeros((0, 4, 4), dtype=np.float32)
+    )
+    times: np.ndarray = field(
+        init=False, default_factory=lambda: np.zeros((0,), dtype=np.float32)
+    )
+    image_paths: List[Path] = field(init=False, default_factory=list)
+    depth_paths: List[Path] = field(init=False, default_factory=list)
+    mask_paths: List[Path] = field(init=False, default_factory=list)
+    train_idxs: List[int] = field(init=False, default_factory=list)
+    test_idxs: List[int] = field(init=False, default_factory=list)
+    video_idxs: List[int] = field(init=False, default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.data_dir = Path(self.data_dir)
+        if not self.data_dir.exists():
+            raise FileNotFoundError(f"data_dir not found: {self.data_dir}")
+
+        if self.dataset_type == "endonerf":
+            self._load_endonerf()
+        elif self.dataset_type == "scared":
+            raise NotImplementedError(
+                "EndoNeRFParser: dataset_type='scared' routing is recognised but "
+                "the SCARED on-disk layout (JSON calibrations under data/frame_data/) "
+                "isn't ported yet — see the G-SHARP v0.2 reference implementation "
+                "for the original SCARED_Dataset loader. PRs welcome."
+            )
+        else:
+            raise ValueError(
+                f"EndoNeRFParser: unknown dataset_type {self.dataset_type!r}. "
+                f"Expected 'endonerf' or 'scared'."
+            )
+
+        n = len(self.image_paths)
+        self.train_idxs = [i for i in range(n) if (i - 1) % self.test_every != 0]
+        self.test_idxs = [i for i in range(n) if (i - 1) % self.test_every == 0]
+        self.video_idxs = list(range(n))
+
+    def _load_endonerf(self) -> None:
+        poses_bounds_path = self.data_dir / "poses_bounds.npy"
+        if not poses_bounds_path.exists():
+            raise FileNotFoundError(
+                f"EndoNeRFParser: missing poses_bounds.npy at {poses_bounds_path}."
+            )
+
+        poses_arr = np.load(str(poses_bounds_path))
+        n = poses_arr.shape[0]
+        # poses_arr layout: (N, 17) = (N, 15) flattened (3 x 5 = 15 pose entries) + (N, 2) bounds.
+        poses = poses_arr[:, :15].reshape(n, 3, 5)
+        self.bounds = poses_arr[:, 15:].astype(np.float32)
+
+        h, w, focal = poses[0, :, -1]
+        self.height = int(h)
+        self.width = int(w)
+        self.focal = float(focal)
+        self.K = np.array(
+            [
+                [focal, 0.0, self.width // 2],
+                [0.0, focal, self.height // 2],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+
+        # Drop the [H, W, focal] column → (N, 3, 4).
+        c2w_3x4 = poses[..., :4]
+
+        # LLFF stores the rotation columns as [down, right, backwards];
+        # convert to the standard [right, up, back] convention used by gsplat /
+        # G-SHARP / Nerfstudio. Mirror endo_loader.py in the G-SHARP source.
+        c2w_3x4 = c2w_3x4[:, :, [1, 0, 2, 3]] * np.array(
+            [1.0, -1.0, 1.0, 1.0], dtype=np.float32
+        )
+
+        # Pad to (N, 4, 4) homogeneous.
+        bottom_row = np.broadcast_to(
+            np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), (n, 1, 4)
+        )
+        self.camtoworlds = np.concatenate([c2w_3x4, bottom_row], axis=1).astype(
+            np.float32
+        )
+
+        self.times = np.arange(n, dtype=np.float32) / n
+
+        self.image_paths = sorted((self.data_dir / "images").glob("*.png"))
+        self.depth_paths = sorted((self.data_dir / "depth").glob("*.png"))
+        self.mask_paths = sorted((self.data_dir / "masks").glob("*.png"))
+
+        for name, paths in (
+            ("images", self.image_paths),
+            ("depth", self.depth_paths),
+            ("masks", self.mask_paths),
+        ):
+            if len(paths) != n:
+                raise ValueError(
+                    f"EndoNeRFParser: {name}/ has {len(paths)} files but "
+                    f"poses_bounds.npy has {n} frames."
+                )
+
+        # Sanity check: the first mask must be binary on disk (values in {0, 255}).
+        _validate_mask_binary(self.mask_paths[0])
+
+
+class EndoNeRFDataset(torch.utils.data.Dataset):
+    """Random-access view over the parser, filtered by split.
+
+    Args:
+        parser: A fully-initialised :class:`EndoNeRFParser`.
+        split: ``"train"``, ``"test"``, or ``"video"`` (default ``"train"``).
+
+    Each item is a dict with keys:
+
+    - ``image``: ``(H, W, 3)`` float32 in ``[0, 1]``.
+    - ``depth``: ``(H, W)`` float32 metric depth (0 = no measurement).
+    - ``mask``: ``(H, W)`` float32 tissue-include mask (``1`` = keep
+      tissue, ``0`` = drop tool), matching G-SHARP's ``1 - mask/255``
+      inversion at ``endo_loader.py:179`` (which has its own
+      ``# 1=tissue, 0=tool`` comment).
+    - ``camtoworld``: ``(4, 4)`` float32 camera-to-world.
+    - ``K``: ``(3, 3)`` float32 intrinsics.
+    - ``time``: scalar float32 timestamp in ``[0, 1)``.
+
+    Raises:
+        ValueError: if *split* is not one of ``"train"``, ``"test"``, ``"video"``.
+    """
+
+    def __init__(self, parser: EndoNeRFParser, split: str = "train") -> None:
+        self.parser = parser
+        self.split = split
+        if split == "train":
+            self.indices: Sequence[int] = parser.train_idxs
+        elif split == "test":
+            self.indices = parser.test_idxs
+        elif split == "video":
+            self.indices = parser.video_idxs
+        else:
+            raise ValueError(
+                f"EndoNeRFDataset: unknown split {split!r}; "
+                f"expected 'train', 'test', or 'video'."
+            )
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    def __getitem__(self, index: int) -> Dict[str, Any]:
+        idx = self.indices[index]
+
+        image = (
+            np.array(Image.open(self.parser.image_paths[idx])).astype(np.float32)
+            / 255.0
+        )
+        depth = np.array(Image.open(self.parser.depth_paths[idx])).astype(np.float32)
+
+        mask_raw = np.array(Image.open(self.parser.mask_paths[idx]))
+        if mask_raw.ndim == 3:
+            mask_raw = mask_raw[..., 0]
+        # G-SHARP convention (endo_loader.py:179 ``# 1=tissue, 0=tool``):
+        # 1 - mask/255 → returned tensor is a tissue-include mask.
+        mask = 1.0 - mask_raw.astype(np.float32) / 255.0
+
+        return {
+            "image": torch.from_numpy(image),
+            "depth": torch.from_numpy(depth),
+            "mask": torch.from_numpy(mask),
+            "camtoworld": torch.from_numpy(self.parser.camtoworlds[idx]),
+            "K": torch.from_numpy(self.parser.K),
+            "time": torch.tensor(float(self.parser.times[idx]), dtype=torch.float32),
+        }
+
+
+def _validate_mask_binary(mask_path: Path) -> None:
+    """Open *mask_path* and raise if the pixel values aren't binary {0, 255}.
+
+    Cheap sanity check at parse time — keeps the EndoNeRF dataset honest
+    about its tool-mask convention without paying per-getitem cost.
+    """
+    arr = np.array(Image.open(mask_path))
+    if arr.ndim == 3:
+        arr = arr[..., 0]
+    unique_vals = np.unique(arr)
+    if not set(unique_vals.tolist()).issubset({0, 255}):
+        raise ValueError(
+            f"EndoNeRFParser: mask {mask_path} is non-binary "
+            f"(unique values: {sorted(unique_vals.tolist())[:8]}...). "
+            f"Masks must be saved as binary {{0, 255}} PNG."
+        )

--- a/examples/dynamic_surgical_trainer.py
+++ b/examples/dynamic_surgical_trainer.py
@@ -1,0 +1,775 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dynamic surgical scene trainer (G-SHARP v0.2 port, experimental).
+
+End-to-end recipe wiring together every module landed in TDD steps 1–8:
+
+- :class:`examples.datasets.endonerf.EndoNeRFParser` /
+  :class:`EndoNeRFDataset` for on-disk data.
+- :func:`gsplat.init_utils.multi_frame_depth_unprojection` for SfM-free
+  point-cloud initialisation.
+- :func:`gsplat.init_utils.knn_scale_init` for per-Gaussian log-scale init.
+- :class:`gsplat.contrib.dynamic.HexPlaneField` +
+  :class:`DeformNetwork` for per-step deformation of
+  ``(means, quats, opacities)``.
+- :class:`gsplat.contrib.dynamic.DynamicStrategy` for densification +
+  :class:`DeformationTable` bookkeeping.
+- Mask-aware depth + photometric losses from :mod:`gsplat.losses` and the
+  TV / smoothness regularizers from :mod:`gsplat.regularizers` +
+  :mod:`gsplat.contrib.dynamic.regulation`.
+- :class:`gsplat.training.TwoStageScheduler` for the coarse → fine schedule.
+
+The MVP exposed here is the integration test surface: build all components
+from a config + parser, then run training-step iterations. No eval /
+checkpointing / viz in v1 — those land in follow-ups.
+
+CUDA is required at runtime (``gsplat.rasterization`` is CUDA-only).
+Component construction (build_* helpers) and config validation work on CPU
+and are covered by ``tests/test_dynamic_surgical_trainer.py``; the actual
+training step is covered by a CUDA-only integration test in the same file.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import tqdm
+from torch import Tensor
+
+from gsplat import rasterization
+from gsplat.contrib.dynamic import (
+    DeformNetwork,
+    DynamicStrategy,
+    HexPlaneField,
+    plane_smoothness,
+    time_l1,
+    time_smoothness,
+)
+from gsplat.init_utils import knn_scale_init, multi_frame_depth_unprojection
+from gsplat.losses import (
+    binocular_disparity_l1,
+    masked_l1,
+    masked_ssim,
+    pearson_depth_loss,
+)
+from gsplat.regularizers import compute_tv_loss_targeted
+from gsplat.training import TwoStageScheduler
+
+# Make the trainer runnable as `python examples/dynamic_surgical_trainer.py`
+# from the repo root (examples/ isn't installed).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from examples.datasets.endonerf import EndoNeRFDataset, EndoNeRFParser  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Config:
+    """CLI / programmatic config for the dynamic surgical trainer."""
+
+    data_dir: Path = Path("./data/EndoNeRF/pulling")
+    output_dir: Path = Path("./output/dynamic_surgical")
+
+    # Schedule
+    coarse_steps: int = 500
+    fine_steps: int = 3000
+
+    # SfM-free initialisation
+    init_max_points: int = 50_000
+    init_scale_multiplier: float = (
+        1.0  # G-SHARP convention: scales = log(knn_dist * init_scale)
+    )
+    init_opacity: float = 0.1
+
+    # HexPlane field
+    # Lower bound on the HexPlane AABB. The trainer auto-derives the actual
+    # bounds from the init means' bounding box (with a 2× margin for gradient
+    # drift) and takes ``max(cfg.hex_bounds, derived)``. Leave at 1.6 for
+    # legacy / fixture compatibility; the auto-derived value wins on real
+    # data.
+    hex_bounds: float = 1.6
+    hex_output_dim: int = 32
+    hex_resolution: Tuple[int, int, int, int] = (64, 64, 64, 25)
+    hex_multires: Tuple[int, ...] = (1, 2)
+
+    # Deformation MLP
+    deform_hidden_dim: int = 64
+    deform_num_layers: int = 3
+
+    # Loss weights
+    lambda_l1: float = 0.8
+    lambda_ssim: float = 0.2
+    lambda_depth: float = 1.0
+    lambda_tv: float = 1e-3
+    lambda_plane_smooth: float = 1e-4
+    lambda_time_smooth: float = 1e-4
+    lambda_time_l1: float = 1e-4
+
+    # Optimisation
+    lr_means: float = 1.6e-4
+    lr_quats: float = 1e-3
+    lr_scales: float = 5e-3
+    lr_opacities: float = 5e-2
+    lr_colors: float = 2.5e-3
+    lr_hexplane: float = 5e-3
+    lr_deform_mlp: float = 1.6e-4
+
+    # Loss config
+    depth_mode: str = "binocular"  # 'binocular' or 'monocular'
+
+    # Misc
+    seed: int = 42
+    device: str = "cuda"
+
+    # Render-GIF (post-training)
+    render_gif_after_train: bool = False
+    gif_filename: str = "preview.gif"
+    gif_fps: int = 10
+    gif_frame_indices: Optional[Tuple[int, ...]] = None  # None = parser.video_idxs
+
+    def __post_init__(self) -> None:
+        self.data_dir = Path(self.data_dir)
+        self.output_dir = Path(self.output_dir)
+        if self.depth_mode not in ("binocular", "monocular"):
+            raise ValueError(
+                f"Config: depth_mode must be 'binocular' or 'monocular', "
+                f"got {self.depth_mode!r}."
+            )
+        if self.coarse_steps < 0 or self.fine_steps < 0:
+            raise ValueError("Config: step counts must be non-negative.")
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_train_tensors(
+    parser: EndoNeRFParser, device: torch.device
+) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Materialise the train-split frames into ``(N, ...)`` tensors on *device*."""
+    from PIL import Image
+
+    idxs = parser.train_idxs
+    images_np: list[np.ndarray] = []
+    depths_np: list[np.ndarray] = []
+    masks_np: list[np.ndarray] = []
+    for idx in idxs:
+        images_np.append(
+            np.array(Image.open(parser.image_paths[idx])).astype(np.float32) / 255.0
+        )
+        depths_np.append(
+            np.array(Image.open(parser.depth_paths[idx])).astype(np.float32)
+        )
+        mask_raw = np.array(Image.open(parser.mask_paths[idx]))
+        if mask_raw.ndim == 3:
+            mask_raw = mask_raw[..., 0]
+        # G-SHARP convention (gsplat_train.py:2102):
+        # ``1 - mask/255`` → on-disk 255 (tool) becomes 0, on-disk 0 (tissue)
+        # becomes 1. The returned mask is a *tissue / include* mask
+        # (``1 = keep this pixel``, ``0 = it's a tool, drop``).
+        masks_np.append(1.0 - mask_raw.astype(np.float32) / 255.0)
+
+    images = torch.from_numpy(np.stack(images_np)).to(device)
+    depths = torch.from_numpy(np.stack(depths_np)).to(device)
+    masks = torch.from_numpy(np.stack(masks_np)).to(device)
+    poses = torch.from_numpy(parser.camtoworlds[idxs]).to(device)
+    intrinsics = (
+        torch.from_numpy(parser.K).unsqueeze(0).expand(len(idxs), -1, -1).to(device)
+    )
+    return images, depths, masks, poses, intrinsics
+
+
+def build_splats_from_parser(
+    parser: EndoNeRFParser, cfg: Config, device: torch.device
+) -> Tuple[nn.ParameterDict, Dict[str, torch.optim.Optimizer]]:
+    """Initialise splat parameters + optimizers from a parsed EndoNeRF directory.
+
+    Pipeline: multi-frame depth unprojection across the train split →
+    optional random subsample to ``cfg.init_max_points`` → kNN log-scale
+    init (with G-SHARP's ``log(knn_dist * init_scale_multiplier)`` rescaling).
+    Quaternions are random-normal then unit-normalised; opacities are
+    initialised in logit space to match ``cfg.init_opacity`` after sigmoid;
+    colors are taken from the unprojected pixel RGBs.
+
+    Returns:
+        ``(params, optimizers)`` where *params* is a ``ParameterDict`` with
+        the five per-Gaussian trainables ``means``, ``quats``, ``scales``,
+        ``opacities``, ``colors``. HexPlane and DeformNet trainables are
+        wired separately via :func:`build_deform_modules` so gsplat's
+        densification ops (which iterate every entry in *params* and
+        per-Gaussian-index them) don't accidentally touch non-per-Gaussian
+        tensors — see :class:`DynamicStrategy` for the contract.
+    """
+    images, depths, masks, poses, intrinsics = _load_train_tensors(parser, device)
+
+    # Clip depths to the dataset's near/far bounds from poses_bounds.npy.
+    # EndoNeRF pulling has a few outlier pixels with depth > 100x the scene
+    # extent (sensor noise / invalid samples); without clipping they pull
+    # the init point cloud's AABB to absurd scales and the HexPlane AABB
+    # (auto-derived in train()) blows up too.
+    if (
+        hasattr(parser, "bounds")
+        and parser.bounds is not None
+        and len(parser.bounds) > 0
+    ):
+        depth_max = (
+            float(parser.bounds.max()) * 1.5
+        )  # 50% margin for unsupervised drift
+        depths = depths.clamp(max=depth_max)
+
+    # ``masks`` is already in tissue=1 / tool=0 convention (see
+    # :func:`_load_train_tensors`), which is exactly the include-mask that
+    # :func:`multi_frame_depth_unprojection` expects (keep where ``!= 0``).
+    xyz, rgb = multi_frame_depth_unprojection(
+        images=images,
+        depths=depths,
+        masks=masks,
+        poses=poses,
+        intrinsics=intrinsics,
+        max_points=cfg.init_max_points,
+    )
+    n = xyz.shape[0]
+    if n < 4:  # need at least k+1 = 4 points for default knn_scale_init.
+        raise RuntimeError(
+            f"build_splats_from_parser: only {n} valid points after "
+            f"unprojection — too few to initialise. Check that the dataset "
+            f"depth + mask combination yields valid pixels."
+        )
+
+    log_scales_1d = knn_scale_init(xyz, k=3) + math.log(cfg.init_scale_multiplier)
+    log_scales = log_scales_1d.unsqueeze(-1).repeat(1, 3).contiguous()
+    quats = torch.randn(n, 4, device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    # Init opacities in logit space so sigmoid(...) == init_opacity.
+    logit_opa = math.log(cfg.init_opacity / max(1.0 - cfg.init_opacity, 1e-12))
+    opacities = torch.full((n, 1), logit_opa, device=device)
+
+    # Strategy params are *per-Gaussian only* — gsplat densification ops
+    # iterate every entry and split/duplicate/prune per-Gaussian. HexPlane
+    # plane grids and DeformNet MLP weights belong to separate optimizers
+    # managed by :func:`build_deform_modules`.
+    params = nn.ParameterDict(
+        {
+            "means": nn.Parameter(xyz.contiguous()),
+            "quats": nn.Parameter(quats),
+            "scales": nn.Parameter(log_scales),
+            "opacities": nn.Parameter(opacities),
+            "colors": nn.Parameter(rgb.contiguous()),
+        }
+    )
+    optimizers = {
+        "means": torch.optim.Adam([params["means"]], lr=cfg.lr_means),
+        "quats": torch.optim.Adam([params["quats"]], lr=cfg.lr_quats),
+        "scales": torch.optim.Adam([params["scales"]], lr=cfg.lr_scales),
+        "opacities": torch.optim.Adam([params["opacities"]], lr=cfg.lr_opacities),
+        "colors": torch.optim.Adam([params["colors"]], lr=cfg.lr_colors),
+    }
+    return params, optimizers
+
+
+def build_deform_modules(
+    cfg: Config,
+    device: torch.device,
+    bounds_override: Optional[float] = None,
+) -> Tuple[HexPlaneField, DeformNetwork, torch.optim.Optimizer, torch.optim.Optimizer]:
+    """Construct the HexPlane field, the DeformNet, and their optimizers.
+
+    Args:
+        cfg: Trainer config.
+        device: Target device.
+        bounds_override: If provided, overrides ``cfg.hex_bounds`` for the
+            HexPlane AABB. The trainer normally derives this from the init
+            point cloud (see ``train()``); passing the override here keeps the
+            HexPlane query inside ``[-1, 1]^3`` after ``_normalize_aabb`` so
+            ``grid_sample(padding_mode="border")`` doesn't clamp every
+            Gaussian to the same edge feature (which would collapse the
+            deformation field to a spatial constant).
+    """
+    plane_cfg = {
+        "grid_dimensions": 2,
+        "input_coordinate_dim": 4,
+        "output_coordinate_dim": cfg.hex_output_dim,
+        "resolution": list(cfg.hex_resolution),
+    }
+    bounds = float(bounds_override) if bounds_override is not None else cfg.hex_bounds
+    hexplane = HexPlaneField(
+        bounds=bounds,
+        planes_config=plane_cfg,
+        multires=cfg.hex_multires,
+    ).to(device)
+    deform_net = DeformNetwork(
+        feature_dim=hexplane.feat_dim,
+        hidden_dim=cfg.deform_hidden_dim,
+        num_layers=cfg.deform_num_layers,
+    ).to(device)
+
+    hex_optimizer = torch.optim.Adam(hexplane.parameters(), lr=cfg.lr_hexplane)
+    deform_optimizer = torch.optim.Adam(deform_net.parameters(), lr=cfg.lr_deform_mlp)
+    return hexplane, deform_net, hex_optimizer, deform_optimizer
+
+
+# ---------------------------------------------------------------------------
+# Deformation routing: gather → DeformNet → scatter
+# ---------------------------------------------------------------------------
+
+
+def _deform_with_mask(
+    means: Tensor,
+    quats: Tensor,
+    opacities_logit: Tensor,
+    t_per_g: Tensor,
+    dynamic_mask: Tensor,
+    hexplane: HexPlaneField,
+    deform_net: DeformNetwork,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Route only the Gaussians flagged dynamic through HexPlane + DeformNet.
+
+    Static Gaussians (``dynamic_mask`` False) pass through unchanged so the
+    rasterizer sees their base values. Mixed-fraction uses an
+    out-of-place index-copy on a ``.clone()`` so autograd flows correctly
+    through both the dynamic and static branches.
+    """
+    if dynamic_mask.numel() == 0:
+        return means, quats, opacities_logit
+
+    if dynamic_mask.all():
+        # Fast path: every Gaussian dynamic (the default at init).
+        xyzt = torch.cat([means, t_per_g], dim=-1)
+        plane_features = hexplane(xyzt)
+        return deform_net(means, quats, opacities_logit, t_per_g, plane_features)
+
+    if not dynamic_mask.any():
+        # Nothing dynamic — skip HexPlane / DeformNet entirely.
+        return means, quats, opacities_logit
+
+    dyn_idx = torch.where(dynamic_mask)[0]
+    means_dyn = means[dyn_idx]
+    quats_dyn = quats[dyn_idx]
+    op_dyn = opacities_logit[dyn_idx]
+    t_dyn = t_per_g[dyn_idx]
+    xyzt_dyn = torch.cat([means_dyn, t_dyn], dim=-1)
+    plane_features_dyn = hexplane(xyzt_dyn)
+    means_d_dyn, quats_d_dyn, op_d_dyn = deform_net(
+        means_dyn, quats_dyn, op_dyn, t_dyn, plane_features_dyn
+    )
+
+    means_out = means.clone()
+    means_out[dyn_idx] = means_d_dyn
+    quats_out = quats.clone()
+    quats_out[dyn_idx] = quats_d_dyn
+    op_out = opacities_logit.clone()
+    op_out[dyn_idx] = op_d_dyn
+    return means_out, quats_out, op_out
+
+
+# ---------------------------------------------------------------------------
+# Train step (CUDA-only — gsplat.rasterization is CUDA-only)
+# ---------------------------------------------------------------------------
+
+
+def train_step(
+    cfg: Config,
+    item: Dict[str, Tensor],
+    params: nn.ParameterDict,
+    optimizers: Dict[str, torch.optim.Optimizer],
+    hexplane: HexPlaneField,
+    deform_net: DeformNetwork,
+    hex_optimizer: torch.optim.Optimizer,
+    deform_optimizer: torch.optim.Optimizer,
+    strategy: DynamicStrategy,
+    state: Dict[str, Any],
+    step: int,
+) -> Dict[str, float]:
+    """One end-to-end training step. Returns scalar loss components for logging."""
+    device = torch.device(cfg.device)
+
+    image_gt = item["image"].to(device).unsqueeze(0)
+    depth_gt = item["depth"].to(device).unsqueeze(0)
+    mask = item["mask"].to(device).unsqueeze(0)
+    camtoworld = item["camtoworld"].to(device).unsqueeze(0)
+    K = item["K"].to(device).unsqueeze(0)
+    t = item["time"].to(device).view(1)
+
+    H, W = image_gt.shape[1:3]
+
+    means = params["means"]
+    quats = params["quats"]
+    log_scales = params["scales"]
+    opacities_logit = params["opacities"]
+    colors = params["colors"]
+
+    # Build per-Gaussian (xyzt) input for HexPlane.
+    n = means.shape[0]
+    t_per_g = t.expand(n).unsqueeze(-1)
+
+    means_d, quats_d, opacities_d_logit = _deform_with_mask(
+        means=means,
+        quats=quats,
+        opacities_logit=opacities_logit,
+        t_per_g=t_per_g,
+        dynamic_mask=state["dynamic_mask"],
+        hexplane=hexplane,
+        deform_net=deform_net,
+    )
+
+    viewmats = torch.linalg.inv(camtoworld)
+    render_colors, _, info = rasterization(
+        means=means_d,
+        quats=quats_d,
+        scales=torch.exp(log_scales),
+        opacities=torch.sigmoid(opacities_d_logit).squeeze(-1),
+        colors=colors,
+        viewmats=viewmats,
+        Ks=K,
+        width=W,
+        height=H,
+        sh_degree=None,
+        render_mode="RGB+ED",
+        packed=True,  # match the strategy's step_post_backward(packed=True) below
+    )
+    image_rendered = render_colors[..., :3]
+    depth_rendered = render_colors[..., 3:4].squeeze(-1)
+
+    rgb_p = image_rendered.permute(0, 3, 1, 2)
+    gt_p = image_gt.permute(0, 3, 1, 2)
+    # ``mask`` is already tissue=1 / tool=0 (the include-mask convention the
+    # mask-aware loss helpers expect). No inversion needed.
+    mask_p = mask.unsqueeze(1)
+
+    l1 = masked_l1(rgb_p, gt_p, mask_p)
+    ssim = masked_ssim(rgb_p, gt_p, mask_p)
+    if cfg.depth_mode == "binocular":
+        d_loss = binocular_disparity_l1(depth_rendered, depth_gt, mask)
+    else:
+        d_loss = pearson_depth_loss(depth_rendered, depth_gt, mask)
+
+    tv = compute_tv_loss_targeted(
+        rgb_p
+    )  # unmasked TV (mask wiring is dataset-specific)
+
+    # Spatial / temporal plane partition lives on HexPlaneField.
+    plane_smooth = plane_smoothness(hexplane.spatial_planes())
+    time_smooth_v = time_smoothness(hexplane.temporal_planes())
+    time_l1_v = time_l1(hexplane.temporal_planes())
+
+    loss = (
+        cfg.lambda_l1 * l1
+        + cfg.lambda_ssim * ssim
+        + cfg.lambda_depth * d_loss
+        + cfg.lambda_tv * tv
+        + cfg.lambda_plane_smooth * plane_smooth
+        + cfg.lambda_time_smooth * time_smooth_v
+        + cfg.lambda_time_l1 * time_l1_v
+    )
+
+    info_with_dims = dict(info)
+    info_with_dims["width"] = W
+    info_with_dims["height"] = H
+    info_with_dims["n_cameras"] = 1
+
+    strategy.step_pre_backward(
+        params=params,
+        optimizers=optimizers,
+        state=state,
+        step=step,
+        info=info_with_dims,
+    )
+
+    for opt in optimizers.values():
+        opt.zero_grad(set_to_none=True)
+    hex_optimizer.zero_grad(set_to_none=True)
+    deform_optimizer.zero_grad(set_to_none=True)
+
+    loss.backward()
+
+    for opt in optimizers.values():
+        opt.step()
+    hex_optimizer.step()
+    deform_optimizer.step()
+
+    strategy.step_post_backward(
+        params=params,
+        optimizers=optimizers,
+        state=state,
+        step=step,
+        info=info_with_dims,
+        packed=True,
+    )
+
+    return {
+        "loss": float(loss.detach().item()),
+        "l1": float(l1.detach().item()),
+        "ssim": float(ssim.detach().item()),
+        "depth": float(d_loss.detach().item()),
+        "tv": float(tv.detach().item()),
+        "plane_smooth": float(plane_smooth.detach().item()),
+        "time_smooth": float(time_smooth_v.detach().item()),
+        "time_l1": float(time_l1_v.detach().item()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Render helpers (post-training)
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def render_frame(
+    parser: EndoNeRFParser,
+    frame_idx: int,
+    params: nn.ParameterDict,
+    hexplane: HexPlaneField,
+    deform_net: DeformNetwork,
+    device: torch.device,
+    dynamic_mask: Optional[Tensor] = None,
+) -> np.ndarray:
+    """Render a single frame at its native time. Returns ``(H, W, 3)`` uint8.
+
+    If *dynamic_mask* is provided, only flagged Gaussians route through
+    HexPlane / DeformNet (matches the train-step routing). Otherwise every
+    Gaussian is treated as dynamic — keeps the legacy single-arg call site
+    working.
+    """
+    camtoworld = torch.from_numpy(parser.camtoworlds[frame_idx]).to(device).unsqueeze(0)
+    K = torch.from_numpy(parser.K).to(device).unsqueeze(0)
+    t = torch.tensor(float(parser.times[frame_idx]), device=device).view(1)
+
+    means = params["means"]
+    quats = params["quats"]
+    log_scales = params["scales"]
+    opacities_logit = params["opacities"]
+    colors = params["colors"]
+
+    n = means.shape[0]
+    t_per_g = t.expand(n).unsqueeze(-1)
+    if dynamic_mask is None:
+        dynamic_mask = torch.ones(n, dtype=torch.bool, device=device)
+    means_d, quats_d, opacities_d_logit = _deform_with_mask(
+        means=means,
+        quats=quats,
+        opacities_logit=opacities_logit,
+        t_per_g=t_per_g,
+        dynamic_mask=dynamic_mask,
+        hexplane=hexplane,
+        deform_net=deform_net,
+    )
+
+    viewmats = torch.linalg.inv(camtoworld)
+    render_colors, _, _ = rasterization(
+        means=means_d,
+        quats=quats_d,
+        scales=torch.exp(log_scales),
+        opacities=torch.sigmoid(opacities_d_logit).squeeze(-1),
+        colors=colors,
+        viewmats=viewmats,
+        Ks=K,
+        width=parser.width,
+        height=parser.height,
+        sh_degree=None,
+        render_mode="RGB+ED",
+        packed=True,
+    )
+    image = render_colors[..., :3].squeeze(0).clamp(0.0, 1.0)
+    return (image * 255).to(torch.uint8).cpu().numpy()
+
+
+def render_gif(
+    parser: EndoNeRFParser,
+    params: nn.ParameterDict,
+    hexplane: HexPlaneField,
+    deform_net: DeformNetwork,
+    output_path: Path,
+    device: torch.device,
+    frame_indices: Optional[list[int]] = None,
+    fps: int = 10,
+    dynamic_mask: Optional[Tensor] = None,
+) -> Path:
+    """Render frames across the dataset and write an animated GIF.
+
+    Args:
+        parser: A parsed :class:`EndoNeRFParser`.
+        params / hexplane / deform_net: Trained trainer components.
+        output_path: Destination GIF path. Parent is created if missing.
+        device: CUDA device.
+        frame_indices: Iterable of parser-relative frame indices to render.
+            Defaults to ``parser.video_idxs`` (every frame).
+        fps: Output GIF frames-per-second.
+
+    Returns:
+        The resolved output path.
+    """
+    import imageio.v2 as imageio
+
+    if frame_indices is None:
+        frame_indices = list(parser.video_idxs)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    frames: list[np.ndarray] = []
+    for idx in tqdm.tqdm(frame_indices, desc=f"rendering -> {output_path.name}"):
+        frames.append(
+            render_frame(
+                parser,
+                idx,
+                params,
+                hexplane,
+                deform_net,
+                device,
+                dynamic_mask=dynamic_mask,
+            )
+        )
+
+    imageio.mimsave(str(output_path), frames, duration=max(1, int(1000 / fps)), loop=0)
+    print(f"Saved GIF: {output_path} ({len(frames)} frames @ {fps} fps)")
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Train loop / entry point
+# ---------------------------------------------------------------------------
+
+
+def train(cfg: Config) -> None:
+    """Run the full coarse → fine training loop."""
+    torch.manual_seed(cfg.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(cfg.seed)
+    np.random.seed(cfg.seed)
+
+    device = torch.device(cfg.device)
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+
+    parser = EndoNeRFParser(data_dir=cfg.data_dir)
+    dataset = EndoNeRFDataset(parser, split="train")
+
+    params, optimizers = build_splats_from_parser(parser, cfg, device)
+
+    # cfg.hex_bounds is a sentinel lower bound, not a fixed value. The
+    # actual init point cloud (EndoNeRF "pulling" has means ~[-8, +8]) blows
+    # past the legacy 1.6 default, and HexPlane's grid_sample(padding_mode=
+    # "border") would clamp every query to the same edge feature → spatially
+    # constant deformation field. Derive the AABB from the init means with a
+    # 2x safety margin so subsequent gradient drift stays inside.
+    with torch.no_grad():
+        init_means_abs_max = float(params["means"].detach().abs().max())
+    if init_means_abs_max <= 0.0:
+        raise RuntimeError(
+            "build_splats_from_parser produced means with zero magnitude; "
+            "check the depth-unprojection / pose pipeline."
+        )
+    derived_bounds = max(cfg.hex_bounds, init_means_abs_max * 2.0)
+    print(
+        f"[hex_bounds] cfg.hex_bounds={cfg.hex_bounds:.3f}, "
+        f"init_means.abs().max()={init_means_abs_max:.3f}, "
+        f"derived={derived_bounds:.3f}"
+    )
+    # Pin the in-AABB invariant explicitly. After deriving bounds, every
+    # init Gaussian must be inside [-derived_bounds, +derived_bounds] on
+    # every axis — otherwise HexPlane.forward's
+    # grid_sample(padding_mode="border") will clamp the out-of-AABB
+    # queries to the same edge feature and the deformation collapses to
+    # a spatial constant. The assert is tautological at init time given
+    # how derived_bounds is computed above, but it documents the contract
+    # and would catch a future refactor that decouples the two computations.
+    with torch.no_grad():
+        if not bool((params["means"].detach().abs() <= derived_bounds).all()):
+            raise RuntimeError(
+                "Post-init means escape the derived HexPlane AABB "
+                f"(derived_bounds={derived_bounds:.3f}, "
+                f"means.abs().max()={float(params['means'].detach().abs().max()):.3f}). "
+                "This should never happen at init given derived_bounds = "
+                "max(cfg.hex_bounds, init_means.abs().max() * 2.0); check "
+                "build_splats_from_parser for a stale snapshot."
+            )
+    hexplane, deform_net, hex_opt, deform_opt = build_deform_modules(
+        cfg, device, bounds_override=derived_bounds
+    )
+
+    strategy = DynamicStrategy()
+    strategy.check_sanity(params, optimizers)
+    state = strategy.initialize_state(
+        scene_scale=1.0, num_gaussians=int(params["means"].shape[0]), device=device
+    )
+
+    scheduler = TwoStageScheduler(
+        coarse_steps=cfg.coarse_steps,
+        fine_steps=cfg.fine_steps,
+    )
+    total_steps = cfg.coarse_steps + cfg.fine_steps
+
+    pbar = tqdm.tqdm(range(total_steps), desc="dynamic_surgical_trainer")
+    for step in pbar:
+        sched = scheduler.step(global_step=step, num_frames=len(dataset))
+        item = dataset[sched.frame_index]
+        losses = train_step(
+            cfg=cfg,
+            item=item,
+            params=params,
+            optimizers=optimizers,
+            hexplane=hexplane,
+            deform_net=deform_net,
+            hex_optimizer=hex_opt,
+            deform_optimizer=deform_opt,
+            strategy=strategy,
+            state=state,
+            step=step,
+        )
+        if step % 50 == 0:
+            pbar.set_postfix(
+                stage=sched.stage,
+                loss=f"{losses['loss']:.4f}",
+                n=int(params["means"].shape[0]),
+            )
+
+    if cfg.render_gif_after_train:
+        gif_path = cfg.output_dir / cfg.gif_filename
+        render_gif(
+            parser=parser,
+            params=params,
+            hexplane=hexplane,
+            deform_net=deform_net,
+            output_path=gif_path,
+            device=device,
+            frame_indices=list(cfg.gif_frame_indices)
+            if cfg.gif_frame_indices is not None
+            else None,
+            fps=cfg.gif_fps,
+            dynamic_mask=state["dynamic_mask"],
+        )
+
+
+def main() -> None:
+    import tyro
+
+    cfg = tyro.cli(Config)
+    train(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/gsplat/contrib/__init__.py
+++ b/gsplat/contrib/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""gsplat experimental / research-grade components.
+
+.. warning::
+
+   Everything under :mod:`gsplat.contrib` is **experimental**. APIs may change
+   or be removed between releases. Pin a version if you depend on it in
+   production.
+
+Contents:
+
+- :mod:`gsplat.contrib.dynamic` — deformable / 4D Gaussian Splatting
+  (HexPlane field, MLP deformation network, :class:`DynamicStrategy`).
+"""

--- a/gsplat/contrib/dynamic/__init__.py
+++ b/gsplat/contrib/dynamic/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Deformable / 4D Gaussian Splatting (experimental).
+
+Ported from G-SHARP v0.2's ``training/scene`` package. See the proposal at
+``docs/source/proposals/gsharp_v0_2_port.rst`` for motivation.
+"""
+
+from .deformation import (
+    DeformationTable,
+    DeformNetwork,
+)  # noqa: F401  (back-compat re-export)
+from .hexplane import HexPlaneField
+from .regulation import (
+    hexplane_regularization,
+    plane_smoothness,
+    time_l1,
+    time_smoothness,
+)
+from .strategy import DynamicStrategy
+
+# Public API: prefer `hexplane_regularization` over calling the three
+# lower-level regularizers with hand-partitioned plane lists; the
+# spatial / temporal partition lives on :class:`HexPlaneField`.
+# `DeformationTable` is intentionally NOT in `__all__`: it's internal
+# bookkeeping that the trainer wires through `state["dynamic_mask"]`.
+# Back-compat callers can still
+# `from gsplat.contrib.dynamic.deformation import DeformationTable`.
+__all__ = [
+    "DeformNetwork",
+    "DynamicStrategy",
+    "HexPlaneField",
+    "hexplane_regularization",
+    # Lower-level regularizers kept for advanced callers.
+    "plane_smoothness",
+    "time_l1",
+    "time_smoothness",
+]

--- a/gsplat/contrib/dynamic/deformation.py
+++ b/gsplat/contrib/dynamic/deformation.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Portions of this file (DeformNetwork architecture, DeformationTable
+# bookkeeping) are ported from the G-SHARP v0.2 reference implementation.
+"""Deformation network and per-Gaussian deformation table (experimental).
+
+Public API:
+
+- :class:`DeformNetwork` — MLP that consumes HexPlane features and emits
+  per-Gaussian deltas on ``(means, quats, opacities)`` at a given time. Heads
+  are zero-initialised so the at-construction behaviour is the identity map
+  on its inputs.
+- :class:`DeformationTable` — per-Gaussian boolean flag indicating whether
+  each Gaussian is animated by the deform-net. Provides
+  :meth:`prune` / :meth:`duplicate` / :meth:`split` for lock-step resize
+  with ``DefaultStrategy``-style densification.
+
+Ported from the G-SHARP v0.2 reference implementation (deformation module
+and deformation-table bookkeeping in the training loop).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+__all__ = ["DeformNetwork", "DeformationTable"]
+
+
+class DeformNetwork(nn.Module):
+    """MLP head emitting per-Gaussian deltas on means / quats / opacities.
+
+    Architecture: a *num_layers*-deep ReLU trunk consuming
+    ``plane_features`` (typically the output of
+    :class:`gsplat.contrib.dynamic.HexPlaneField`), followed by three linear
+    heads — 3-d for the position delta, 4-d for the quaternion delta, and
+    1-d for the opacity delta. The three heads are zero-initialised so the
+    at-construction forward pass returns ``(means, quats, opacities)``
+    unchanged (identity map). Locked by
+    ``test_deform_net_zero_init_is_identity``.
+
+    The *t* argument is reserved for future time-aware extensions; the
+    current implementation expects time information to already be encoded
+    into ``plane_features`` via :class:`HexPlaneField`.
+
+    Args:
+        feature_dim: Dimensionality of ``plane_features`` (must match
+            the producing :class:`HexPlaneField`'s ``feat_dim``).
+        hidden_dim: Trunk width. Default ``64``.
+        num_layers: Number of ``Linear + ReLU`` blocks in the trunk
+            (must be ``>= 1``). Default ``3``.
+    """
+
+    def __init__(
+        self,
+        feature_dim: int,
+        hidden_dim: int = 64,
+        num_layers: int = 3,
+    ) -> None:
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError(f"num_layers must be >= 1, got {num_layers}.")
+        if feature_dim < 1:
+            raise ValueError(f"feature_dim must be >= 1, got {feature_dim}.")
+
+        self.feature_dim = feature_dim
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+
+        layers: list[nn.Module] = [nn.Linear(feature_dim, hidden_dim), nn.ReLU()]
+        for _ in range(num_layers - 1):
+            layers.extend([nn.Linear(hidden_dim, hidden_dim), nn.ReLU()])
+        self.trunk = nn.Sequential(*layers)
+
+        self.pos_head = nn.Linear(hidden_dim, 3)
+        self.quat_head = nn.Linear(hidden_dim, 4)
+        self.opacity_head = nn.Linear(hidden_dim, 1)
+
+        # Zero-init the heads so the initial deformation is identity.
+        # Gradients still flow through the heads (so the trunk learns).
+        for head in (self.pos_head, self.quat_head, self.opacity_head):
+            nn.init.zeros_(head.weight)
+            nn.init.zeros_(head.bias)
+
+    def forward(
+        self,
+        means: Tensor,
+        quats: Tensor,
+        opacities: Tensor,
+        t: Tensor,  # noqa: ARG002 — reserved for future time-aware extensions
+        plane_features: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        """Apply the per-Gaussian deformation deltas.
+
+        Args:
+            means: ``(N, 3)`` Gaussian centres.
+            quats: ``(N, 4)`` rotation quaternions (any layout; deltas are
+                added in the same layout).
+            opacities: ``(N, 1)`` opacity values (raw or activated; the
+                delta is added in the same space).
+            t: ``(N, 1)`` (or broadcastable) time stamp. Currently ignored;
+                kept in the signature for forward-compatibility with
+                time-aware variants.
+            plane_features: ``(N, feature_dim)`` features sampled from the
+                HexPlane field. Must share dtype with the other tensors.
+
+        Returns:
+            ``(means_new, quats_new, opacities_new)`` — same shapes as the
+            inputs.
+
+        Raises:
+            ValueError: on batch-dim mismatch, plane-feature-dim mismatch,
+                or dtype mismatch among the four tensors.
+        """
+        n = means.shape[0]
+        if (
+            quats.shape[0] != n
+            or opacities.shape[0] != n
+            or plane_features.shape[0] != n
+        ):
+            raise ValueError(
+                f"DeformNetwork: batch dim mismatch — means {means.shape[0]}, "
+                f"quats {quats.shape[0]}, opacities {opacities.shape[0]}, "
+                f"plane_features {plane_features.shape[0]}."
+            )
+        if plane_features.shape[-1] != self.feature_dim:
+            raise ValueError(
+                f"DeformNetwork: plane_features last dim "
+                f"{plane_features.shape[-1]} != feature_dim {self.feature_dim}."
+            )
+        if not (means.dtype == quats.dtype == opacities.dtype == plane_features.dtype):
+            raise ValueError(
+                f"DeformNetwork: dtype mismatch — means {means.dtype}, "
+                f"quats {quats.dtype}, opacities {opacities.dtype}, "
+                f"plane_features {plane_features.dtype}."
+            )
+
+        h = self.trunk(plane_features)
+        d_means = self.pos_head(h)
+        d_quats = self.quat_head(h)
+        d_opacities = self.opacity_head(h)
+
+        return means + d_means, quats + d_quats, opacities + d_opacities
+
+
+class DeformationTable:
+    """Per-Gaussian boolean table marking which Gaussians are dynamic.
+
+    Used by :class:`gsplat.contrib.dynamic.DynamicStrategy` to decide which
+    Gaussians get fed through :class:`DeformNetwork` each step. Resize
+    lock-step with the gsplat ``DefaultStrategy`` densification ops via
+    :meth:`prune`, :meth:`duplicate`, and :meth:`split`.
+
+    The table is a plain ``torch.bool`` tensor (no autograd, no parameters)
+    so it adds zero overhead to the optimiser state.
+
+    Args:
+        num_gaussians: Initial Gaussian count.
+        device: Optional device (defaults to CPU).
+    """
+
+    def __init__(
+        self, num_gaussians: int, device: Optional[torch.device] = None
+    ) -> None:
+        if num_gaussians < 0:
+            raise ValueError(
+                f"DeformationTable: num_gaussians must be >= 0, got {num_gaussians}."
+            )
+        self.mask = torch.zeros(num_gaussians, dtype=torch.bool, device=device)
+
+    def __len__(self) -> int:
+        return int(self.mask.shape[0])
+
+    def set_indices(self, indices: Tensor, value: bool = True) -> None:
+        """Mark the given Gaussian indices as dynamic (or static if *value* is False)."""
+        self.mask[indices] = value
+
+    def prune(self, keep_mask: Tensor) -> None:
+        """Drop Gaussians where *keep_mask* is False (DefaultStrategy prune op).
+
+        Args:
+            keep_mask: ``(N,)`` bool tensor with ``True`` for surviving
+                Gaussians. Length must equal current table size.
+        """
+        if keep_mask.shape != self.mask.shape:
+            raise ValueError(
+                f"DeformationTable.prune: keep_mask shape {tuple(keep_mask.shape)} "
+                f"!= table shape {tuple(self.mask.shape)}."
+            )
+        self.mask = self.mask[keep_mask]
+
+    def duplicate(self, indices: Tensor) -> None:
+        """Append duplicates of the given indices (DefaultStrategy duplicate op).
+
+        Originals stay; one duplicate is appended per index, inheriting
+        the parent's dynamic flag.
+        """
+        self.mask = torch.cat([self.mask, self.mask[indices]], dim=0)
+
+    def split(self, indices: Tensor, factor: int = 2) -> None:
+        """Replace each index with *factor* children (DefaultStrategy split op).
+
+        Original indices are removed; ``factor`` children are appended per
+        split index, each inheriting the parent's dynamic flag.
+
+        Args:
+            indices: ``(S,)`` indices to split.
+            factor: Children per split. Default ``2`` (matches the gsplat
+                ``DefaultStrategy`` convention).
+        """
+        if factor < 1:
+            raise ValueError(
+                f"DeformationTable.split: factor must be >= 1, got {factor}."
+            )
+        keep = torch.ones(self.mask.shape[0], dtype=torch.bool, device=self.mask.device)
+        keep[indices] = False
+        children = self.mask[indices].repeat_interleave(factor)
+        self.mask = torch.cat([self.mask[keep], children], dim=0)

--- a/gsplat/contrib/dynamic/hexplane.py
+++ b/gsplat/contrib/dynamic/hexplane.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Portions of this file (HexPlane construction) are adapted from the
+# Nerfstudio K-Planes / HexPlane reference implementation; see
+# https://github.com/sarafridov/K-Planes for the upstream.
+"""HexPlane spatio-temporal feature field (experimental).
+
+Multi-resolution 6-plane decomposition of a 4D ``(x, y, z, t)`` feature
+field, ported from the G-SHARP v0.2 reference implementation, itself
+derived from the K-Planes / 4DGaussians formulation.
+
+Six 2D feature planes — one for each pair of input axes ``(xy, xz, xt,
+yz, yt, zt)`` — are sampled with bilinear interpolation, multiplied
+element-wise across planes (giving a per-scale feature vector), and
+concatenated across multi-resolution scales to produce the final feature.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+__all__ = ["HexPlaneField"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (private; faithful port of the G-SHARP implementations)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_aabb(pts: Tensor, aabb: Tensor) -> Tensor:
+    """Linear remap of *pts* into ``[-1, 1]`` using the axis-aligned bounding box.
+
+    Matches the ``normalize_aabb`` helper in the G-SHARP source. With
+    ``aabb = [[+b, +b, +b], [-b, -b, -b]]`` the remap is
+    ``-pts / b`` (sign-flipped, kept for parity with upstream).
+    """
+    return (pts - aabb[0]) * (2.0 / (aabb[1] - aabb[0])) - 1.0
+
+
+def _grid_sample_wrapper(
+    grid: Tensor, coords: Tensor, align_corners: bool = True
+) -> Tensor:
+    grid_dim = coords.shape[-1]
+    if grid.dim() == grid_dim + 1:
+        grid = grid.unsqueeze(0)
+    if coords.dim() == 2:
+        coords = coords.unsqueeze(0)
+    if grid_dim not in (2, 3):
+        raise NotImplementedError(
+            f"_grid_sample_wrapper supports 2D / 3D coords only; got {grid_dim}D."
+        )
+    coords = coords.view(
+        [coords.shape[0]] + [1] * (grid_dim - 1) + list(coords.shape[1:])
+    )
+    b, feature_dim = grid.shape[:2]
+    n = coords.shape[-2]
+    interp = F.grid_sample(
+        grid,
+        coords,
+        align_corners=align_corners,
+        mode="bilinear",
+        padding_mode="border",
+    )
+    return interp.view(b, feature_dim, n).transpose(-1, -2).squeeze(0)
+
+
+def _init_grid_param(
+    grid_nd: int,
+    in_dim: int,
+    out_dim: int,
+    reso: Sequence[int],
+    a: float = 0.1,
+    b: float = 0.5,
+) -> nn.ParameterList:
+    if in_dim != len(reso):
+        raise ValueError(f"_init_grid_param: in_dim={in_dim} != len(reso)={len(reso)}.")
+    if grid_nd > in_dim:
+        raise ValueError(f"_init_grid_param: grid_nd={grid_nd} > in_dim={in_dim}.")
+    has_time_planes = in_dim == 4
+    coo_combs = list(itertools.combinations(range(in_dim), grid_nd))
+    grid_coefs = nn.ParameterList()
+    for coo_comb in coo_combs:
+        new_grid_coef = nn.Parameter(
+            torch.empty([1, out_dim] + [reso[cc] for cc in coo_comb[::-1]])
+        )
+        if has_time_planes and 3 in coo_comb:
+            # Spatio-temporal planes initialise to ones so deformation
+            # starts identity-like; matches G-SHARP convention.
+            nn.init.ones_(new_grid_coef)
+        else:
+            nn.init.uniform_(new_grid_coef, a=a, b=b)
+        grid_coefs.append(new_grid_coef)
+    return grid_coefs
+
+
+def _interpolate_ms_features(
+    pts: Tensor,
+    ms_grids: nn.ModuleList,
+    grid_dimensions: int,
+    concat_features: bool,
+) -> Tensor:
+    coo_combs = list(itertools.combinations(range(pts.shape[-1]), grid_dimensions))
+    multi_scale_interp: list[Tensor] = [] if concat_features else None
+    summed: Tensor | float = 0.0
+
+    for grids in ms_grids:
+        interp_space: Tensor | float = 1.0
+        for ci, coo_comb in enumerate(coo_combs):
+            feature_dim = grids[ci].shape[1]
+            interp_plane = _grid_sample_wrapper(grids[ci], pts[..., coo_comb]).view(
+                -1, feature_dim
+            )
+            interp_space = interp_space * interp_plane
+
+        if concat_features:
+            assert multi_scale_interp is not None
+            multi_scale_interp.append(interp_space)
+        else:
+            summed = summed + interp_space
+
+    if concat_features:
+        assert multi_scale_interp is not None
+        return torch.cat(multi_scale_interp, dim=-1)
+    return summed if isinstance(summed, Tensor) else torch.zeros(0)
+
+
+# ---------------------------------------------------------------------------
+# Public class
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_PLANE_CONFIG: dict = {
+    "grid_dimensions": 2,
+    "input_coordinate_dim": 4,
+    "output_coordinate_dim": 32,
+    "resolution": [64, 64, 64, 25],
+}
+_DEFAULT_MULTIRES: tuple[int, ...] = (1, 2)
+
+
+class HexPlaneField(nn.Module):
+    """Multi-resolution 6-plane decomposition of a 4D feature field.
+
+    For each scale, six 2D feature planes covering every pair of the four
+    input axes ``(x, y, z, t)`` are sampled bilinearly and multiplied
+    element-wise to produce a per-scale feature vector. With
+    ``concat_features=True`` (the default and only mode currently supported)
+    feature vectors from all scales are concatenated; the resulting feature
+    dimensionality is ``output_coordinate_dim * len(multires)``.
+
+    Spatial coordinates are normalized into ``[-1, 1]`` using the
+    axis-aligned bounding box ``[-bounds, bounds]`` along x/y/z; the time
+    coordinate is passed through unchanged (callers should pre-normalize it
+    into a sensible range — values outside the grid are clamped via
+    ``padding_mode="border"`` in :func:`torch.nn.functional.grid_sample`).
+
+    Args:
+        bounds: Half-extent of the spatial AABB along each axis (default
+            ``1.6``, matching G-SHARP).
+        planes_config: Optional dict with keys ``grid_dimensions``,
+            ``input_coordinate_dim``, ``output_coordinate_dim``,
+            ``resolution``. The default is suitable for surgical-scene
+            4D fields (32 features per plane, ``[64, 64, 64, 25]``
+            resolution).
+        multires: Iterable of integer multipliers applied to the *spatial*
+            grid resolution for each scale; the temporal resolution is
+            kept fixed across scales. Default ``(1, 2)``.
+    """
+
+    def __init__(
+        self,
+        bounds: float = 1.6,
+        planes_config: Optional[dict] = None,
+        multires: Optional[Sequence[int]] = None,
+    ) -> None:
+        super().__init__()
+
+        config = (
+            dict(planes_config)
+            if planes_config is not None
+            else dict(_DEFAULT_PLANE_CONFIG)
+        )
+        multires_seq = (
+            list(multires) if multires is not None else list(_DEFAULT_MULTIRES)
+        )
+
+        self.bounds = float(bounds)
+        aabb = torch.tensor(
+            [[bounds, bounds, bounds], [-bounds, -bounds, -bounds]],
+            dtype=torch.float32,
+        )
+        self.aabb = nn.Parameter(aabb, requires_grad=False)
+
+        self.grid_config = config
+        self.multires = multires_seq
+        self.concat_features = True
+
+        self.grids = nn.ModuleList()
+        self.feat_dim = 0
+        for res in self.multires:
+            scale_config = dict(config)
+            base_reso = list(scale_config["resolution"])
+            # Multi-res only on spatial axes; time grid stays fixed across scales.
+            scale_config["resolution"] = [r * res for r in base_reso[:3]] + base_reso[
+                3:
+            ]
+            gp = _init_grid_param(
+                grid_nd=scale_config["grid_dimensions"],
+                in_dim=scale_config["input_coordinate_dim"],
+                out_dim=scale_config["output_coordinate_dim"],
+                reso=scale_config["resolution"],
+            )
+            if self.concat_features:
+                self.feat_dim += gp[-1].shape[1]
+            else:
+                self.feat_dim = gp[-1].shape[1]
+            self.grids.append(gp)
+
+    def forward(self, xyzt: Tensor) -> Tensor:
+        """Sample the multi-resolution HexPlane at the given 4D points.
+
+        Args:
+            xyzt: ``(N, 4)`` (or any shape ending in 4) with ``[..., :3]``
+                being world-space spatial coordinates inside the AABB and
+                ``[..., 3]`` being the temporal coordinate.
+
+        Returns:
+            ``(N, feat_dim)`` feature tensor where ``feat_dim ==
+            output_coordinate_dim * len(multires)`` under
+            ``concat_features=True``.
+        """
+        if xyzt.shape[-1] != 4:
+            raise ValueError(
+                f"HexPlaneField.forward: xyzt last dim must be 4, "
+                f"got shape {tuple(xyzt.shape)}."
+            )
+
+        xyz = xyzt[..., :3]
+        t = xyzt[..., 3:]
+        xyz_norm = _normalize_aabb(xyz, self.aabb)
+        pts = torch.cat([xyz_norm, t], dim=-1).reshape(-1, 4)
+
+        return _interpolate_ms_features(
+            pts,
+            ms_grids=self.grids,
+            grid_dimensions=self.grid_config["grid_dimensions"],
+            concat_features=self.concat_features,
+        )
+
+    # ------------------------------------------------------------------
+    # Plane-partition accessors: keep the spatial / temporal grouping
+    # next to the grid construction code so regularizers don't have to
+    # hardcode the (0,1,3) / (2,4,5) indices.
+    # ------------------------------------------------------------------
+
+    _SPATIAL_PLANE_IDXS: Tuple[int, ...] = (0, 1, 3)  # xy, xz, yz
+    _TEMPORAL_PLANE_IDXS: Tuple[int, ...] = (2, 4, 5)  # xt, yt, zt
+
+    def spatial_planes(self) -> list[Tensor]:
+        """Return the flat list of spatial planes across all multi-res scales."""
+        out: list[Tensor] = []
+        for scale_grids in self.grids:
+            for i in self._SPATIAL_PLANE_IDXS:
+                out.append(scale_grids[i])
+        return out
+
+    def temporal_planes(self) -> list[Tensor]:
+        """Return the flat list of spatio-temporal planes across all scales."""
+        out: list[Tensor] = []
+        for scale_grids in self.grids:
+            for i in self._TEMPORAL_PLANE_IDXS:
+                out.append(scale_grids[i])
+        return out

--- a/gsplat/contrib/dynamic/regulation.py
+++ b/gsplat/contrib/dynamic/regulation.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""HexPlane regularizers (experimental).
+
+Three regularizers ported from the G-SHARP v0.2 reference implementation. They operate on lists of feature-plane
+tensors of shape ``(B, C, H, W)`` — typically the per-scale
+:class:`gsplat.contrib.dynamic.HexPlaneField` planes.
+
+- :func:`plane_smoothness` and :func:`time_smoothness` share the same math
+  (sum of squared second-difference along the H axis); the distinction is
+  *which* planes the caller passes. For HexPlane outputs, the spatial
+  planes ``[xy, xz, yz]`` (combo indices ``[0, 1, 3]``) are smoothed
+  spatially, and the spatio-temporal planes ``[xt, yt, zt]`` (combo
+  indices ``[2, 4, 5]``) are smoothed in time.
+- :func:`time_l1` regularizes spatio-temporal planes toward 1.0 (their
+  initialization), encouraging static regions to stay put — matches
+  ``L1TimePlanes`` in the G-SHARP source.
+
+Caller selects which planes go where; these functions just iterate the
+input list and sum the result.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+from torch import Tensor
+
+__all__ = [
+    "plane_smoothness",
+    "time_smoothness",
+    "time_l1",
+    "hexplane_regularization",
+]
+
+
+def _second_difference_squared(planes: Sequence[Tensor]) -> Tensor:
+    """Mean squared second-difference along the H axis, summed across planes.
+
+    Ports ``compute_plane_smoothness`` from
+    ``training/scene/regulation.py:45`` in the G-SHARP source.
+    """
+    total: Optional[Tensor] = None
+    for p in planes:
+        if p.ndim != 4:
+            raise ValueError(
+                f"Expected 4D plane tensors (B, C, H, W); got {p.ndim}D "
+                f"shape {tuple(p.shape)}."
+            )
+        if p.shape[-2] < 3:
+            continue
+        first = p[..., 1:, :] - p[..., :-1, :]
+        second = first[..., 1:, :] - first[..., :-1, :]
+        contribution = second.pow(2).mean()
+        total = contribution if total is None else total + contribution
+    if total is None:
+        first_p = next(iter(planes), None)
+        device = first_p.device if first_p is not None else None
+        dtype = first_p.dtype if first_p is not None else torch.float32
+        return torch.zeros((), dtype=dtype, device=device)
+    return total
+
+
+def plane_smoothness(planes: Sequence[Tensor]) -> Tensor:
+    """Spatial 2D smoothness — sum of mean squared second-difference along H.
+
+    Pass the *spatial* HexPlane planes (combo indices ``[0, 1, 3]`` of a
+    4D HexPlane: ``xy``, ``xz``, ``yz``) for the spatial-smoothness
+    regularizer described in the G-SHARP proposal.
+
+    Args:
+        planes: Iterable of 4D ``(B, C, H, W)`` plane tensors.
+
+    Returns:
+        Scalar tensor (sum across planes; mean within each plane).
+    """
+    return _second_difference_squared(planes)
+
+
+def time_smoothness(planes: Sequence[Tensor]) -> Tensor:
+    """Temporal smoothness — same math as :func:`plane_smoothness`.
+
+    Pass the *spatio-temporal* HexPlane planes (combo indices
+    ``[2, 4, 5]`` of a 4D HexPlane: ``xt``, ``yt``, ``zt``). For these
+    planes the H axis is the temporal axis (per the
+    :func:`HexPlaneField._init_grid_param` reversed-order layout), so
+    the second-difference squared is the per-plane temporal smoothness.
+
+    Args:
+        planes: Iterable of 4D ``(B, C, H, W)`` spatio-temporal plane tensors.
+
+    Returns:
+        Scalar tensor.
+    """
+    return _second_difference_squared(planes)
+
+
+def time_l1(planes: Sequence[Tensor]) -> Tensor:
+    """L1 deviation from 1.0 on spatio-temporal planes.
+
+    HexPlane spatio-temporal planes are initialised to 1.0 so deformation
+    starts identity-like. ``time_l1`` penalises their deviation from 1.0,
+    encouraging static tissue to keep an identity (no-time-deformation)
+    response. Matches G-SHARP's ``L1TimePlanes`` regularizer.
+
+    Args:
+        planes: Iterable of plane tensors (any shape with ``mean()``).
+
+    Returns:
+        Scalar L1 deviation summed across planes (mean within each plane).
+    """
+    total: Optional[Tensor] = None
+    for p in planes:
+        contribution = (1.0 - p).abs().mean()
+        total = contribution if total is None else total + contribution
+    if total is None:
+        first_p = next(iter(planes), None)
+        device = first_p.device if first_p is not None else None
+        dtype = first_p.dtype if first_p is not None else torch.float32
+        return torch.zeros((), dtype=dtype, device=device)
+    return total
+
+
+def hexplane_regularization(
+    field: "HexPlaneField",
+    lambda_plane_smooth: float = 1.0,
+    lambda_time_smooth: float = 1.0,
+    lambda_time_l1: float = 1.0,
+) -> Tensor:
+    """Convenience wrapper: applies the three HexPlane regularizers using the
+    field's own spatial / temporal plane accessors.
+
+    Use this instead of calling :func:`plane_smoothness`,
+    :func:`time_smoothness`, :func:`time_l1` with hand-partitioned plane
+    lists — the spatial / temporal partition is a property of the
+    HexPlane construction and lives on
+    :class:`gsplat.contrib.dynamic.HexPlaneField`. Hand-rolled partitions
+    drift when HexPlaneField is refactored.
+
+    Args:
+        field: A :class:`HexPlaneField` instance.
+        lambda_plane_smooth: Scalar weight for the spatial smoothness term.
+        lambda_time_smooth: Scalar weight for the temporal smoothness term.
+        lambda_time_l1: Scalar weight for the temporal L1 deviation term.
+
+    Returns:
+        Scalar tensor — weighted sum of the three regularizers.
+    """
+    spatial = field.spatial_planes()
+    temporal = field.temporal_planes()
+    return (
+        lambda_plane_smooth * plane_smoothness(spatial)
+        + lambda_time_smooth * time_smoothness(temporal)
+        + lambda_time_l1 * time_l1(temporal)
+    )
+
+
+# Forward-decl-friendly type ref — avoids a circular import on top.
+if False:  # pragma: no cover  (type checking only)
+    from .hexplane import HexPlaneField  # noqa: F401

--- a/gsplat/contrib/dynamic/strategy.py
+++ b/gsplat/contrib/dynamic/strategy.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DynamicStrategy — deformable extension of :class:`DefaultStrategy`.
+
+Public API:
+
+- :class:`DynamicStrategy` — subclass of :class:`gsplat.strategy.DefaultStrategy`
+  that additionally tracks a :class:`DeformationTable` and resizes it
+  in lock-step with each densify / prune op so that subsequent forward
+  passes can route only the dynamic Gaussians through the deform-net.
+
+Design notes:
+
+- ``gsplat.rasterization`` has no time axis. The deformation pass itself
+  (HexPlane → :class:`DeformNetwork` → ``(means, quats, opacities)``) lives
+  in the trainer (``examples/dynamic_surgical_trainer.py``) and runs *before*
+  ``rasterization(...)`` is called, mirroring G-SHARP's ``rasterize_splats``.
+  This strategy class only owns the densification policy + deformation-table
+  bookkeeping; it does **not** apply the deform-net itself.
+- The ``@dataclass`` decorator is intentionally not applied here: no new
+  fields are added with defaults, so we inherit the parent's auto-generated
+  ``__init__`` cleanly without dataclass-field ordering errors.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Union
+
+import torch
+
+from gsplat.strategy import DefaultStrategy
+
+from .deformation import DeformationTable  # noqa: F401  (re-export for back-compat)
+
+__all__ = ["DynamicStrategy"]
+
+
+class DynamicStrategy(DefaultStrategy):
+    """Deformable-aware densification / pruning strategy.
+
+    Extra invariants on top of :class:`DefaultStrategy`:
+
+    - ``state["dynamic_mask"]`` is a per-Gaussian ``torch.bool`` tensor of
+      shape ``(num_gaussians,)`` that flags which Gaussians the trainer
+      should route through the DeformNet. Resized in lock-step with
+      ``params["means"]`` by gsplat's strategy ops (which iterate every
+      tensor in *state* and apply the per-Gaussian split / duplicate /
+      prune permutation — see ``gsplat/strategy/ops.py:135, 191-195,
+      223-225``). Identity is preserved across split (children inherit
+      the parent's flag).
+
+    Note that the HexPlane and DeformNet trainables are **not** part of
+    *params*. gsplat's densification ops blindly iterate every entry in
+    *params* and split/duplicate/prune them per-Gaussian; non-per-Gaussian
+    tensors (HexPlane plane grids, DeformNet MLP weights) would be indexed
+    with out-of-bounds per-Gaussian indices. Keep those trainables in
+    their own optimizers, wired separately by the trainer (see
+    ``examples/dynamic_surgical_trainer.py:build_deform_modules``).
+
+    Historical note: an earlier version of this strategy stored a
+    :class:`DeformationTable` wrapper at ``state["deformation_table"]``
+    and resized it via a custom ``_resize_table`` hook. That hook did
+    not preserve survivor identity across split, and the trainer never
+    consulted the mask anyway. Wiring it through *state* as a plain
+    tensor (so gsplat's ops do the right thing) closes both gaps. The
+    wrapper class is still importable for back-compat; the canonical
+    mask is the tensor in *state*.
+    """
+
+    def check_sanity(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+    ) -> None:
+        """Sanity-check identical to :meth:`DefaultStrategy.check_sanity`.
+
+        The HexPlane / DeformNet trainables live outside *params* (see the
+        class docstring), so this method has no extra requirements beyond
+        the parent's "params and optimizers share keys, and per-Gaussian
+        keys means/scales/quats/opacities are present" check.
+        """
+        super().check_sanity(params, optimizers)
+
+    def initialize_state(
+        self,
+        scene_scale: float = 1.0,
+        num_gaussians: int = 0,
+        device: Optional[torch.device] = None,
+        init_dynamic: bool = True,
+    ) -> Dict[str, Any]:
+        """Extend :meth:`DefaultStrategy.initialize_state` with a per-Gaussian
+        dynamic mask.
+
+        The mask is stored under ``state["dynamic_mask"]`` as a plain bool
+        tensor (shape ``(num_gaussians,)``). It is **not** wrapped in a
+        :class:`DeformationTable` so that gsplat's densification ops in
+        :mod:`gsplat.strategy.ops` (which iterate every tensor in *state*
+        and apply the per-Gaussian split / duplicate / prune permutation
+        automatically — see ops.py:135, 191-195, 223-225) can resize it in
+        lock-step with ``params["means"]`` with identity preservation
+        across split. The wrapper class is still exposed for callers that
+        want the helper API (see :class:`DeformationTable`), but the
+        canonical mask now lives in *state*.
+
+        Args:
+            scene_scale: Forwarded to the parent.
+            num_gaussians: Initial Gaussian count.
+            device: Device for the mask tensor (defaults to CPU).
+            init_dynamic: Initial value for every flag. ``True`` matches the
+                current trainer behaviour (every Gaussian goes through
+                :class:`DeformNetwork`); set ``False`` if you have a
+                static-by-default workflow and intend to flip dynamic
+                indices manually.
+
+        Returns:
+            The strategy state dict with the additional ``dynamic_mask``
+            entry (a ``torch.bool`` tensor of shape ``(num_gaussians,)``).
+        """
+        state = super().initialize_state(scene_scale=scene_scale)
+        fill = bool(init_dynamic)
+        state["dynamic_mask"] = torch.full(
+            (num_gaussians,), fill, dtype=torch.bool, device=device
+        )
+        return state
+
+    def step_pre_backward(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+        state: Dict[str, Any],
+        step: int,
+        info: Dict[str, Any],
+    ) -> None:
+        """Pre-backward hook — passthrough to the parent."""
+        super().step_pre_backward(params, optimizers, state, step, info)
+
+    def step_post_backward(
+        self,
+        params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
+        optimizers: Dict[str, torch.optim.Optimizer],
+        state: Dict[str, Any],
+        step: int,
+        info: Dict[str, Any],
+        packed: bool = False,
+    ) -> None:
+        """Post-backward hook — defers to the parent.
+
+        ``state["dynamic_mask"]`` is resized in lock-step with the per-Gaussian
+        parameters automatically by gsplat's densification ops (which iterate
+        every tensor in *state* and apply the same per-Gaussian permutation
+        as the params — see ``gsplat/strategy/ops.py:135``). No extra hook
+        needed here.
+
+        Raises:
+            RuntimeError: if ``state["dynamic_mask"]`` is missing (i.e.
+                :meth:`initialize_state` wasn't called first).
+        """
+        if "dynamic_mask" not in state:
+            raise RuntimeError(
+                "DynamicStrategy.step_post_backward called before "
+                "initialize_state(...). Call "
+                "`state = strategy.initialize_state(scene_scale=..., "
+                "num_gaussians=N)` first."
+            )
+
+        super().step_post_backward(
+            params=params,
+            optimizers=optimizers,
+            state=state,
+            step=step,
+            info=info,
+            packed=packed,
+        )

--- a/gsplat/init_utils.py
+++ b/gsplat/init_utils.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SfM-free point-cloud initialization ported from G-SHARP v0.2.
+
+Public API:
+
+- :func:`multi_frame_depth_unprojection` — unproject masked depth maps from
+  multiple frames into a shared world-space point cloud + per-point RGB.
+  Ported from the G-SHARP v0.2 reference implementation
+  (``accumulate_multiframe_pointcloud``).
+- :func:`knn_scale_init` — per-Gaussian initial log-scale based on the
+  root-mean-square distance to the ``k`` nearest neighbours in the point cloud. Pure-torch
+  (uses ``torch.cdist`` + ``topk``) so the core library has no sklearn
+  dependency. Numerically matches the G-SHARP path
+  ``sqrt((knn(points, k+1)[:, 1:] ** 2).mean(dim=-1)).clamp_min(eps).log()``
+  inside ``create_splats_with_optimizers`` (lines 1832–1838 in the source).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+
+def multi_frame_depth_unprojection(
+    images: Tensor,
+    depths: Tensor,
+    masks: Tensor,
+    poses: Tensor,
+    intrinsics: Tensor,
+    max_points: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    """Multi-frame depth unprojection into a shared world-space point cloud.
+
+    For each frame, identifies valid pixels (``mask != 0`` AND ``depth > 0``),
+    unprojects them to camera space using the per-frame pinhole intrinsics,
+    and transforms to world space via the camera-to-world pose. All per-frame
+    point sets are concatenated and (optionally) random-subsampled to
+    ``max_points``.
+
+    Args:
+        images: ``(N, H, W, 3)`` RGB. ``uint8`` is normalized to ``[0, 1]``;
+            float inputs are taken as-is.
+        depths: ``(N, H, W)`` metric depth (zero = no measurement).
+        masks: ``(N, H, W)`` mask (``!= 0`` = keep pixel).
+        poses: ``(N, 4, 4)`` camera-to-world transforms.
+        intrinsics: ``(N, 3, 3)`` per-frame pinhole intrinsics.
+        max_points: Optional cap; a random subset is returned if exceeded.
+
+    Returns:
+        Tuple ``(xyz, rgb)``:
+
+        - ``xyz`` ``(P, 3)`` — world-space coordinates.
+        - ``rgb`` ``(P, 3)`` — float ``[0, 1]`` colors at the source pixels.
+
+        Both are ``(0, 3)`` if no pixel passes the mask + valid-depth gate.
+
+    Raises:
+        ValueError: if leading dimensions disagree across the inputs.
+    """
+    n = images.shape[0]
+    for name, t in (
+        ("depths", depths),
+        ("masks", masks),
+        ("poses", poses),
+        ("intrinsics", intrinsics),
+    ):
+        if t.shape[0] != n:
+            raise ValueError(
+                f"multi_frame_depth_unprojection: leading dim mismatch — "
+                f"images has {n} frames but {name} has {t.shape[0]}."
+            )
+
+    h, w = images.shape[1:3]
+    device = images.device
+
+    images_f = images.float() / 255.0 if images.dtype == torch.uint8 else images.float()
+    depths_f = depths.float()
+    masks_b = masks != 0
+
+    v_coords, u_coords = torch.meshgrid(
+        torch.arange(h, device=device, dtype=torch.float32),
+        torch.arange(w, device=device, dtype=torch.float32),
+        indexing="ij",
+    )
+
+    xyz_chunks: list[Tensor] = []
+    rgb_chunks: list[Tensor] = []
+
+    for i in range(n):
+        valid = masks_b[i] & (depths_f[i] > 0)
+        if not bool(valid.any()):
+            continue
+
+        u_i = u_coords[valid]
+        v_i = v_coords[valid]
+        d_i = depths_f[i][valid]
+        rgb_i = images_f[i][valid]
+
+        k = intrinsics[i]
+        fx, fy = k[0, 0], k[1, 1]
+        cx, cy = k[0, 2], k[1, 2]
+
+        x_cam = (u_i - cx) * d_i / fx
+        y_cam = (v_i - cy) * d_i / fy
+        z_cam = d_i
+
+        cam_h = torch.stack(
+            [x_cam, y_cam, z_cam, torch.ones_like(z_cam)], dim=-1
+        )  # (P_i, 4)
+        world_h = cam_h @ poses[i].T.float()  # (P_i, 4)
+        xyz_chunks.append(world_h[:, :3])
+        rgb_chunks.append(rgb_i)
+
+    if not xyz_chunks:
+        empty = torch.zeros(0, 3, device=device)
+        return empty, empty.clone()
+
+    xyz = torch.cat(xyz_chunks, dim=0)
+    rgb = torch.cat(rgb_chunks, dim=0)
+
+    if max_points is not None and xyz.shape[0] > max_points:
+        idx = torch.randperm(xyz.shape[0], device=device)[:max_points]
+        xyz = xyz[idx]
+        rgb = rgb[idx]
+
+    return xyz, rgb
+
+
+def knn_scale_init(
+    xyz: Tensor, k: int = 3, eps: float = 1e-7, chunk_size: int = 1024
+) -> Tensor:
+    """Per-point initial log-scale based on the root-mean-square distance to the *k* nearest neighbours.
+
+    Pure-torch implementation (``cdist`` + ``topk``) — no sklearn dependency.
+    For each point, computes the Euclidean distances to its *k* nearest other
+    points (excluding self), takes the root-mean-square of those distances,
+    clamps to *eps* (so duplicate points don't yield ``-inf`` after the log),
+    then returns the natural log.
+
+    The output is shape ``(N,)`` and is intended to be broadcast to a
+    ``(N, 3)`` log-scale tensor by the caller (typical use:
+    ``scales = result.unsqueeze(-1).repeat(1, 3)``), matching the convention
+    in G-SHARP's ``create_splats_with_optimizers``.
+
+    Args:
+        xyz: Point cloud ``(N, 3)``.
+        k: Number of nearest neighbours per point, excluding self
+            (default ``3``).
+        eps: Minimum distance clamp before the log; default ``1e-7``.
+        chunk_size: Row-block size for the pairwise distance scan. Memory
+            is ``O(chunk_size * N)`` per block; default 1024 fits comfortably
+            on a 12 GB consumer GPU at ``N = 50_000``.
+
+    Returns:
+        ``(N,)`` per-point log-distance.
+
+    Raises:
+        ValueError: if ``N <= k`` (need at least ``k + 1`` points so each
+            point has *k* neighbours after excluding self).
+    """
+    n = xyz.shape[0]
+    if n <= k:
+        raise ValueError(f"knn_scale_init: need at least k+1={k + 1} points, got {n}.")
+
+    # Chunked pairwise KNN: a single (N, N) cdist is ~N^2 * 4 bytes, which is
+    # ~10 GB at N=50_000 (fits on an A100, OOMs on a 12-16 GB consumer card).
+    # Loop over query rows in blocks; per block we only allocate (chunk, N)
+    # distances, then top-k.  Memory drops from O(N^2) to O(chunk * N).
+    chunk = max(1, min(chunk_size, n))
+    out = torch.empty(n, device=xyz.device, dtype=xyz.dtype)
+    for start in range(0, n, chunk):
+        end = min(start + chunk, n)
+        block_dists = torch.cdist(xyz[start:end], xyz)  # (chunk, N)
+        knn_dists, _ = block_dists.topk(k + 1, largest=False)  # (chunk, k+1)
+        neighbor_dists = knn_dists[:, 1:]  # drop self → (chunk, k)
+        rms = neighbor_dists.pow(2).mean(dim=-1).sqrt()
+        out[start:end] = rms
+    return out.clamp_min(eps).log()

--- a/gsplat/losses.py
+++ b/gsplat/losses.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Loss functions for Gaussian Splatting training.
 
 This module provides loss functions commonly used in 3D Gaussian Splatting
@@ -29,7 +28,6 @@ from __future__ import annotations
 
 import math
 import os
-import sys
 from typing import Callable, Optional
 
 import torch
@@ -218,6 +216,168 @@ def depth_l1_loss(
     disp = torch.where(pred_depth > 0.0, 1.0 / pred_depth, torch.zeros_like(pred_depth))
     disp_gt = torch.where(gt_depth > 0.0, 1.0 / gt_depth, torch.zeros_like(gt_depth))
     return F.l1_loss(disp, disp_gt) * scene_scale
+
+
+def binocular_disparity_l1(
+    pred_depth: Tensor,
+    gt_depth: Tensor,
+    mask: Optional[Tensor] = None,
+    eps: float = 1e-7,
+) -> Tensor:
+    """L1 loss in inverse-depth (disparity) space, with optional masking.
+
+    Ported from G-SHARP v0.2's binocular branch of
+    ``EndoRunner.compute_depth_loss``. Pixels whose predicted *or*
+    ground-truth depth has absolute value at or below *eps* are treated as
+    "no depth" and contribute 0 to the inverse-depth tensor (matching the
+    ``rendered_depth != 0`` sentinel convention used by the source).
+
+    Args:
+        pred_depth: Predicted depth, shape ``(..., H, W)``.
+        gt_depth: Ground-truth depth, same shape as *pred_depth*.
+        mask: Optional binary mask broadcastable to *pred_depth*; ``!= 0`` =
+            include pixel, ``0`` = ignore. Without a mask, the loss is the
+            mean over all pixels (the zero-depth ones contribute 0 on both
+            sides).
+        eps: Threshold below which depth is treated as invalid; also keeps
+            the divisor away from zero so the reciprocal stays finite.
+
+    Returns:
+        Scalar disparity-space L1 loss.
+    """
+    if pred_depth.shape != gt_depth.shape:
+        raise ValueError(
+            f"binocular_disparity_l1: pred_depth shape {pred_depth.shape} != "
+            f"gt_depth shape {gt_depth.shape}. Shapes must match."
+        )
+    # A pair (pred_i, gt_i) contributes only when *both* sides are valid.
+    # Otherwise the per-side `1/x ↔ 0` substitution leaks `|0 - 1/other|`
+    # into the loss when only one side is invalid, which is not what the
+    # docstring promises.
+    valid_pred = pred_depth.abs() > eps
+    valid_gt = gt_depth.abs() > eps
+    pair_valid = valid_pred & valid_gt
+
+    ones = torch.ones_like(pred_depth)
+    safe_pred = torch.where(valid_pred, pred_depth, ones)
+    safe_gt = torch.where(valid_gt, gt_depth, ones)
+    pred_inv = 1.0 / safe_pred
+    gt_inv = 1.0 / safe_gt
+
+    pair_mask = pair_valid.to(pred_depth.dtype)
+    if mask is not None:
+        pair_mask = pair_mask * mask.to(pred_depth.dtype)
+    return masked_l1(pred_inv, gt_inv, pair_mask)
+
+
+def pearson_depth_loss(
+    pred_depth: Tensor,
+    gt_depth: Tensor,
+    mask: Optional[Tensor] = None,
+) -> Tensor:
+    """Monocular depth loss: ``1 - Pearson r`` on (masked) flattened depth pairs.
+
+    Ported from G-SHARP v0.2 (monocular branch). Returns a differentiable 0
+    when fewer than two valid samples remain after masking, and clamps the
+    denominator to a tiny positive constant when either input has near-zero
+    variance — both situations would otherwise yield NaN.
+
+    Args:
+        pred_depth: Predicted depth, shape ``(..., H, W)``.
+        gt_depth: Ground-truth depth, same shape as *pred_depth*.
+        mask: Optional binary mask broadcastable to *pred_depth*; samples
+            where ``mask == 0`` are dropped before the correlation.
+
+    Returns:
+        Scalar loss in approximately ``[0, 2]``.
+    """
+    if pred_depth.shape != gt_depth.shape:
+        raise ValueError(
+            f"pearson_depth_loss: pred_depth shape {pred_depth.shape} != "
+            f"gt_depth shape {gt_depth.shape}. Shapes must match."
+        )
+    pred_flat = pred_depth.reshape(-1)
+    gt_flat = gt_depth.reshape(-1)
+    if mask is not None:
+        mask_flat = (mask != 0).reshape(-1)
+        pred_flat = pred_flat[mask_flat]
+        gt_flat = gt_flat[mask_flat]
+    if pred_flat.numel() < 2:
+        return pred_depth.sum() * 0.0
+
+    pred_centered = pred_flat - pred_flat.mean()
+    gt_centered = gt_flat - gt_flat.mean()
+    num = (pred_centered * gt_centered).sum()
+    denom = (
+        (pred_centered.pow(2).sum() * gt_centered.pow(2).sum()).clamp(min=1e-12).sqrt()
+    )
+    return 1.0 - num / denom
+
+
+# ---------------------------------------------------------------------------
+# Mask-aware photometric wrappers (G-SHARP v0.2)
+# ---------------------------------------------------------------------------
+
+
+def masked_l1(pred: Tensor, gt: Tensor, mask: Tensor) -> Tensor:
+    """L1 over only the ``mask != 0`` region.
+
+    Mask-aware wrapper around :func:`l1_loss`, ported from G-SHARP v0.2 to
+    zero out tool / dynamic-object regions. The mask is broadcast to *pred*'s
+    shape (so a ``[B, 1, H, W]`` mask works on ``[B, C, H, W]`` inputs) and
+    the mean is taken over unmasked elements only. Returns a differentiable 0
+    when the mask is all-zero (no NaN).
+
+    Args:
+        pred: Predicted tensor.
+        gt: Ground-truth tensor, same shape as *pred*.
+        mask: Mask broadcastable to *pred*; ``!= 0`` = include element.
+
+    Returns:
+        Scalar L1 loss.
+    """
+    if pred.shape != gt.shape:
+        raise ValueError(
+            f"masked_l1: pred shape {pred.shape} != gt shape {gt.shape}. "
+            "Shapes must match."
+        )
+    abs_diff = (pred - gt).abs()
+    bool_mask = mask != 0
+    if bool_mask.shape != abs_diff.shape:
+        bool_mask = bool_mask.expand_as(abs_diff)
+    selected = abs_diff[bool_mask]
+    if selected.numel() == 0:
+        return pred.sum() * 0.0
+    return selected.mean()
+
+
+def masked_ssim(pred: Tensor, gt: Tensor, mask: Tensor) -> Tensor:
+    """SSIM loss after zeroing both inputs in the masked region.
+
+    Mask-aware wrapper around :func:`ssim_loss`, ported from G-SHARP v0.2.
+    Both *pred* and *gt* are multiplied by *mask* before SSIM, matching the
+    G-SHARP training-loop convention (mask the rendered output and the GT,
+    then take an unmasked SSIM over the zeroed pair).
+
+    Note that the mean is taken over the full image, so the loss magnitude
+    scales with mask coverage — sparse masks dilute the reported loss in
+    proportion to the masked-out fraction. This bias is intentional and
+    matches the upstream G-SHARP convention.
+
+    Args:
+        pred: Predicted image batch ``[B, C, H, W]``, values in ``[0, 1]``.
+        gt: Ground-truth image batch, same shape as *pred*.
+        mask: Mask broadcastable to *pred* (e.g. ``[B, 1, H, W]``).
+
+    Returns:
+        Scalar SSIM loss (``1 - SSIM`` of the zeroed pair).
+    """
+    if pred.shape != gt.shape:
+        raise ValueError(
+            f"masked_ssim: pred shape {pred.shape} != gt shape {gt.shape}. "
+            "Shapes must match."
+        )
+    return ssim_loss(pred * mask, gt * mask)
 
 
 # ---------------------------------------------------------------------------

--- a/gsplat/regularizers.py
+++ b/gsplat/regularizers.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regularizers ported from G-SHARP v0.2.
+
+Public API:
+
+- :func:`compute_tv_loss_targeted` — anisotropic total-variation loss,
+  optionally restricted to a binary mask region. Ported from the
+  G-SHARP v0.2 reference implementation.
+- :func:`dilate_mask` — pure-torch 2D mask dilation via max-pool. Replaces
+  the ``cv2.dilate`` call used by G-SHARP so the core library has no OpenCV
+  dependency.
+- :func:`create_invisible_mask` — union of per-frame tool / dynamic-object
+  masks, matching the "regions chronically occluded by instruments"
+  definition from G-SHARP. Accepts either an iterable of tensors (assumed
+  already in tool=1 convention) or PNG paths (loaded and inverted to match
+  G-SHARP's tissue=1 on-disk convention).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+# Mirror the `gsplat.losses.ENFORCE_CONTRACTS` knob: contract checks (binary
+# mask / shape constraints / ...) cost a CPU-GPU sync each call, so they are
+# disabled in the hot training loop unless explicitly opted into. Enable via
+# `GSPLAT_ENFORCE_CONTRACTS=1` or `PYTHONOPTIMIZE=0`.
+ENFORCE_CONTRACTS: bool = (
+    os.environ.get("GSPLAT_ENFORCE_CONTRACTS") == "1"
+    or os.environ.get("PYTHONOPTIMIZE") == "0"
+)
+
+
+def compute_tv_loss_targeted(image: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+    """Anisotropic total-variation loss, optionally weighted by a binary mask.
+
+    Without a mask, returns the unweighted TV averaged over ``image.numel()``.
+    With a mask, sums each anisotropic difference weighted by the mask
+    cropped to the difference shape, then divides by the number of valid
+    elements (``mask.sum() * C``) plus a tiny epsilon — matching the G-SHARP
+    behaviour at ``training/gsplat_train.py`` lines 1992-2028.
+
+    Args:
+        image: 4D tensor ``(B, C, H, W)``.
+        mask: Optional 4D binary mask ``(B, 1, H, W)`` (or broadcastable),
+            with values in ``{0, 1}``.
+
+    Returns:
+        Scalar TV loss.
+
+    Raises:
+        ValueError: if *image* isn't 4D, or if *mask* contains non-binary
+            values.
+    """
+    if image.ndim != 4:
+        raise ValueError(
+            f"compute_tv_loss_targeted: expected 4D image (B, C, H, W), "
+            f"got {image.ndim}D shape {tuple(image.shape)}."
+        )
+
+    tv_h = (image[:, :, 1:, :] - image[:, :, :-1, :]).abs()
+    tv_w = (image[:, :, :, 1:] - image[:, :, :, :-1]).abs()
+
+    if mask is None:
+        return (tv_h.sum() + tv_w.sum()) / image.numel()
+
+    if ENFORCE_CONTRACTS and not (((mask == 0) | (mask == 1)).all()):
+        # Gated behind ENFORCE_CONTRACTS because the .all() → __bool__ forces a
+        # host sync; this loss is called every training step.
+        raise ValueError(
+            "compute_tv_loss_targeted: mask must be binary (values in {0, 1}). "
+            "Convert via `(mask > threshold).float()` first if needed."
+        )
+
+    mask_h = mask[:, :, 1:, :]
+    mask_w = mask[:, :, :, 1:]
+
+    tv_h_sum = (tv_h * mask_h).sum()
+    tv_w_sum = (tv_w * mask_w).sum()
+
+    channels = image.shape[1]
+    num_h = mask_h.sum() * channels + 1e-8
+    num_w = mask_w.sum() * channels + 1e-8
+
+    return tv_h_sum / num_h + tv_w_sum / num_w
+
+
+def dilate_mask(mask: Tensor, kernel_size: int = 3) -> Tensor:
+    """Binary mask dilation via 2D max-pool.
+
+    Pure-torch replacement for ``cv2.dilate``. With *kernel_size* = 1, this
+    is the identity. With *kernel_size* = 3, each ``1`` pixel grows to a
+    ``3x3`` neighbourhood (one-pixel safety margin). Larger odd kernel
+    sizes scale accordingly.
+
+    Args:
+        mask: 2D ``(H, W)``, 3D ``(C, H, W)``, or 4D ``(B, C, H, W)`` mask.
+        kernel_size: Positive odd integer (default ``3``).
+
+    Returns:
+        Dilated mask of the same shape and dtype-promotion as the input
+        (cast to float internally).
+
+    Raises:
+        ValueError: if *kernel_size* is not a positive odd integer, or if
+            *mask* isn't 2D/3D/4D.
+    """
+    if not isinstance(kernel_size, int) or kernel_size < 1 or kernel_size % 2 == 0:
+        raise ValueError(
+            f"dilate_mask: kernel_size must be a positive odd integer, "
+            f"got {kernel_size!r}."
+        )
+
+    original_ndim = mask.ndim
+    if original_ndim == 2:
+        x = mask.unsqueeze(0).unsqueeze(0).float()
+    elif original_ndim == 3:
+        x = mask.unsqueeze(0).float()
+    elif original_ndim == 4:
+        x = mask.float()
+    else:
+        raise ValueError(
+            f"dilate_mask: expected 2D / 3D / 4D mask, got {original_ndim}D."
+        )
+
+    pad = kernel_size // 2
+    dilated = F.max_pool2d(x, kernel_size=kernel_size, stride=1, padding=pad)
+
+    if original_ndim == 2:
+        return dilated.squeeze(0).squeeze(0)
+    if original_ndim == 3:
+        return dilated.squeeze(0)
+    return dilated
+
+
+def create_invisible_mask(masks: Iterable[Union[Tensor, str]]) -> Tensor:
+    """Union of per-frame tool / dynamic-object masks ("invisible region").
+
+    Pixels that appear as ``1`` (tool / occluder) in *any* frame are marked
+    ``1`` in the returned mask — i.e. regions that are *ever* occluded by an
+    instrument across the dataset. Matches the G-SHARP semantics of
+    ``create_invisible_mask_from_paths`` (lines 1925-1957 in the source).
+
+    Two input modes are supported per element of *masks*:
+
+    - ``Tensor`` — treated as already in tool=1 convention (no inversion).
+    - ``str`` (path) — loaded via PIL, normalized to ``[0, 1]``, and
+      inverted (``1 - mask``) per the G-SHARP convention that on-disk PNGs
+      are tissue=1.
+
+    Args:
+        masks: Iterable of tensors or PNG paths. All must share spatial
+            shape after loading.
+
+    Returns:
+        2D float tensor with values in ``[0, 1]``, the union across all
+        inputs (element-wise max).
+
+    Raises:
+        ValueError: if *masks* is empty or shapes don't match.
+        TypeError: if an element is neither ``Tensor`` nor ``str``.
+    """
+    masks_list = list(masks)
+    if not masks_list:
+        raise ValueError("create_invisible_mask: at least one mask is required.")
+
+    import numpy as np
+
+    tensors = []
+    for i, m in enumerate(masks_list):
+        if isinstance(m, str):
+            from PIL import Image
+
+            arr = np.array(Image.open(m)) / 255.0
+            if arr.ndim == 3:
+                arr = arr[:, :, 0]
+            t = torch.from_numpy((1.0 - arr).astype("float32"))
+        elif isinstance(m, Tensor):
+            t = m.float()
+        else:
+            raise TypeError(
+                f"create_invisible_mask: expected Tensor or str path at index {i}, "
+                f"got {type(m).__name__}."
+            )
+        tensors.append(t)
+
+    first_shape = tensors[0].shape
+    for i, t in enumerate(tensors[1:], 1):
+        if t.shape != first_shape:
+            raise ValueError(
+                f"create_invisible_mask: mask {i} shape {tuple(t.shape)} != "
+                f"mask 0 shape {tuple(first_shape)}."
+            )
+
+    return torch.stack(tensors).amax(dim=0).clamp(0.0, 1.0)

--- a/gsplat/training/__init__.py
+++ b/gsplat/training/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Training-loop utilities (schedulers etc.)."""
+
+from .schedulers import TwoStageScheduler
+
+__all__ = ["TwoStageScheduler"]

--- a/gsplat/training/schedulers.py
+++ b/gsplat/training/schedulers.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Training schedulers ported from G-SHARP v0.2.
+
+Public API:
+
+- :class:`TwoStageScheduleStep` — return type of :meth:`TwoStageScheduler.step`.
+- :class:`TwoStageScheduler` — coarse → fine two-stage training schedule.
+  Ported from the G-SHARP v0.2 reference implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TwoStageScheduleStep:
+    """Output of :meth:`TwoStageScheduler.step`.
+
+    Attributes:
+        stage: ``"coarse"`` or ``"fine"``.
+        frame_index: Frame index to use this step. In the coarse stage this
+            is always ``coarse_frame_index``; in the fine stage it cycles
+            ``(global_step - coarse_steps) % num_frames``, giving the caller
+            a deterministic index that visits every frame.
+        shuffle: ``True`` in the fine stage, ``False`` in the coarse stage —
+            mirrors the ``shuffle=(stage == "fine")`` flag G-SHARP passes to
+            its ``DataLoader``. Callers building a ``DataLoader`` should
+            forward this flag and may then ignore *frame_index* (the loader
+            provides its own random order).
+    """
+
+    stage: str
+    frame_index: int
+    shuffle: bool
+
+
+class TwoStageScheduler:
+    """Coarse → fine training schedule ported from G-SHARP v0.2.
+
+    - **Coarse stage** (``global_step < coarse_steps``): lock on a single
+      fixed frame (``coarse_frame_index``); ``shuffle=False``. This warms up
+      the static Gaussians on one viewpoint before time deformation kicks
+      in.
+    - **Fine stage** (``global_step >= coarse_steps``): cycle through frames
+      with ``shuffle=True``. Saturates as fine indefinitely past
+      ``coarse_steps + fine_steps`` — the ``fine_steps`` value is the
+      caller's training-budget hint and isn't enforced here so that the
+      scheduler stays purely a stateless mapping.
+
+    Ported from the G-SHARP v0.2 reference implementation.
+
+    Args:
+        coarse_steps: Number of coarse-stage iterations (must be ``>= 0``).
+        fine_steps: Informational fine-stage budget (must be ``>= 0``;
+            the scheduler does not gate the fine stage on this).
+        coarse_frame_index: Frame to lock on during coarse (default ``0``,
+            matching G-SHARP's ``self.trainset[0]``).
+
+    Raises:
+        ValueError: at construction if any step count is negative.
+    """
+
+    def __init__(
+        self,
+        coarse_steps: int,
+        fine_steps: int,
+        coarse_frame_index: int = 0,
+    ) -> None:
+        if coarse_steps < 0 or fine_steps < 0:
+            raise ValueError("step counts must be non-negative")
+        self.coarse_steps = coarse_steps
+        self.fine_steps = fine_steps
+        self.coarse_frame_index = coarse_frame_index
+
+    def step(self, global_step: int, num_frames: int) -> TwoStageScheduleStep:
+        """Resolve which stage / frame the given global step falls in.
+
+        Args:
+            global_step: Non-negative iteration counter (0-indexed).
+            num_frames: Total number of training frames available
+                (must be ``> 0``).
+
+        Returns:
+            :class:`TwoStageScheduleStep` describing the stage, frame index,
+            and shuffle flag for this step.
+
+        Raises:
+            ValueError: if *global_step* is negative, *num_frames* is not
+                positive, or ``coarse_frame_index`` falls outside
+                ``[0, num_frames)`` (validated lazily at call time since
+                ``num_frames`` isn't known at construction).
+        """
+        if global_step < 0:
+            raise ValueError(f"global_step must be non-negative, got {global_step}")
+        if num_frames <= 0:
+            raise ValueError(f"num_frames must be positive, got {num_frames}")
+        if not 0 <= self.coarse_frame_index < num_frames:
+            raise ValueError(
+                f"coarse_frame_index={self.coarse_frame_index} out of "
+                f"[0, num_frames={num_frames})."
+            )
+
+        if global_step < self.coarse_steps:
+            return TwoStageScheduleStep(
+                stage="coarse",
+                frame_index=self.coarse_frame_index,
+                shuffle=False,
+            )
+
+        fine_offset = global_step - self.coarse_steps
+        return TwoStageScheduleStep(
+            stage="fine",
+            frame_index=fine_offset % num_frames,
+            shuffle=True,
+        )

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         "numpy",
         "jaxtyping",
         "rich>=12",
-        "torch",
+        "torch>=2.0",
         "typing_extensions; python_version<'3.8'",
         # gsplat-scene / gsplat-stage live under libs/scene and libs/stage and
         # are installed via ``libs/install.sh scene && libs/install.sh stage``;
@@ -119,6 +119,16 @@ setup(
         "lidar": [
             "scipy",
         ],
+        # examples / tutorial dependencies. The dynamic-surgical trainer and
+        # the EndoNeRF parser/dataset import these at module top, but they
+        # are not needed to use the core gsplat library — install with
+        # `pip install gsplat[examples]`.
+        "examples": [
+            "Pillow",
+            "tqdm",
+            "tyro",
+            "imageio>=2.37.2",
+        ],
         # dev dependencies. Install them by `pip install gsplat[dev]`
         "dev": [
             "black[jupyter]==22.3.0",
@@ -127,6 +137,11 @@ setup(
             "pytest==7.1.3",
             "pytest-env==0.8.1",
             "pytest-xdist==2.5.0",
+            # Tests for examples/datasets/endonerf.py and the dynamic-surgical
+            # trainer import Pillow + tqdm at module top — without these the
+            # test collection ImportErrors on a fresh `[dev]` install.
+            "Pillow",
+            "tqdm",
             "typeguard>=2.13.3",
             "pyyaml>=6.0.1",
             "build",

--- a/tests/test_contrib_deformnet.py
+++ b/tests/test_contrib_deformnet.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``gsplat.contrib.dynamic.DeformNetwork`` and ``DeformationTable``.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.contrib.dynamic.deformation import DeformationTable, DeformNetwork
+
+
+# ---------------------------------------------------------------------------
+# DeformNetwork — construction
+# ---------------------------------------------------------------------------
+
+
+def test_deform_net_invalid_construction_raises():
+    with pytest.raises(ValueError, match="num_layers"):
+        DeformNetwork(feature_dim=32, num_layers=0)
+    with pytest.raises(ValueError, match="feature_dim"):
+        DeformNetwork(feature_dim=0)
+
+
+# ---------------------------------------------------------------------------
+# DeformNetwork — forward / identity
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs(n: int, feature_dim: int, dtype: torch.dtype = torch.float32):
+    means = torch.randn(n, 3, dtype=dtype)
+    quats = torch.randn(n, 4, dtype=dtype)
+    opacities = torch.randn(n, 1, dtype=dtype)
+    t = torch.zeros(n, 1, dtype=dtype)
+    features = torch.randn(n, feature_dim, dtype=dtype)
+    return means, quats, opacities, t, features
+
+
+def test_deform_net_zero_init_is_identity():
+    """Heads are zero-initialised → forward returns inputs unchanged."""
+    feature_dim = 64
+    net = DeformNetwork(feature_dim=feature_dim)
+    means, quats, opacities, t, features = _make_inputs(16, feature_dim)
+
+    out_m, out_q, out_o = net(means, quats, opacities, t, features)
+
+    assert torch.allclose(out_m, means, atol=1e-6)
+    assert torch.allclose(out_q, quats, atol=1e-6)
+    assert torch.allclose(out_o, opacities, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# DeformNetwork — gradient flow
+# ---------------------------------------------------------------------------
+
+
+def test_deform_net_gradients_flow_to_mlp_weights():
+    """Backward graph is correctly wired across trunk + heads.
+
+    Zero-init head weights are an intentional design choice (see
+    ``test_deform_net_zero_init_is_identity``), but they short-circuit
+    gradient flow to the trunk at init: ``dL/d(trunk_out) = dL/d(out) ·
+    head_weight`` is zero everywhere when ``head_weight == 0``. The first
+    backward pass sets head-weight gradients to non-zero, so after one
+    optimiser step the trunk would receive gradients. To test the
+    backward graph itself without doing an opt step, perturb the heads
+    off zero before forward.
+    """
+    feature_dim = 32
+    net = DeformNetwork(feature_dim=feature_dim, hidden_dim=16, num_layers=2)
+    with torch.no_grad():
+        for head in (net.pos_head, net.quat_head, net.opacity_head):
+            torch.nn.init.normal_(head.weight, std=0.01)
+
+    means, quats, opacities, t, features = _make_inputs(8, feature_dim)
+    out_m, out_q, out_o = net(means, quats, opacities, t, features)
+    (out_m.sum() + out_q.sum() + out_o.sum()).backward()
+
+    has_trunk_grad = any(
+        p.grad is not None and p.grad.abs().sum() > 0 for p in net.trunk.parameters()
+    )
+    assert has_trunk_grad, "No trunk parameter received a gradient."
+
+    for head in (net.pos_head, net.quat_head, net.opacity_head):
+        assert head.weight.grad is not None
+        assert (
+            head.weight.grad.abs().sum() > 0
+        ), f"Head {head} weight received zero gradient."
+
+
+def test_deform_net_zero_init_blocks_trunk_gradient_at_init():
+    """Companion to the above: at init (zero-init heads), the trunk gradient
+    is exactly zero. This locks the design choice — if a future change
+    flips heads to non-zero init, this test must be updated alongside the
+    `_zero_init_is_identity` test.
+    """
+    feature_dim = 32
+    net = DeformNetwork(feature_dim=feature_dim, hidden_dim=16, num_layers=2)
+
+    means, quats, opacities, t, features = _make_inputs(8, feature_dim)
+    out_m, out_q, out_o = net(means, quats, opacities, t, features)
+    (out_m.sum() + out_q.sum() + out_o.sum()).backward()
+
+    for p in net.trunk.parameters():
+        assert p.grad is None or p.grad.abs().sum() == 0, (
+            "Trunk gradient must be zero at init; otherwise zero-init heads "
+            "are no longer a strict identity."
+        )
+    # Head weight gradients ARE non-zero (they receive trunk_out as input).
+    assert net.pos_head.weight.grad is not None
+    assert net.pos_head.weight.grad.abs().sum() > 0
+
+
+# ---------------------------------------------------------------------------
+# DeformNetwork — input validation
+# ---------------------------------------------------------------------------
+
+
+def test_deform_net_dtype_mismatch_raises():
+    feature_dim = 32
+    net = DeformNetwork(feature_dim=feature_dim)
+    means, quats, opacities, t, _ = _make_inputs(4, feature_dim, dtype=torch.float32)
+    bad_features = torch.randn(4, feature_dim, dtype=torch.float64)
+    with pytest.raises(ValueError, match="dtype"):
+        net(means, quats, opacities, t, bad_features)
+
+
+def test_deform_net_batch_dim_mismatch_raises():
+    feature_dim = 32
+    net = DeformNetwork(feature_dim=feature_dim)
+    means = torch.randn(4, 3)
+    quats = torch.randn(5, 4)  # mismatch
+    opacities = torch.randn(4, 1)
+    t = torch.zeros(4, 1)
+    features = torch.randn(4, feature_dim)
+    with pytest.raises(ValueError, match="batch dim"):
+        net(means, quats, opacities, t, features)
+
+
+def test_deform_net_feature_dim_mismatch_raises():
+    feature_dim = 32
+    net = DeformNetwork(feature_dim=feature_dim)
+    means, quats, opacities, t, _ = _make_inputs(4, feature_dim)
+    bad_features = torch.randn(4, feature_dim + 1)  # wrong feature dim
+    with pytest.raises(ValueError, match="last dim"):
+        net(means, quats, opacities, t, bad_features)
+
+
+# ---------------------------------------------------------------------------
+# DeformationTable — basics
+# ---------------------------------------------------------------------------
+
+
+def test_deformation_table_init_all_static():
+    table = DeformationTable(num_gaussians=10)
+    assert len(table) == 10
+    assert not table.mask.any()
+
+
+def test_deformation_table_negative_count_raises():
+    with pytest.raises(ValueError, match="num_gaussians"):
+        DeformationTable(num_gaussians=-1)
+
+
+def test_deformation_table_set_indices():
+    table = DeformationTable(num_gaussians=10)
+    table.set_indices(torch.tensor([1, 3, 5]))
+    assert bool(table.mask[1])
+    assert bool(table.mask[3])
+    assert bool(table.mask[5])
+    assert not bool(table.mask[0])
+    assert not bool(table.mask[2])
+
+
+# ---------------------------------------------------------------------------
+# DeformationTable — densify ops (lock-step resize)
+# ---------------------------------------------------------------------------
+
+
+def test_deformation_table_prune_resizes_correctly():
+    table = DeformationTable(num_gaussians=5)
+    table.set_indices(torch.tensor([0, 2, 4]))  # mask = [T, F, T, F, T]
+    keep = torch.tensor([True, False, True, False, True])
+    table.prune(keep)
+    assert len(table) == 3
+    # All survivors were dynamic (indices 0, 2, 4).
+    assert table.mask.all()
+
+
+def test_deformation_table_prune_shape_mismatch_raises():
+    table = DeformationTable(num_gaussians=5)
+    bad_keep = torch.tensor([True, False, True])
+    with pytest.raises(ValueError, match="shape"):
+        table.prune(bad_keep)
+
+
+def test_deformation_table_duplicate_appends_children():
+    table = DeformationTable(num_gaussians=5)
+    table.set_indices(torch.tensor([0, 2]))  # [T, F, T, F, F]
+    table.duplicate(torch.tensor([0, 1]))
+    assert len(table) == 7
+    expected = torch.tensor([True, False, True, False, False, True, False])
+    assert (table.mask == expected).all()
+
+
+def test_deformation_table_split_removes_parents_appends_children():
+    table = DeformationTable(num_gaussians=5)
+    table.set_indices(torch.tensor([0, 2]))  # [T, F, T, F, F]
+    table.split(torch.tensor([0, 2]), factor=2)
+    # Survivors after removing indices 0 and 2: [F, F, F]
+    # Two children per split, each inheriting parent's flag (both T): [T, T, T, T]
+    expected = torch.tensor([False, False, False, True, True, True, True])
+    assert len(table) == 7
+    assert (table.mask == expected).all()
+
+
+def test_deformation_table_split_invalid_factor_raises():
+    table = DeformationTable(num_gaussians=5)
+    with pytest.raises(ValueError, match="factor"):
+        table.split(torch.tensor([0]), factor=0)

--- a/tests/test_contrib_dynamic_strategy.py
+++ b/tests/test_contrib_dynamic_strategy.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``gsplat.contrib.dynamic.DynamicStrategy``.
+
+Covers the deformable-aware densification strategy ported from G-SHARP v0.2.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.contrib.dynamic.strategy import DynamicStrategy
+
+
+def _make_params_optimizers(num_gaussians: int = 10):
+    """Build the per-Gaussian params + optimizers pair expected by ``check_sanity``."""
+    params: dict[str, torch.nn.Parameter] = {
+        "means": torch.nn.Parameter(torch.randn(num_gaussians, 3)),
+        "scales": torch.nn.Parameter(torch.randn(num_gaussians, 3)),
+        "quats": torch.nn.Parameter(torch.randn(num_gaussians, 4)),
+        "opacities": torch.nn.Parameter(torch.randn(num_gaussians, 1)),
+    }
+    optimizers = {k: torch.optim.Adam([p], lr=1e-3) for k, p in params.items()}
+    return params, optimizers
+
+
+# ---------------------------------------------------------------------------
+# check_sanity
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_strategy_check_sanity_passes_on_well_formed_params():
+    """DynamicStrategy.check_sanity has the same per-Gaussian requirements
+    as the parent — means/scales/quats/opacities must be present and
+    optimizer keys must match. HexPlane / DeformNet trainables live
+    outside *params* (see DynamicStrategy class docstring)."""
+    strategy = DynamicStrategy()
+    params, optimizers = _make_params_optimizers()
+    strategy.check_sanity(params, optimizers)  # must not raise
+
+
+def test_dynamic_strategy_check_sanity_fails_on_missing_per_gaussian_keys():
+    """The parent's check still fires if a per-Gaussian key is missing."""
+    strategy = DynamicStrategy()
+    params, optimizers = _make_params_optimizers()
+    # Drop means (required by DefaultStrategy.check_sanity).
+    del params["means"]
+    del optimizers["means"]
+    with pytest.raises(AssertionError, match="means"):
+        strategy.check_sanity(params, optimizers)
+
+
+# ---------------------------------------------------------------------------
+# initialize_state
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_strategy_initialize_state_creates_dynamic_mask_tensor():
+    """``state["dynamic_mask"]`` is a plain bool tensor (not a wrapper).
+    Default is all-True so every Gaussian routes through DeformNet."""
+    strategy = DynamicStrategy()
+    state = strategy.initialize_state(scene_scale=1.0, num_gaussians=10)
+    assert "dynamic_mask" in state
+    mask = state["dynamic_mask"]
+    assert isinstance(mask, torch.Tensor)
+    assert mask.dtype == torch.bool
+    assert mask.shape == (10,)
+    assert mask.all()  # default: every Gaussian dynamic
+
+
+def test_dynamic_strategy_initialize_state_honours_init_dynamic_false():
+    strategy = DynamicStrategy()
+    state = strategy.initialize_state(
+        scene_scale=1.0, num_gaussians=4, init_dynamic=False
+    )
+    assert not state["dynamic_mask"].any()
+
+
+def test_dynamic_strategy_initialize_state_preserves_default_keys():
+    """Make sure we don't drop any of the parent's state keys."""
+    strategy = DynamicStrategy()
+    state = strategy.initialize_state(scene_scale=2.5, num_gaussians=4)
+    assert state["scene_scale"] == 2.5
+    assert state["grad2d"] is None
+    assert state["count"] is None
+
+
+# ---------------------------------------------------------------------------
+# step_post_backward guard rails
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_strategy_post_backward_without_init_raises():
+    strategy = DynamicStrategy()
+    params, optimizers = _make_params_optimizers()
+    state = {"grad2d": None, "count": None, "scene_scale": 1.0}  # no dynamic_mask
+    info: dict = {}
+    with pytest.raises(RuntimeError, match="initialize_state"):
+        strategy.step_post_backward(
+            params=params,
+            optimizers=optimizers,
+            state=state,
+            step=0,
+            info=info,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full one-step training pass — covered by the integration test once the
+# trainer (TDD step 9) lands. Skipped here because rasterization is
+# CUDA-only and the strategy on its own can't drive a forward pass.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason=(
+        "Activated as tests/test_dynamic_surgical_trainer.py::"
+        "test_trainer_one_step_train_no_nan (CUDA + ENDONERF_DATA_DIR-gated). "
+        "Kept here as a marker so anyone scanning DynamicStrategy tests can "
+        "find the integration counterpart."
+    )
+)
+def test_dynamic_strategy_one_step_train_no_nan():
+    pass

--- a/tests/test_contrib_hexplane.py
+++ b/tests/test_contrib_hexplane.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``gsplat.contrib.dynamic.HexPlaneField``.
+
+Covers the multi-resolution 6-plane spatio-temporal feature field ported
+from G-SHARP v0.2 (`training/scene/hexplane.py`).
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.contrib.dynamic.hexplane import HexPlaneField
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_hexplane_default_construction_has_expected_feat_dim():
+    """Default config: 32 features per plane × 2 scales = 64-d output."""
+    field = HexPlaneField()
+    assert field.feat_dim == 32 * 2
+
+
+def test_hexplane_custom_planes_config_changes_feat_dim():
+    """Smaller plane resolution + 3 scales: feat_dim = 16 * 3 = 48."""
+    cfg = {
+        "grid_dimensions": 2,
+        "input_coordinate_dim": 4,
+        "output_coordinate_dim": 16,
+        "resolution": [16, 16, 16, 8],
+    }
+    field = HexPlaneField(bounds=1.0, planes_config=cfg, multires=(1, 2, 4))
+    assert field.feat_dim == 16 * 3
+
+
+# ---------------------------------------------------------------------------
+# Forward shape
+# ---------------------------------------------------------------------------
+
+
+def test_hexplane_forward_shape():
+    field = HexPlaneField()
+    n = 16
+    xyzt = torch.rand(n, 4) * 2 - 1
+    feat = field(xyzt)
+    assert feat.shape == (n, field.feat_dim)
+
+
+def test_hexplane_forward_finite_for_in_bounds_input():
+    field = HexPlaneField()
+    xyzt = torch.rand(16, 4) * 2 - 1
+    feat = field(xyzt)
+    assert torch.isfinite(feat).all()
+
+
+# ---------------------------------------------------------------------------
+# Gradient flow
+# ---------------------------------------------------------------------------
+
+
+def test_hexplane_gradients_reach_plane_params():
+    field = HexPlaneField()
+    xyzt = torch.rand(16, 4) * 2 - 1
+    feat = field(xyzt)
+    feat.sum().backward()
+
+    has_grad = False
+    for grids in field.grids:
+        for plane in grids:
+            if plane.grad is not None and plane.grad.abs().sum() > 0:
+                has_grad = True
+                break
+        if has_grad:
+            break
+    assert has_grad, "No HexPlane parameter received a gradient."
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_hexplane_out_of_bounds_time_handled():
+    """Out-of-range t values are clamped via ``padding_mode='border'`` in
+    grid_sample; output must stay finite."""
+    field = HexPlaneField()
+    xyzt = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, -2.0],  # t below grid
+            [0.0, 0.0, 0.0, 2.0],  # t above grid
+            [0.0, 0.0, 0.0, 0.0],  # in-bounds
+        ]
+    )
+    feat = field(xyzt)
+    assert feat.shape == (3, field.feat_dim)
+    assert torch.isfinite(feat).all()
+
+
+def test_hexplane_invalid_input_shape_raises():
+    field = HexPlaneField()
+    bad = torch.rand(16, 3)  # 3D, missing time
+    with pytest.raises(ValueError, match="last dim"):
+        field(bad)

--- a/tests/test_contrib_regulation.py
+++ b/tests/test_contrib_regulation.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for HexPlane regularizers in ``gsplat.contrib.dynamic.regulation``.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.contrib.dynamic.regulation import (
+    plane_smoothness,
+    time_l1,
+    time_smoothness,
+)
+
+
+# ---------------------------------------------------------------------------
+# plane_smoothness / time_smoothness (share the same math)
+# ---------------------------------------------------------------------------
+
+
+def test_plane_smoothness_constant_input_is_zero():
+    plane = torch.full((1, 4, 8, 8), 0.5)
+    out = plane_smoothness([plane])
+    assert torch.allclose(out, torch.tensor(0.0), atol=1e-7)
+
+
+def test_plane_smoothness_linear_input_is_zero():
+    """Linear ramp along H → constant first-difference → zero second-difference."""
+    h, w = 8, 8
+    plane = torch.arange(h, dtype=torch.float32).view(1, 1, h, 1).expand(1, 4, h, w)
+    out = plane_smoothness([plane])
+    assert torch.allclose(out, torch.tensor(0.0), atol=1e-6)
+
+
+def test_plane_smoothness_curved_input_positive():
+    """Quadratic ramp along H → constant non-zero second-difference → positive."""
+    h, w = 8, 8
+    coords = torch.arange(h, dtype=torch.float32)
+    plane = (coords**2).view(1, 1, h, 1).expand(1, 4, h, w).contiguous()
+    out = plane_smoothness([plane])
+    assert out.item() > 0
+
+
+def test_plane_smoothness_sums_across_planes():
+    plane_a = torch.full((1, 1, 4, 4), 0.5)  # constant → 0 contribution
+    plane_b = (torch.arange(4 * 4, dtype=torch.float32) ** 2).view(
+        1, 1, 4, 4
+    )  # nonzero
+    out_b_only = plane_smoothness([plane_b])
+    out_both = plane_smoothness([plane_a, plane_b])
+    assert torch.allclose(out_both, out_b_only, atol=1e-6)
+
+
+def test_plane_smoothness_invalid_rank_raises():
+    bad = torch.rand(8, 8)  # 2D, missing batch + channel
+    with pytest.raises(ValueError, match="4D"):
+        plane_smoothness([bad])
+
+
+def test_time_smoothness_same_math_as_plane_smoothness():
+    """The two functions are intentionally interchangeable on the math level."""
+    plane = torch.randn(1, 3, 6, 6)
+    assert torch.allclose(plane_smoothness([plane]), time_smoothness([plane]))
+
+
+def test_smoothness_on_too_short_axis_skips_plane():
+    """H = 2 is too short for a second difference; the plane is silently skipped."""
+    plane = torch.randn(1, 3, 2, 8)  # H = 2
+    out = plane_smoothness([plane])
+    assert torch.allclose(out, torch.tensor(0.0), atol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# time_l1 — penalises deviation from 1.0
+# ---------------------------------------------------------------------------
+
+
+def test_time_l1_at_one_is_zero():
+    plane = torch.ones(1, 4, 8, 8)
+    out = time_l1([plane])
+    assert torch.allclose(out, torch.tensor(0.0), atol=1e-7)
+
+
+def test_time_l1_constant_offset_matches_offset():
+    """Plane at constant 0.7 → mean |1 - 0.7| = 0.3 per plane."""
+    plane = torch.full((1, 1, 4, 4), 0.7)
+    out = time_l1([plane])
+    assert torch.allclose(out, torch.tensor(0.3), atol=1e-6)
+
+
+def test_time_l1_sums_across_planes():
+    p1 = torch.full((1, 1, 2, 2), 0.5)  # mean |1 - 0.5| = 0.5
+    p2 = torch.full((1, 1, 2, 2), 0.8)  # mean |1 - 0.8| = 0.2
+    out = time_l1([p1, p2])
+    assert torch.allclose(out, torch.tensor(0.7), atol=1e-6)
+
+
+def test_time_l1_gradient_flows():
+    plane = torch.full((1, 1, 4, 4), 0.5, requires_grad=True)
+    out = time_l1([plane])
+    out.backward()
+    assert plane.grad is not None
+    # |1 - 0.5| = 0.5, derivative w.r.t. plane is -1 / numel = -1/16.
+    assert torch.allclose(plane.grad, torch.full_like(plane, -1.0 / 16.0), atol=1e-6)
+
+
+# CUDA-gated regression: earlier impl initialised the accumulator on CPU and
+# crashed on the first GPU training step. Pin the contract.
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_plane_smoothness_on_cuda_planes_runs():
+    plane = torch.randn(1, 4, 5, 5, device="cuda", requires_grad=True)
+    out = plane_smoothness([plane])
+    assert out.device.type == "cuda"
+    out.backward()
+    assert plane.grad is not None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_time_smoothness_on_cuda_planes_runs():
+    plane = torch.randn(1, 4, 5, 5, device="cuda", requires_grad=True)
+    out = time_smoothness([plane])
+    assert out.device.type == "cuda"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_time_l1_on_cuda_planes_runs():
+    plane = torch.full((1, 1, 4, 4), 0.5, device="cuda", requires_grad=True)
+    out = time_l1([plane])
+    assert out.device.type == "cuda"
+    out.backward()
+    assert plane.grad is not None

--- a/tests/test_dataset_endonerf.py
+++ b/tests/test_dataset_endonerf.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``examples.datasets.endonerf``.
+
+Builds a tiny synthetic EndoNeRF-shaped directory on disk and exercises
+:class:`EndoNeRFParser` + :class:`EndoNeRFDataset` end-to-end. Seed is set
+to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+# Pillow is an `[examples]` / `[dev]` extra dep — skip the whole module
+# cleanly if a fresh `pip install .` doesn't pull it.
+Image = pytest.importorskip("PIL.Image")
+
+# The ``examples`` directory is a sibling of ``gsplat/`` and isn't installed.
+# Add the gsplat repo root to ``sys.path`` so ``examples.datasets.endonerf``
+# resolves the same way the trainer would.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from examples.datasets.endonerf import EndoNeRFDataset, EndoNeRFParser  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture — tiny synthetic EndoNeRF directory
+# ---------------------------------------------------------------------------
+
+
+def _write_endonerf_fixture(
+    root: Path, n_frames: int = 4, height: int = 8, width: int = 8
+) -> Path:
+    """Write a minimal EndoNeRF-shaped directory under *root* and return *root*."""
+    (root / "images").mkdir(parents=True, exist_ok=True)
+    (root / "depth").mkdir(parents=True, exist_ok=True)
+    (root / "masks").mkdir(parents=True, exist_ok=True)
+
+    # poses_bounds.npy: (N, 17) — 15 = pose [3 x 5] flattened, 2 = near/far bounds.
+    poses = np.zeros((n_frames, 3, 5), dtype=np.float32)
+    for i in range(n_frames):
+        poses[i, :, :3] = np.eye(3)  # identity rotation
+        poses[i, :, 3] = [0.0, 0.0, float(i)]  # translation along z so frames differ
+        poses[i, :, 4] = [height, width, 100.0]  # [H, W, focal]
+    bounds = np.tile([[0.1, 100.0]], (n_frames, 1)).astype(np.float32)
+    poses_arr = np.concatenate([poses.reshape(n_frames, 15), bounds], axis=1)
+    np.save(root / "poses_bounds.npy", poses_arr)
+
+    for i in range(n_frames):
+        # Per-frame greyscale value spread across [0, 255] so the fixture
+        # works for any n_frames (the old `i * 60` overflowed uint8 at i>=5
+        # under numpy >=2.0, which CI runs).
+        gray = int(round(i * 255.0 / max(1, n_frames - 1)))
+        rgb = np.full((height, width, 3), gray, dtype=np.uint8)
+        Image.fromarray(rgb).save(root / "images" / f"{i:06d}.png")
+
+        depth = np.full((height, width), 10 + i, dtype=np.uint8)
+        Image.fromarray(depth).save(root / "depth" / f"{i:06d}.png")
+
+        # Binary mask on-disk (will be inverted by the dataset to tool=1).
+        mask = np.full((height, width), 0 if i % 2 == 0 else 255, dtype=np.uint8)
+        Image.fromarray(mask).save(root / "masks" / f"{i:06d}.png")
+
+    return root
+
+
+@pytest.fixture
+def endonerf_dir(tmp_path: Path) -> Path:
+    return _write_endonerf_fixture(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Parser — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_endonerf_parser_loads_fixture(endonerf_dir: Path):
+    parser = EndoNeRFParser(data_dir=endonerf_dir)
+
+    assert parser.height == 8
+    assert parser.width == 8
+    assert parser.focal == pytest.approx(100.0)
+    assert parser.K.shape == (3, 3)
+    assert parser.K[0, 0] == pytest.approx(100.0)
+    assert parser.K[1, 1] == pytest.approx(100.0)
+
+    assert parser.camtoworlds.shape == (4, 4, 4)
+    # The fixture writes an identity rotation in LLFF raw format ([down,
+    # right, backwards]). The parser applies the LLFF → OpenGL/Nerfstudio
+    # axis permutation: `c2w[:, :, [1, 0, 2, 3]] * [1, -1, 1, 1]`.
+    # Identity LLFF maps to the column-permuted matrix below; translation
+    # is unchanged.
+    llff_identity_after_permutation = np.array(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    np.testing.assert_allclose(
+        parser.camtoworlds[0, :3, :3], llff_identity_after_permutation, atol=1e-6
+    )
+    np.testing.assert_allclose(parser.camtoworlds[2, :3, 3], [0.0, 0.0, 2.0])
+    np.testing.assert_allclose(parser.camtoworlds[:, 3, :], [[0.0, 0.0, 0.0, 1.0]] * 4)
+
+    assert len(parser.image_paths) == 4
+    assert len(parser.depth_paths) == 4
+    assert len(parser.mask_paths) == 4
+    np.testing.assert_allclose(parser.times, [0.0, 0.25, 0.5, 0.75])
+
+
+def test_endonerf_parser_applies_llff_axis_permutation(endonerf_dir: Path):
+    """Parser must apply ``c2w[:, :, [1, 0, 2, 3]] * [1, -1, 1, 1]`` to
+    match the OpenGL / Nerfstudio camera convention (G-SHARP ``endo_loader.py``).
+
+    Verified by writing a non-trivial LLFF pose and asserting the parser's
+    output matches the hand-computed permutation."""
+    # Custom fixture: scaled-identity LLFF rotation per frame.
+    import shutil
+
+    custom_root = endonerf_dir.parent / "endonerf_axis_test"
+    if custom_root.exists():
+        shutil.rmtree(custom_root)
+    custom_root = _write_endonerf_fixture(custom_root)
+
+    poses = np.load(custom_root / "poses_bounds.npy")[:, :15].reshape(-1, 3, 5)
+    llff_c2w_3x4 = poses[..., :4].copy()
+
+    # Expected post-permutation: apply the same transform the parser does.
+    expected = llff_c2w_3x4[:, :, [1, 0, 2, 3]] * np.array(
+        [1.0, -1.0, 1.0, 1.0], dtype=np.float32
+    )
+
+    parser = EndoNeRFParser(data_dir=custom_root)
+    np.testing.assert_allclose(parser.camtoworlds[:, :3, :4], expected, atol=1e-6)
+
+
+def test_endonerf_parser_split_indices_obey_test_every():
+    """test_every=2: indices with (i-1)%2 == 0 → test; others → train."""
+    # n_frames=8, test_every=2 → test = {1, 3, 5, 7}, train = {0, 2, 4, 6}.
+    with pytest.MonkeyPatch.context() as _:
+        pass
+    # Use a fresh temp dir to control n_frames.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write_endonerf_fixture(root, n_frames=8)
+        parser = EndoNeRFParser(data_dir=root, test_every=2)
+        assert parser.train_idxs == [0, 2, 4, 6]
+        assert parser.test_idxs == [1, 3, 5, 7]
+        assert parser.video_idxs == [0, 1, 2, 3, 4, 5, 6, 7]
+
+
+# ---------------------------------------------------------------------------
+# Parser — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_endonerf_parser_scared_routing_raises():
+    """SCARED dataset_type currently raises a clear NotImplementedError."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(NotImplementedError, match="SCARED"):
+            EndoNeRFParser(data_dir=Path(tmp), dataset_type="scared")
+
+
+def test_endonerf_parser_missing_data_dir_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="data_dir"):
+        EndoNeRFParser(data_dir=tmp_path / "does-not-exist")
+
+
+def test_endonerf_parser_missing_poses_bounds_raises(tmp_path: Path):
+    # Make all dirs but skip writing poses_bounds.npy.
+    (tmp_path / "images").mkdir()
+    (tmp_path / "depth").mkdir()
+    (tmp_path / "masks").mkdir()
+    with pytest.raises(FileNotFoundError, match="poses_bounds"):
+        EndoNeRFParser(data_dir=tmp_path)
+
+
+def test_endonerf_parser_non_binary_mask_rejected(endonerf_dir: Path):
+    """Overwrite the first mask with a non-binary value → parser rejects."""
+    bad_mask = np.full((8, 8), 127, dtype=np.uint8)  # half-grey, not binary
+    Image.fromarray(bad_mask).save(endonerf_dir / "masks" / "000000.png")
+    with pytest.raises(ValueError, match="non-binary"):
+        EndoNeRFParser(data_dir=endonerf_dir)
+
+
+def test_endonerf_parser_unknown_dataset_type_raises(endonerf_dir: Path):
+    with pytest.raises(ValueError, match="unknown dataset_type"):
+        EndoNeRFParser(data_dir=endonerf_dir, dataset_type="foo")  # type: ignore[arg-type]
+
+
+def test_endonerf_parser_count_mismatch_raises(endonerf_dir: Path):
+    """Delete one mask → count mismatch error at parse time."""
+    (endonerf_dir / "masks" / "000003.png").unlink()
+    with pytest.raises(ValueError, match="masks/"):
+        EndoNeRFParser(data_dir=endonerf_dir)
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+def test_endonerf_dataset_default_split_is_train(endonerf_dir: Path):
+    parser = EndoNeRFParser(data_dir=endonerf_dir)
+    ds = EndoNeRFDataset(parser)
+    assert ds.split == "train"
+    assert len(ds) == len(parser.train_idxs)
+
+
+def test_endonerf_dataset_unknown_split_raises(endonerf_dir: Path):
+    parser = EndoNeRFParser(data_dir=endonerf_dir)
+    with pytest.raises(ValueError, match="unknown split"):
+        EndoNeRFDataset(parser, split="bogus")
+
+
+def test_endonerf_dataset_getitem_returns_expected_keys(endonerf_dir: Path):
+    parser = EndoNeRFParser(data_dir=endonerf_dir)
+    ds = EndoNeRFDataset(parser, split="video")
+    item = ds[0]
+    for key in ("image", "depth", "mask", "camtoworld", "K", "time"):
+        assert key in item, f"missing key {key!r}"
+    assert item["image"].shape == (8, 8, 3)
+    assert item["depth"].shape == (8, 8)
+    assert item["mask"].shape == (8, 8)
+    assert item["camtoworld"].shape == (4, 4)
+    assert item["K"].shape == (3, 3)
+    assert item["time"].ndim == 0
+
+
+def test_endonerf_dataset_mask_is_tissue_include_convention(endonerf_dir: Path):
+    """EndoNeRF / G-SHARP convention: on-disk 0 = tissue, 255 = tool.
+
+    After ``1 - mask/255`` in the dataset, the returned mask is a
+    tissue-include mask: ``1`` where we should keep (tissue), ``0`` where
+    the pixel is a tool (drop). Frame 0 on-disk is all 0 → returned all 1
+    (keep everything); frame 1 on-disk is all 255 → returned all 0 (drop
+    everything).
+    """
+    parser = EndoNeRFParser(data_dir=endonerf_dir)
+    ds = EndoNeRFDataset(parser, split="video")
+    assert torch.allclose(ds[0]["mask"], torch.ones(8, 8), atol=1e-6)
+    assert torch.allclose(ds[1]["mask"], torch.zeros(8, 8), atol=1e-6)
+
+
+def test_endonerf_dataset_image_in_unit_range(endonerf_dir: Path):
+    parser = EndoNeRFParser(data_dir=endonerf_dir)
+    ds = EndoNeRFDataset(parser, split="video")
+    for i in range(len(ds)):
+        img = ds[i]["image"]
+        assert img.min() >= 0.0 - 1e-6
+        assert img.max() <= 1.0 + 1e-6

--- a/tests/test_dynamic_surgical_trainer.py
+++ b/tests/test_dynamic_surgical_trainer.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``examples/dynamic_surgical_trainer.py``.
+
+Three test groups:
+
+- Config validation — CPU.
+- Setup helpers (``build_splats_from_parser``, ``build_deform_modules``) —
+  CPU, on a tiny synthetic EndoNeRF fixture.
+- End-to-end one-step training — **CUDA-only** because
+  :func:`gsplat.rasterization` is CUDA-only. The end-to-end test also
+  requires a real-data EndoNeRF directory (the synthetic 32×32 fixture
+  produces sub-pixel Gaussian scales after unprojection + kNN); point at
+  one via ``ENDONERF_DATA_DIR`` (typically a ``pulling/`` directory).
+  Skipped if either CUDA or the env var is missing — that's the same
+  contract documented on
+  ``tests/test_contrib_dynamic_strategy.py::test_dynamic_strategy_one_step_train_no_nan``.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+# Pillow + tqdm are `[examples]` / `[dev]` extras — skip the whole module
+# cleanly if a fresh `pip install .` doesn't pull them. Must
+# importorskip *before* we touch examples.dynamic_surgical_trainer which
+# imports tqdm at module top.
+Image = pytest.importorskip("PIL.Image")
+pytest.importorskip("tqdm")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from examples.datasets.endonerf import EndoNeRFDataset, EndoNeRFParser  # noqa: E402
+from examples.dynamic_surgical_trainer import (  # noqa: E402
+    Config,
+    build_deform_modules,
+    build_splats_from_parser,
+    train_step,
+)
+
+_ENDONERF_DATA_DIR = os.environ.get("ENDONERF_DATA_DIR")
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture for CPU-friendly setup tests
+# ---------------------------------------------------------------------------
+
+
+def _write_trainer_fixture(
+    root: Path, n_frames: int = 4, h: int = 32, w: int = 32
+) -> Path:
+    (root / "images").mkdir(parents=True, exist_ok=True)
+    (root / "depth").mkdir(parents=True, exist_ok=True)
+    (root / "masks").mkdir(parents=True, exist_ok=True)
+
+    focal = float(w)
+    poses = np.zeros((n_frames, 3, 5), dtype=np.float32)
+    for i in range(n_frames):
+        poses[i, :, :3] = np.eye(3)
+        poses[i, :, 3] = [0.0, 0.0, i * 0.1]
+        poses[i, :, 4] = [h, w, focal]
+    bounds = np.tile([[0.1, 10.0]], (n_frames, 1)).astype(np.float32)
+    poses_arr = np.concatenate([poses.reshape(n_frames, 15), bounds], axis=1)
+    np.save(root / "poses_bounds.npy", poses_arr)
+
+    rng = np.random.default_rng(42)
+    for i in range(n_frames):
+        rgb = rng.integers(50, 200, size=(h, w, 3), dtype=np.uint8)
+        Image.fromarray(rgb).save(root / "images" / f"{i:06d}.png")
+        depth = np.tile(np.linspace(2, 8, h, dtype=np.float32).reshape(h, 1), (1, w))
+        Image.fromarray(depth.astype(np.uint8)).save(root / "depth" / f"{i:06d}.png")
+        # EndoNeRF / G-SHARP convention: on-disk 0 = tissue, 255 = tool.
+        # All-zero PNG → dataset returns tissue=1 everywhere (all-tissue).
+        mask = np.zeros((h, w), dtype=np.uint8)
+        Image.fromarray(mask).save(root / "masks" / f"{i:06d}.png")
+    return root
+
+
+@pytest.fixture
+def trainer_dir(tmp_path: Path) -> Path:
+    return _write_trainer_fixture(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_rejects_invalid_depth_mode():
+    with pytest.raises(ValueError, match="depth_mode"):
+        Config(data_dir=Path("./_unused"), depth_mode="bogus")
+
+
+def test_config_rejects_negative_step_counts():
+    with pytest.raises(ValueError, match="step counts"):
+        Config(data_dir=Path("./_unused"), coarse_steps=-1)
+    with pytest.raises(ValueError, match="step counts"):
+        Config(data_dir=Path("./_unused"), fine_steps=-1)
+
+
+def test_config_paths_are_coerced_to_path():
+    cfg = Config(data_dir="./somewhere", output_dir="./output/xyz")  # type: ignore[arg-type]
+    assert isinstance(cfg.data_dir, Path)
+    assert isinstance(cfg.output_dir, Path)
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_splats_from_parser_produces_expected_shapes(trainer_dir: Path):
+    cfg = Config(data_dir=trainer_dir, init_max_points=200)
+    parser = EndoNeRFParser(data_dir=trainer_dir)
+    params, optimizers = build_splats_from_parser(
+        parser, cfg, device=torch.device("cpu")
+    )
+
+    n = params["means"].shape[0]
+    assert n > 0
+    assert n <= 200
+    assert params["means"].shape == (n, 3)
+    assert params["scales"].shape == (n, 3)
+    assert params["quats"].shape == (n, 4)
+    assert params["opacities"].shape == (n, 1)
+    assert params["colors"].shape == (n, 3)
+    # build_splats_from_parser returns only the five per-Gaussian trainables;
+    # HexPlane / DeformNet trainables live in their own optimizers (see
+    # build_deform_modules). See DynamicStrategy class docstring for why.
+    assert "hexplane_params" not in params
+    assert "deform_mlp_params" not in params
+    assert set(params.keys()) == {"means", "scales", "quats", "opacities", "colors"}
+    # Optimizer keys must match parameter keys (Strategy.check_sanity contract).
+    assert set(optimizers.keys()) == set(params.keys())
+
+
+def test_build_splats_from_parser_quats_are_unit_norm(trainer_dir: Path):
+    cfg = Config(data_dir=trainer_dir, init_max_points=100)
+    parser = EndoNeRFParser(data_dir=trainer_dir)
+    params, _ = build_splats_from_parser(parser, cfg, device=torch.device("cpu"))
+    norms = params["quats"].norm(dim=-1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)
+
+
+def test_build_deform_modules_constructs(trainer_dir: Path):
+    cfg = Config(data_dir=trainer_dir)
+    hexplane, deform_net, hex_opt, deform_opt = build_deform_modules(
+        cfg, device=torch.device("cpu")
+    )
+    assert hexplane.feat_dim == cfg.hex_output_dim * len(cfg.hex_multires)
+    assert deform_net.feature_dim == hexplane.feat_dim
+    assert sum(p.numel() for p in hex_opt.param_groups[0]["params"]) > 0
+    assert sum(p.numel() for p in deform_opt.param_groups[0]["params"]) > 0
+
+
+def test_init_means_inside_derived_hexplane_aabb(trainer_dir: Path):
+    """Pin the in-AABB invariant.
+
+    After ``build_splats_from_parser`` produces the init point cloud,
+    ``train()`` derives ``derived_bounds = max(cfg.hex_bounds,
+    init_means.abs().max() * 2.0)``. Every init Gaussian must then be
+    inside ``[-derived_bounds, +derived_bounds]^3`` — otherwise
+    ``HexPlaneField.forward``'s ``grid_sample(padding_mode="border")``
+    clamps the out-of-AABB queries to the same edge feature and the
+    deformation field collapses to a spatial constant.
+    """
+    cfg = Config(data_dir=trainer_dir, init_max_points=200)
+    parser = EndoNeRFParser(data_dir=trainer_dir)
+    params, _ = build_splats_from_parser(parser, cfg, device=torch.device("cpu"))
+
+    means_abs_max = float(params["means"].detach().abs().max())
+    derived_bounds = max(cfg.hex_bounds, means_abs_max * 2.0)
+
+    inside = (params["means"].detach().abs() <= derived_bounds).all()
+    assert bool(inside), (
+        f"Init means escape derived HexPlane AABB: "
+        f"means.abs().max()={means_abs_max:.3f}, "
+        f"derived_bounds={derived_bounds:.3f}"
+    )
+    # And the 2× safety margin must actually exist (not just an equality).
+    assert means_abs_max <= derived_bounds * 0.5 + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# End-to-end one-step train (CUDA + real EndoNeRF data)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or _ENDONERF_DATA_DIR is None,
+    reason=(
+        "Requires CUDA and ENDONERF_DATA_DIR env var pointing at a "
+        "pulling-style EndoNeRF directory."
+    ),
+)
+def test_trainer_one_step_train_no_nan():
+    """End-to-end one-step training pass — no NaN / Inf in losses or params.
+
+    Activates the deferred test
+    ``test_dynamic_strategy_one_step_train_no_nan`` from
+    ``tests/test_contrib_dynamic_strategy.py``. The synthetic
+    ``trainer_dir`` fixture is too small to exercise rasterization
+    meaningfully (sub-pixel Gaussian scales after kNN init), so this test
+    points at a real dataset via ``ENDONERF_DATA_DIR``.
+    """
+    from gsplat.contrib.dynamic import DynamicStrategy
+
+    cfg = Config(
+        data_dir=Path(_ENDONERF_DATA_DIR),  # type: ignore[arg-type]
+        init_max_points=1000,
+        coarse_steps=1,
+        fine_steps=0,
+    )
+    device = torch.device("cuda")
+
+    parser = EndoNeRFParser(data_dir=cfg.data_dir)
+    dataset = EndoNeRFDataset(parser, split="train")
+    params, optimizers = build_splats_from_parser(parser, cfg, device=device)
+    hexplane, deform_net, hex_opt, deform_opt = build_deform_modules(cfg, device=device)
+
+    strategy = DynamicStrategy()
+    strategy.check_sanity(params, optimizers)
+    state = strategy.initialize_state(
+        scene_scale=1.0,
+        num_gaussians=int(params["means"].shape[0]),
+        device=device,
+    )
+
+    item = dataset[0]
+    losses = train_step(
+        cfg=cfg,
+        item=item,
+        params=params,
+        optimizers=optimizers,
+        hexplane=hexplane,
+        deform_net=deform_net,
+        hex_optimizer=hex_opt,
+        deform_optimizer=deform_opt,
+        strategy=strategy,
+        state=state,
+        step=0,
+    )
+
+    for k, v in losses.items():
+        assert np.isfinite(v), f"loss[{k}] = {v} is not finite"
+    for k, p in params.items():
+        assert torch.isfinite(p).all(), f"param[{k}] has NaN/Inf after one step"

--- a/tests/test_init_multiframe.py
+++ b/tests/test_init_multiframe.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the G-SHARP v0.2 init utilities in ``gsplat.init_utils``.
+
+Covers the two ported functions:
+
+- :func:`gsplat.init_utils.multi_frame_depth_unprojection` — masked depth →
+  world-space point cloud via per-frame pinhole intrinsics + camera-to-world
+  poses.
+- :func:`gsplat.init_utils.knn_scale_init` — pure-torch per-point log of
+  mean-k-NN distance, used as Gaussian log-scale init.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.init_utils import knn_scale_init, multi_frame_depth_unprojection
+
+
+# ---------------------------------------------------------------------------
+# multi_frame_depth_unprojection
+# ---------------------------------------------------------------------------
+
+
+def test_multiframe_unprojection_recovers_synthetic_grid():
+    """Single frame, identity pose, constant depth: unprojection should
+    recover an analytically known world-space grid.
+
+    With ``fx = fy = 4``, ``cx = cy = 2``, ``depth = 1.0`` everywhere, the
+    pixel ``(u, v)`` maps to camera-space ``((u - 2)/4, (v - 2)/4, 1.0)``.
+    Identity camera-to-world keeps that as world-space.
+    """
+    h, w = 4, 4
+    fx = fy = 4.0
+    cx = cy = 2.0
+
+    images = torch.rand(1, h, w, 3)
+    depths = torch.full((1, h, w), 1.0)
+    masks = torch.ones(1, h, w)
+    poses = torch.eye(4).unsqueeze(0)
+    intrinsics = torch.tensor([[[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]]])
+
+    xyz, rgb = multi_frame_depth_unprojection(images, depths, masks, poses, intrinsics)
+
+    assert xyz.shape == (h * w, 3)
+    assert rgb.shape == (h * w, 3)
+    # All z = depth = 1.0.
+    assert torch.allclose(xyz[:, 2], torch.ones(h * w), atol=1e-6)
+    # x in [(0-cx)/fx, (w-1-cx)/fx] = [-0.5, 0.25] for w=4.
+    assert xyz[:, 0].min() >= -0.5 - 1e-6
+    assert xyz[:, 0].max() <= 0.25 + 1e-6
+    assert xyz[:, 1].min() >= -0.5 - 1e-6
+    assert xyz[:, 1].max() <= 0.25 + 1e-6
+
+
+def test_multiframe_unprojection_rgb_matches_source_pixels():
+    """All four source RGBs should appear in the output point set (one per pixel)."""
+    images = torch.tensor(
+        [
+            [
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+                [[0.0, 0.0, 1.0], [1.0, 1.0, 0.0]],
+            ]
+        ]
+    )  # (1, 2, 2, 3)
+    depths = torch.full((1, 2, 2), 1.0)
+    masks = torch.ones(1, 2, 2)
+    poses = torch.eye(4).unsqueeze(0)
+    intrinsics = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]]])
+
+    _, rgb = multi_frame_depth_unprojection(images, depths, masks, poses, intrinsics)
+
+    assert rgb.shape == (4, 3)
+    expected = images.reshape(-1, 3)
+    for r in expected:
+        assert any(
+            torch.allclose(out, r, atol=1e-6) for out in rgb
+        ), f"Expected RGB {r.tolist()} not found in output."
+
+
+def test_multiframe_unprojection_frame_count_mismatch_raises():
+    images = torch.rand(2, 4, 4, 3)
+    depths = torch.rand(3, 4, 4)  # mismatch
+    masks = torch.ones(2, 4, 4)
+    poses = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
+    intrinsics = torch.eye(3).unsqueeze(0).repeat(2, 1, 1)
+    with pytest.raises(ValueError, match="leading dim"):
+        multi_frame_depth_unprojection(images, depths, masks, poses, intrinsics)
+
+
+def test_multiframe_unprojection_all_masked_returns_empty():
+    images = torch.rand(2, 4, 4, 3)
+    depths = torch.full((2, 4, 4), 1.0)
+    masks = torch.zeros(2, 4, 4)
+    poses = torch.eye(4).unsqueeze(0).repeat(2, 1, 1)
+    intrinsics = torch.eye(3).unsqueeze(0).repeat(2, 1, 1)
+    xyz, rgb = multi_frame_depth_unprojection(images, depths, masks, poses, intrinsics)
+    assert xyz.shape == (0, 3)
+    assert rgb.shape == (0, 3)
+
+
+def test_multiframe_unprojection_zero_depth_pixels_excluded():
+    """Pixels with depth == 0 should be dropped even when mask is on."""
+    h, w = 4, 4
+    images = torch.rand(1, h, w, 3)
+    depths = torch.full((1, h, w), 1.0)
+    depths[0, :2, :] = 0.0  # top half: no depth
+    masks = torch.ones(1, h, w)
+    poses = torch.eye(4).unsqueeze(0)
+    intrinsics = torch.tensor([[[4.0, 0.0, 2.0], [0.0, 4.0, 2.0], [0.0, 0.0, 1.0]]])
+
+    xyz, rgb = multi_frame_depth_unprojection(images, depths, masks, poses, intrinsics)
+    # Only bottom half (8 pixels) should remain.
+    assert xyz.shape == (8, 3)
+    assert rgb.shape == (8, 3)
+
+
+def test_multiframe_unprojection_max_points_subsamples():
+    h, w = 4, 4
+    images = torch.rand(1, h, w, 3)
+    depths = torch.full((1, h, w), 1.0)
+    masks = torch.ones(1, h, w)
+    poses = torch.eye(4).unsqueeze(0)
+    intrinsics = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]]])
+
+    xyz, rgb = multi_frame_depth_unprojection(
+        images, depths, masks, poses, intrinsics, max_points=5
+    )
+    assert xyz.shape == (5, 3)
+    assert rgb.shape == (5, 3)
+
+
+# ---------------------------------------------------------------------------
+# knn_scale_init
+# ---------------------------------------------------------------------------
+
+
+def test_knn_scale_init_matches_sklearn_reference():
+    """Pure-torch result must agree with sklearn's NearestNeighbors path
+    used by G-SHARP's ``knn`` helper (skips if sklearn is not installed).
+    """
+    pytest.importorskip("sklearn.neighbors")
+    from sklearn.neighbors import NearestNeighbors
+
+    xyz = torch.randn(50, 3)
+    result = knn_scale_init(xyz, k=3)
+
+    model = NearestNeighbors(n_neighbors=4, metric="euclidean").fit(xyz.numpy())
+    distances, _ = model.kneighbors(xyz.numpy())
+    neighbor_dists = torch.from_numpy(distances[:, 1:].astype("float32"))
+    expected = neighbor_dists.pow(2).mean(dim=-1).sqrt().clamp_min(1e-7).log()
+
+    assert torch.allclose(result, expected, atol=1e-5)
+
+
+def test_knn_scale_init_too_few_points_raises():
+    xyz = torch.randn(2, 3)  # need k+1=4 for default k=3
+    with pytest.raises(ValueError, match="at least"):
+        knn_scale_init(xyz, k=3)
+
+
+def test_knn_scale_init_duplicate_points_no_inf():
+    """All-zero point cloud → all neighbour distances are 0 → eps-clamped log
+    must stay finite (no -inf).
+    """
+    xyz = torch.zeros(10, 3)
+    result = knn_scale_init(xyz, k=3)
+    assert torch.isfinite(result).all()
+
+
+def test_knn_scale_init_uniform_grid_constant_scale():
+    """Points on a regular 1D grid have a known nearest-neighbour distance
+    (the grid spacing). The k=1 result should be exactly ``log(spacing)``
+    everywhere except the two end points (which we exclude from the check).
+    """
+    spacing = 0.5
+    xyz = torch.zeros(8, 3)
+    xyz[:, 0] = torch.arange(8, dtype=torch.float32) * spacing
+    result = knn_scale_init(xyz, k=1)
+    # Interior points have nearest-neighbor at exactly *spacing*; endpoints too.
+    expected = torch.full_like(result, torch.tensor(spacing).log().item())
+    assert torch.allclose(result, expected, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_knn_scale_init_large_n_peak_memory_bounded():
+    """Regression test pinning the chunked KNN memory contract.
+
+    The old ``cdist(xyz, xyz)`` allocated ~N^2 * 4 bytes = ~10 GB at
+    N=50_000. The chunked impl is O(chunk_size * N). With the default
+    ``chunk_size=1024`` that's ~200 MB at N=50_000 — leave comfortable
+    headroom and assert well below 1 GB so a silent regression back to
+    the dense path fails loudly. The input is only ~600 KB
+    (50k * 3 * 4 bytes), so the measured peak is dominated by the kNN
+    scan itself.
+    """
+    n = 50_000
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    baseline_alloc = torch.cuda.memory_allocated()
+
+    xyz = torch.randn(n, 3, device="cuda")
+    result = knn_scale_init(xyz, k=3)  # chunk_size default = 1024
+
+    peak_alloc_during = torch.cuda.max_memory_allocated() - baseline_alloc
+
+    assert result.shape == (n,)
+    assert torch.isfinite(result).all()
+
+    one_gb = 1 * 1024**3
+    assert peak_alloc_during < one_gb, (
+        f"knn_scale_init peak CUDA allocation "
+        f"{peak_alloc_during / 1024**3:.2f} GB exceeds the 1 GB ceiling — "
+        f"looks like a regression back to the O(N^2) dense cdist path."
+    )

--- a/tests/test_losses_depth.py
+++ b/tests/test_losses_depth.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the G-SHARP v0.2 additions to ``gsplat.losses``.
+
+Covers the four ported functions:
+
+- :func:`gsplat.losses.binocular_disparity_l1` — L1 in inverse-depth space, mask-aware.
+- :func:`gsplat.losses.pearson_depth_loss` — ``1 - Pearson r`` on (masked) flattened depth pairs.
+- :func:`gsplat.losses.masked_l1` — L1 over only the ``mask != 0`` region.
+- :func:`gsplat.losses.masked_ssim` — SSIM loss after zeroing both inputs in the masked region.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.losses import (
+    binocular_disparity_l1,
+    masked_l1,
+    masked_ssim,
+    pearson_depth_loss,
+)
+
+
+# ---------------------------------------------------------------------------
+# binocular_disparity_l1
+# ---------------------------------------------------------------------------
+
+
+def test_binocular_disparity_l1_identical_depths_is_zero():
+    depth = torch.rand(2, 4, 8) + 0.1  # strictly positive
+    loss = binocular_disparity_l1(depth, depth)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_binocular_disparity_l1_gradient_flows():
+    pred = (torch.rand(2, 4, 8) + 0.1).requires_grad_(True)
+    gt = torch.rand(2, 4, 8) + 0.1
+    loss = binocular_disparity_l1(pred, gt)
+    loss.backward()
+    assert pred.grad is not None
+    assert pred.grad.abs().sum() > 0
+
+
+def test_binocular_disparity_l1_mask_slices_correct():
+    """Errors in mask==0 region must not contribute to the loss."""
+    pred = torch.full((2, 4, 8), 0.5)
+    gt = pred.clone()
+    # Inject a large error only where the mask is zero.
+    pred_with_bad_left = pred.clone()
+    pred_with_bad_left[..., :4] = 100.0
+
+    mask = torch.zeros(2, 4, 8)
+    mask[..., 4:] = 1.0  # only the right half counts
+
+    loss = binocular_disparity_l1(pred_with_bad_left, gt, mask=mask)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_binocular_disparity_l1_shape_mismatch_raises():
+    pred = torch.rand(2, 4, 8) + 0.1
+    gt = torch.rand(2, 4, 7) + 0.1
+    with pytest.raises(ValueError, match="shape"):
+        binocular_disparity_l1(pred, gt)
+
+
+def test_binocular_disparity_l1_all_masked_returns_zero_no_nan():
+    pred = torch.rand(2, 4, 8) + 0.1
+    gt = torch.rand(2, 4, 8) + 0.1
+    mask = torch.zeros(2, 4, 8)
+    loss = binocular_disparity_l1(pred, gt, mask=mask)
+    assert torch.isfinite(loss).all()
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_binocular_disparity_l1_zero_depth_handled_via_eps():
+    """Zero (sentinel for ``no depth``) must not produce NaN / Inf in the inverse step."""
+    pred = torch.tensor([[1.0, 0.0, 2.0, 0.5]])
+    gt = torch.tensor([[1.0, 0.0, 2.0, 0.5]])
+    loss = binocular_disparity_l1(pred, gt)
+    assert torch.isfinite(loss).all()
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_binocular_disparity_l1_one_side_invalid_excludes_pair():
+    """If only one side of a pair is invalid (depth ~ 0), that pair must not
+    leak ``|0 - 1/other|`` into the loss — the docstring promises pair-level
+    validity, not per-side."""
+    # Pair 0: both valid, identical → contributes 0.
+    # Pair 1: pred invalid (0.0), gt = 2.0 → excluded.
+    # Pair 2: pred = 4.0, gt invalid (0.0) → excluded.
+    # Pair 3: both valid, identical → contributes 0.
+    pred = torch.tensor([[1.0, 0.0, 4.0, 0.5]])
+    gt = torch.tensor([[1.0, 2.0, 0.0, 0.5]])
+    loss = binocular_disparity_l1(pred, gt)
+    assert torch.isfinite(loss).all()
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# pearson_depth_loss
+# ---------------------------------------------------------------------------
+
+
+def test_pearson_depth_loss_correlated_inputs_zero():
+    gt = torch.rand(2, 4, 8)
+    pred = gt.clone()  # perfect positive correlation -> loss = 0
+    loss = pearson_depth_loss(pred, gt)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-5)
+
+
+def test_pearson_depth_loss_anticorrelated_inputs_two():
+    gt = torch.rand(2, 4, 8)
+    pred = -gt  # perfect negative correlation -> loss = 1 - (-1) = 2
+    loss = pearson_depth_loss(pred, gt)
+    assert torch.allclose(loss, torch.tensor(2.0), atol=1e-5)
+
+
+def test_pearson_depth_loss_shape_mismatch_raises():
+    pred = torch.rand(2, 4, 8)
+    gt = torch.rand(2, 4, 7)
+    with pytest.raises(ValueError, match="shape"):
+        pearson_depth_loss(pred, gt)
+
+
+def test_pearson_depth_loss_constant_input_no_nan():
+    """Pearson is undefined when one input has zero variance; loss must stay finite."""
+    pred = torch.zeros(2, 4, 8)
+    gt = torch.rand(2, 4, 8)
+    loss = pearson_depth_loss(pred, gt)
+    assert torch.isfinite(loss).all()
+
+
+def test_pearson_depth_loss_fully_masked_returns_zero_no_nan():
+    pred = torch.rand(2, 4, 8)
+    gt = torch.rand(2, 4, 8)
+    mask = torch.zeros(2, 4, 8)
+    loss = pearson_depth_loss(pred, gt, mask=mask)
+    assert torch.isfinite(loss).all()
+
+
+# ---------------------------------------------------------------------------
+# masked_l1
+# ---------------------------------------------------------------------------
+
+
+def test_masked_l1_ignores_masked_out_pixels():
+    pred = torch.zeros(2, 3, 8, 8)
+    gt = torch.zeros(2, 3, 8, 8)
+    pred[..., :4] = 1.0  # error only on the masked-out (left) half
+
+    mask = torch.zeros(2, 1, 8, 8)
+    mask[..., 4:] = 1.0  # right half is the active region
+
+    loss = masked_l1(pred, gt, mask)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_masked_l1_empty_mask_returns_zero_no_nan():
+    pred = torch.rand(2, 3, 8, 8)
+    gt = torch.rand(2, 3, 8, 8)
+    mask = torch.zeros(2, 1, 8, 8)
+    loss = masked_l1(pred, gt, mask)
+    assert torch.isfinite(loss).all()
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_masked_l1_shape_mismatch_raises():
+    pred = torch.rand(2, 3, 8, 8)
+    gt = torch.rand(2, 3, 8, 7)
+    mask = torch.ones(2, 1, 8, 8)
+    with pytest.raises(ValueError, match="shape"):
+        masked_l1(pred, gt, mask)
+
+
+def test_masked_l1_gradient_flows():
+    pred = torch.rand(2, 3, 8, 8, requires_grad=True)
+    gt = torch.rand(2, 3, 8, 8)
+    mask = torch.ones(2, 1, 8, 8)
+    loss = masked_l1(pred, gt, mask)
+    loss.backward()
+    assert pred.grad is not None
+    assert pred.grad.abs().sum() > 0
+
+
+# ---------------------------------------------------------------------------
+# masked_ssim
+# ---------------------------------------------------------------------------
+
+
+def test_masked_ssim_identical_inputs_loss_near_zero():
+    img = torch.rand(2, 3, 32, 32)  # values already in [0, 1]
+    mask = torch.ones(2, 1, 32, 32)
+    loss = masked_ssim(img, img, mask)
+    assert loss.item() < 1e-3
+
+
+def test_masked_ssim_shape_mismatch_raises():
+    pred = torch.rand(2, 3, 32, 32)
+    gt = torch.rand(2, 3, 32, 31)
+    mask = torch.ones(2, 1, 32, 32)
+    with pytest.raises(ValueError, match="shape"):
+        masked_ssim(pred, gt, mask)
+
+
+def test_masked_ssim_gradient_flows():
+    pred = torch.rand(2, 3, 32, 32, requires_grad=True)
+    gt = torch.rand(2, 3, 32, 32)
+    mask = torch.ones(2, 1, 32, 32)
+    loss = masked_ssim(pred, gt, mask)
+    loss.backward()
+    assert pred.grad is not None
+
+
+def test_masked_ssim_partial_mask_loss_near_zero():
+    """Partial mask: identical inputs in the active half, mismatch in the masked-out half.
+
+    `masked_ssim` zeros both inputs in the masked-out region before SSIM, so
+    pred*mask and gt*mask are identical everywhere (matching values in the
+    active half; both zeroed in the inactive half). SSIM ≈ 1 → loss ≈ 0.
+
+    This pins the "masked-out region is excluded" semantic against any
+    future drift to a crop-then-SSIM alternative.
+    """
+    pred = torch.rand(2, 3, 32, 32)
+    gt = pred.clone()
+    # Inject a deliberate mismatch only in the left half (masked-out).
+    gt[..., :16] = torch.rand(2, 3, 32, 16)
+
+    mask = torch.zeros(2, 1, 32, 32)
+    mask[..., 16:] = 1.0  # active region: right half only
+
+    loss = masked_ssim(pred, gt, mask)
+    assert loss.item() < 1e-3

--- a/tests/test_regularizers_occlusion.py
+++ b/tests/test_regularizers_occlusion.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the G-SHARP v0.2 regularizers in ``gsplat.regularizers``.
+
+Covers the three ported functions:
+
+- :func:`gsplat.regularizers.compute_tv_loss_targeted` — anisotropic TV with
+  optional binary mask weighting.
+- :func:`gsplat.regularizers.dilate_mask` — torch max-pool dilation.
+- :func:`gsplat.regularizers.create_invisible_mask` — union of per-frame masks.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py``.
+"""
+
+import pytest
+import torch
+
+from gsplat.regularizers import (
+    compute_tv_loss_targeted,
+    create_invisible_mask,
+    dilate_mask,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_tv_loss_targeted
+# ---------------------------------------------------------------------------
+
+
+def test_tv_targeted_constant_image_is_zero():
+    img = torch.full((1, 3, 8, 8), 0.5)
+    loss = compute_tv_loss_targeted(img)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-7)
+
+
+def test_tv_targeted_step_edge_matches_analytic_value():
+    """3x3 image with a horizontal step at row 1.
+
+    tv_h sums |row1 - row0| + |row2 - row1| = 1 + 0 across each of 3 columns = 3.
+    tv_w is 0 (rows are constant horizontally).
+    Without a mask: (3 + 0) / image.numel() = 3 / 9 = 1/3.
+    """
+    img = torch.tensor([[[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]])
+    loss = compute_tv_loss_targeted(img)
+    assert torch.allclose(loss, torch.tensor(1.0 / 3.0), atol=1e-6)
+
+
+def test_tv_targeted_empty_mask_returns_zero_no_div_by_zero():
+    img = torch.rand(2, 3, 8, 8)
+    mask = torch.zeros(2, 1, 8, 8)
+    loss = compute_tv_loss_targeted(img, mask)
+    assert torch.isfinite(loss).all()
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_tv_targeted_non_binary_mask_rejected(monkeypatch):
+    """Binary-mask check is gated behind ENFORCE_CONTRACTS to avoid a CPU sync
+    in the hot training loop; this test opts in so it can verify the check
+    still fires when asked."""
+    monkeypatch.setattr("gsplat.regularizers.ENFORCE_CONTRACTS", True)
+    img = torch.rand(2, 3, 8, 8)
+    mask = torch.full((2, 1, 8, 8), 0.5)
+    with pytest.raises(ValueError, match="binary"):
+        compute_tv_loss_targeted(img, mask)
+
+
+def test_tv_targeted_non_binary_mask_silent_when_contracts_disabled(monkeypatch):
+    """When ENFORCE_CONTRACTS is off (default), a non-binary mask should NOT
+    raise — production hot-path behaviour."""
+    monkeypatch.setattr("gsplat.regularizers.ENFORCE_CONTRACTS", False)
+    img = torch.rand(2, 3, 8, 8)
+    mask = torch.full((2, 1, 8, 8), 0.5)
+    loss = compute_tv_loss_targeted(img, mask)
+    assert torch.isfinite(loss).all()
+
+
+def test_tv_targeted_non_4d_image_raises():
+    img = torch.rand(3, 8, 8)  # missing batch dim
+    with pytest.raises(ValueError, match="4D"):
+        compute_tv_loss_targeted(img)
+
+
+def test_tv_targeted_gradient_flows():
+    img = torch.rand(2, 3, 8, 8, requires_grad=True)
+    mask = torch.ones(2, 1, 8, 8)
+    loss = compute_tv_loss_targeted(img, mask)
+    loss.backward()
+    assert img.grad is not None
+    assert img.grad.abs().sum() > 0
+
+
+# ---------------------------------------------------------------------------
+# dilate_mask
+# ---------------------------------------------------------------------------
+
+
+def test_dilate_mask_kernel_one_is_identity():
+    mask = (torch.rand(8, 8) > 0.5).float()
+    dilated = dilate_mask(mask, kernel_size=1)
+    assert torch.equal(dilated, mask)
+
+
+def test_dilate_mask_kernel_three_grows_by_one_pixel():
+    mask = torch.zeros(5, 5)
+    mask[2, 2] = 1.0
+    dilated = dilate_mask(mask, kernel_size=3)
+    expected = torch.zeros(5, 5)
+    expected[1:4, 1:4] = 1.0
+    assert torch.equal(dilated, expected)
+
+
+def test_dilate_mask_invalid_kernel_size_raises():
+    mask = torch.zeros(4, 4)
+    with pytest.raises(ValueError, match="kernel_size"):
+        dilate_mask(mask, kernel_size=2)
+    with pytest.raises(ValueError, match="kernel_size"):
+        dilate_mask(mask, kernel_size=0)
+
+
+def test_dilate_mask_preserves_input_rank():
+    mask_2d = torch.zeros(4, 4)
+    mask_2d[1, 1] = 1.0
+    assert dilate_mask(mask_2d).ndim == 2
+
+    mask_3d = mask_2d.unsqueeze(0)
+    assert dilate_mask(mask_3d).ndim == 3
+
+    mask_4d = mask_3d.unsqueeze(0)
+    assert dilate_mask(mask_4d).ndim == 4
+
+
+# ---------------------------------------------------------------------------
+# create_invisible_mask
+# ---------------------------------------------------------------------------
+
+
+def test_create_invisible_mask_union_of_inputs():
+    m1 = torch.tensor([[1.0, 0.0], [0.0, 0.0]])
+    m2 = torch.tensor([[0.0, 0.0], [0.0, 1.0]])
+    m3 = torch.tensor([[0.0, 1.0], [0.0, 0.0]])
+    invisible = create_invisible_mask([m1, m2, m3])
+    expected = torch.tensor([[1.0, 1.0], [0.0, 1.0]])
+    assert torch.equal(invisible, expected)
+
+
+def test_create_invisible_mask_empty_iterable_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        create_invisible_mask([])
+
+
+def test_create_invisible_mask_shape_mismatch_raises():
+    m1 = torch.zeros(4, 4)
+    m2 = torch.zeros(4, 5)
+    with pytest.raises(ValueError, match="shape"):
+        create_invisible_mask([m1, m2])
+
+
+def test_create_invisible_mask_invalid_element_type_raises():
+    with pytest.raises(TypeError, match="Tensor or str"):
+        create_invisible_mask([torch.zeros(4, 4), 42])

--- a/tests/test_two_stage_scheduler.py
+++ b/tests/test_two_stage_scheduler.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``gsplat.training.TwoStageScheduler``.
+
+Covers the coarse → fine schedule ported from G-SHARP v0.2's
+``EndoRunner._train_stage``.
+
+Seed is set to 42 by the autouse fixture in ``conftest.py`` (not relevant
+here since the scheduler is deterministic, but kept for consistency).
+"""
+
+import pytest
+
+from gsplat.training import TwoStageScheduler
+from gsplat.training.schedulers import TwoStageScheduleStep
+
+
+# ---------------------------------------------------------------------------
+# Construction-time validation
+# ---------------------------------------------------------------------------
+
+
+def test_two_stage_negative_step_count_raises():
+    with pytest.raises(ValueError):
+        TwoStageScheduler(coarse_steps=-1, fine_steps=10)
+    with pytest.raises(ValueError):
+        TwoStageScheduler(coarse_steps=10, fine_steps=-1)
+
+
+def test_two_stage_default_coarse_frame_index_is_zero():
+    sched = TwoStageScheduler(coarse_steps=5, fine_steps=10)
+    assert sched.coarse_frame_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Coarse stage
+# ---------------------------------------------------------------------------
+
+
+def test_two_stage_coarse_locks_on_coarse_frame_index():
+    sched = TwoStageScheduler(coarse_steps=5, fine_steps=20, coarse_frame_index=2)
+    for global_step in range(5):
+        s = sched.step(global_step=global_step, num_frames=10)
+        assert isinstance(s, TwoStageScheduleStep)
+        assert s.stage == "coarse"
+        assert s.frame_index == 2
+        assert s.shuffle is False
+
+
+def test_two_stage_coarse_uses_default_frame_zero():
+    sched = TwoStageScheduler(coarse_steps=3, fine_steps=10)
+    s = sched.step(global_step=0, num_frames=8)
+    assert s.frame_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Fine stage
+# ---------------------------------------------------------------------------
+
+
+def test_two_stage_fine_shuffles_after_boundary():
+    """At global_step == coarse_steps the schedule transitions to fine."""
+    sched = TwoStageScheduler(coarse_steps=5, fine_steps=20)
+    last_coarse = sched.step(global_step=4, num_frames=10)
+    first_fine = sched.step(global_step=5, num_frames=10)
+
+    assert last_coarse.stage == "coarse"
+    assert last_coarse.shuffle is False
+    assert first_fine.stage == "fine"
+    assert first_fine.shuffle is True
+    assert 0 <= first_fine.frame_index < 10
+
+
+def test_two_stage_fine_frame_index_cycles_through_num_frames():
+    """Fine stage cycles `(global_step - coarse_steps) % num_frames`."""
+    sched = TwoStageScheduler(coarse_steps=2, fine_steps=20)
+    num_frames = 4
+    expected = [0, 1, 2, 3, 0, 1, 2, 3]
+    actual = [
+        sched.step(global_step=2 + i, num_frames=num_frames).frame_index
+        for i in range(8)
+    ]
+    assert actual == expected
+
+
+def test_two_stage_fine_saturates_past_fine_steps():
+    """Past ``coarse_steps + fine_steps`` the schedule still returns fine
+    (the budget value is informational; gating is the caller's job)."""
+    sched = TwoStageScheduler(coarse_steps=2, fine_steps=3)
+    # coarse: 0, 1; fine budget: 2, 3, 4; query 5 (past the budget)
+    s = sched.step(global_step=5, num_frames=4)
+    assert s.stage == "fine"
+    assert s.shuffle is True
+
+
+def test_two_stage_zero_coarse_steps_starts_in_fine():
+    """A scheduler with coarse_steps=0 starts in fine immediately."""
+    sched = TwoStageScheduler(coarse_steps=0, fine_steps=10)
+    s = sched.step(global_step=0, num_frames=5)
+    assert s.stage == "fine"
+    assert s.shuffle is True
+
+
+# ---------------------------------------------------------------------------
+# step() argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_two_stage_step_negative_global_step_raises():
+    sched = TwoStageScheduler(coarse_steps=5, fine_steps=10)
+    with pytest.raises(ValueError, match="global_step"):
+        sched.step(global_step=-1, num_frames=10)
+
+
+def test_two_stage_step_zero_num_frames_raises():
+    sched = TwoStageScheduler(coarse_steps=5, fine_steps=10)
+    with pytest.raises(ValueError, match="num_frames"):
+        sched.step(global_step=0, num_frames=0)
+
+
+def test_two_stage_step_coarse_frame_index_out_of_range_raises():
+    sched = TwoStageScheduler(coarse_steps=5, fine_steps=10, coarse_frame_index=8)
+    with pytest.raises(ValueError, match="coarse_frame_index"):
+        sched.step(global_step=0, num_frames=4)


### PR DESCRIPTION
## Summary

This PR ports G-SHARP v0.2's training-time pipeline for dynamic surgical scenes into gsplat. It adds:

- **Depth/mask supervision** — disparity and Pearson depth losses, masked RGB/SSIM helpers
- **Scene priors** — occlusion-targeted TV regularization, multi-frame depth unprojection for init, KNN scale init
- **Training schedule** — two-stage coarse→fine scheduler
- **4D Gaussians** — HexPlane field + MLP deformation + dynamic densification strategy
- **End-to-end tutorial** — EndoNeRF dataset loader and `dynamic_surgical_trainer.py`

It does **not** ship Holoscan, depth/mask estimation models, compression, or pose optimization. gsplat provides the training primitives and example wiring; users bring precomputed depth, masks, and poses (or generate them externally).

Core rasterization and CUDA are unchanged.

## New modules

| Module | Description |
|---|---|
| `gsplat/losses.py` | Disparity L1, Pearson depth, masked RGB/SSIM losses |
| `gsplat/regularizers.py` | Occlusion-targeted TV regularization, invisible mask |
| `gsplat/init_utils.py` | Multi-frame depth unprojection, KNN scale init |
| `gsplat/training/schedulers.py` | Two-stage coarse→fine training scheduler |
| `gsplat/contrib/dynamic/` | HexPlane field, DeformNetwork, DeformationTable, DynamicStrategy |
| `examples/datasets/endonerf.py` | EndoNeRF dataset loader |
| `examples/dynamic_surgical_trainer.py` | End-to-end training example |

## Test plan

- [x] All 122 new G-SHARP tests pass (120 passed, 2 skipped integration tests)
- [x] Existing core tests unaffected (236 passed, 0 failed)
- [x] No internal/NVIDIA-specific references in code
- [x] Code review completed — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)