### PR TITLE
[NV] CUDA constant and error-check cleanups; relax assert_shape

### DIFF
--- a/gsplat/_helper.py
+++ b/gsplat/_helper.py
@@ -150,10 +150,6 @@ def assert_shape(name: str, t: torch.Tensor, shape: tuple):
         t: Tensor to check
         shape: Shape to check against
     """
-    if t.ndim != len(shape):
-        raise ValueError(
-            f"{name} must have rank {len(shape)} like {shape}, got {t.shape}"
-        )
 
     try:
         torch.broadcast_shapes(t.shape, shape)

--- a/gsplat/cuda/_constants.py
+++ b/gsplat/cuda/_constants.py
@@ -22,8 +22,6 @@ ALPHA_THRESHOLD = 1.0 / 255.0
 MAX_ALPHA = 0.99
 TRANSMITTANCE_THRESHOLD = 1e-4
 
-MAX_KERNEL_DENSITY_CUTOFF = 0.0113
-
 # Floor for the antialiased compensation factor (sqrt(det_orig / det_blur)).
 # Prevents compensation from reaching zero for extremely small Gaussians.
 MIN_COMPENSATION = 0.005

--- a/gsplat/cuda/_torch_impl_eval3d.py
+++ b/gsplat/cuda/_torch_impl_eval3d.py
@@ -43,7 +43,6 @@ from ._wrapper import RollingShutterType
 from ._constants import (
     ALPHA_THRESHOLD,
     TRANSMITTANCE_THRESHOLD,
-    MAX_KERNEL_DENSITY_CUTOFF,
 )
 
 
@@ -386,9 +385,7 @@ def accumulate_eval3d(
 
     # 9. Filter out low-contribution Gaussians (explicit masking)
     # CUDA: if (alpha < 1.f / 255.f) continue;
-    valid_mask = (alphas >= ALPHA_THRESHOLD) & (
-        max_response > MAX_KERNEL_DENSITY_CUTOFF
-    )
+    valid_mask = alphas >= ALPHA_THRESHOLD
 
     # Apply filter to all arrays early to reduce memory usage
     alphas = alphas[valid_mask]

--- a/gsplat/cuda/csrc/CameraWrappers.cu
+++ b/gsplat/cuda/csrc/CameraWrappers.cu
@@ -122,20 +122,6 @@ TensorView<T, SHAPE...> make_tensor_view(
         : TensorView<T, SHAPE...>{};
 }
 
-// CUDA error checking macro
-#define CUDA_CHECK(call) \
-    do \
-    { \
-        cudaError_t error = call; \
-        if (error != cudaSuccess) \
-        { \
-            throw std::runtime_error( \
-                std::string("CUDA error: ") + cudaGetErrorString(error) + \
-                " at " + __FILE__ + ":" + std::to_string(__LINE__) \
-            ); \
-        } \
-    } while(0)
-
 // Dimension tags for method kernels
 constexpr struct ray_tag_t {} RAY;
 constexpr struct coeff_tag_t {} COEFF;
@@ -246,7 +232,7 @@ c10::intrusive_ptr<PyBaseCameraModel<>> PyBaseCameraModel<>::create(
 template <typename CameraModel>
 void PyBaseCameraModel<CameraModel>::CudaDeleter::operator()(void* ptr) const
 {
-    CUDA_CHECK(cudaFree(ptr));
+    C10_CUDA_CHECK(cudaFree(ptr));
 }
 
 template <typename CameraModel>
@@ -260,7 +246,7 @@ PyBaseCameraModel<CameraModel>::PyBaseCameraModel(int num_cameras, int width, in
     , m_principal_points(principal_points)
 {
     CameraModel* d_cameras;
-    CUDA_CHECK(cudaMalloc(&d_cameras,num_cameras * sizeof(CameraModel)));
+    C10_CUDA_CHECK(cudaMalloc(&d_cameras,num_cameras * sizeof(CameraModel)));
     m_dev_cameras.reset(d_cameras);
 }
 
@@ -283,8 +269,8 @@ void PyBaseCameraModel<CameraModel>::init_external_distortion(
 
     // Allocate device memory and copy
     gsplat::extdist::BivariateWindshieldModelDeviceParams* d_params;
-    CUDA_CHECK(cudaMalloc(&d_params, sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams)));
-    CUDA_CHECK(cudaMemcpy(d_params, &host_params,
+    C10_CUDA_CHECK(cudaMalloc(&d_params, sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams)));
+    C10_CUDA_CHECK(cudaMemcpy(d_params, &host_params,
                           sizeof(gsplat::extdist::BivariateWindshieldModelDeviceParams),
                           cudaMemcpyHostToDevice));
     m_dev_ext_dist_params.reset(d_params);
@@ -366,7 +352,7 @@ std::tuple<torch::Tensor, torch::Tensor> PyBaseCameraModel<CameraModel>::camera_
         make_tensor_view<bool, CAMERA, RAY>(valid_result, m_num_cameras, "valid_result"),
         margin_factor
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 
     return std::make_tuple(image_points, valid_result);
 }
@@ -432,7 +418,7 @@ std::tuple<torch::Tensor, torch::Tensor> PyBaseCameraModel<CameraModel>::image_p
         make_tensor_view<float, CAMERA, POINT, 3>(camera_rays, m_num_cameras, "camera_rays"),
         make_tensor_view<bool, CAMERA, POINT>(valid_result, m_num_cameras, "valid_result")
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 
     return std::make_tuple(camera_rays, valid_result);
 }
@@ -487,7 +473,7 @@ torch::Tensor PyBaseCameraModel<CameraModel>::shutter_relative_frame_time(
         make_tensor_view<const float, CAMERA, POINT, 2>(image_points, m_num_cameras, "image_points"),
         make_tensor_view<float, CAMERA, POINT>(relative_times, m_num_cameras, "relative_times")
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 
     return relative_times;
 }
@@ -579,7 +565,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> PyBaseCameraModel<Camera
         make_tensor_view<float, CAMERA, POINT, 3>(world_rays_dir, m_num_cameras, "world_rays_dir"),
         make_tensor_view<bool, CAMERA, POINT>(valid_result, m_num_cameras, "valid_result")
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 
     return std::make_tuple(world_rays_org, world_rays_dir, valid_result);
 }
@@ -665,7 +651,7 @@ std::tuple<torch::Tensor, torch::Tensor> PyBaseCameraModel<CameraModel>::world_p
         make_tensor_view<bool, CAMERA, POINT>(valid_result, m_num_cameras, "valid_result"),
         margin_factor
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 
     return std::make_tuple(image_points, valid_result);
 }
@@ -733,7 +719,7 @@ PyPerfectPinholeCameraModel::PyPerfectPinholeCameraModel(
         m_width, m_height, m_rs_type,
         dev_ext_dist_params()
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 // ====================== PyOpenCVPinholeCameraModel Implementation ========================
@@ -831,7 +817,7 @@ PyOpenCVPinholeCameraModel::PyOpenCVPinholeCameraModel(
         m_width, m_height, m_rs_type,
         dev_ext_dist_params()
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 // ================ PyOpenCVFisheye Implementation ==============================
@@ -903,7 +889,7 @@ PyOpenCVFisheyeCameraModel::PyOpenCVFisheyeCameraModel(
         m_width, m_height, m_rs_type,
         dev_ext_dist_params()
     );
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 // ================================== FTheta Implementation ==================================
@@ -994,7 +980,7 @@ PyFThetaCameraModel::PyFThetaCameraModel(
         dev_ext_dist_params()
     );
 
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 // ================================== Lidar Implementation ==================================
@@ -1032,7 +1018,7 @@ PyRowOffsetStructuredSpinningLidarModel::PyRowOffsetStructuredSpinningLidarModel
     construct_lidar_cameras_kernel<<<blocks, threads, 0, stream>>>(
         make_tensor_view<CAMERA>(this->dev_cameras(), {m_num_cameras}, {1}, "cameras"), m_params);
 
-    CUDA_CHECK(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 } // namespace gsplat

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
@@ -407,7 +407,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
 
                 vis = __expf(power);
                 alpha = min(MAX_ALPHA, opac * vis);
-                if (power > 0.f || alpha < 1.f / 255.f || vis <= MAX_KERNEL_DENSITY_CUTOFF) {
+                if (power > 0.f || alpha < 1.f / 255.f) {
                     valid = false;
                 }
 

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
@@ -407,7 +407,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
 
                 vis = __expf(power);
                 alpha = min(MAX_ALPHA, opac * vis);
-                if (power > 0.f || alpha < 1.f / 255.f) {
+                if (power > 0.f || alpha < ALPHA_THRESHOLD) {
                     valid = false;
                 }
 

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
@@ -378,7 +378,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_fwd_kernel(
             const float power = -0.5f * grayDist;
             float max_response = __expf(power);
             float alpha = min(MAX_ALPHA, opac * max_response);
-            if (alpha < 1.f / 255.f || max_response <= MAX_KERNEL_DENSITY_CUTOFF) {
+            if (alpha < 1.f / 255.f) {
                 continue;
             }
 

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSFwd.cu
@@ -378,7 +378,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_fwd_kernel(
             const float power = -0.5f * grayDist;
             float max_response = __expf(power);
             float alpha = min(MAX_ALPHA, opac * max_response);
-            if (alpha < 1.f / 255.f) {
+            if (alpha < ALPHA_THRESHOLD) {
                 continue;
             }
 

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -82,7 +82,7 @@ enum CameraModelType {
 #define MAX_ALPHA 0.99f
 #define TRANSMITTANCE_THRESHOLD 1e-4f
 
-#define MAX_KERNEL_DENSITY_CUTOFF 0.0113
+#define MAX_KERNEL_DENSITY_CUTOFF 0.0113f
 
 // Floor for the antialiased compensation factor (sqrt(det_orig / det_blur)).
 // Prevents compensation from reaching zero for extremely small Gaussians.

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -82,8 +82,6 @@ enum CameraModelType {
 #define MAX_ALPHA 0.99f
 #define TRANSMITTANCE_THRESHOLD 1e-4f
 
-#define MAX_KERNEL_DENSITY_CUTOFF 0.0113f
-
 // Floor for the antialiased compensation factor (sqrt(det_orig / det_blur)).
 // Prevents compensation from reaching zero for extremely small Gaussians.
 #define MIN_COMPENSATION 0.005f


### PR DESCRIPTION
Main features / fixes:
- Named `ALPHA_THRESHOLD` constant; remove `MAX_KERNEL_DENSITY_CUTOFF`
- Use PyTorch `C10_CUDA_CHECK` instead of the custom check
- Relax `assert_shape` to broadcast-match optional-rank inputs
