### PR TITLE
[NV] CUDA robustness fixes and examples

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.8.0 --index-url https://download.pytorch.org/whl/cpu
           BUILD_NO_CUDA=1 pip install .
       
       # Get version (read from source to avoid importing gsplat; BUILD_NO_CUDA=1

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Changes on `main` since the [v1.5.3](https://github.com/nerfstudio-project/gspla
 
 ### v1.5.3
 
-- [May 2025] Arbitrary batching (over multiple scenes and multiple viewpoints) is supported now!! Checkout [here](docs/batch.md) for more details! Kudos to [Junchen Liu](https://junchenliu77.github.io/).
+- [May 2025] Arbitrary batching (over multiple scenes and multiple viewpoints) is supported now!! Checkout the [batching guide](docs/batch.md) for more details! Kudos to [Junchen Liu](https://junchenliu77.github.io/).
 - [May 2025] [Jonathan Stephens](https://x.com/jonstephens85) makes a great [tutorial video](https://www.youtube.com/watch?v=ACPTiP98Pf8) for Windows users on how to install gsplat and get start with 3DGUT.
-- [April 2025] [NVIDIA 3DGUT](https://research.nvidia.com/labs/toronto-ai/3DGUT/) is now integrated in gsplat! Checkout [here](docs/3dgut.md) for more details. [[NVIDIA Tech Blog]](https://developer.nvidia.com/blog/revolutionizing-neural-reconstruction-and-rendering-in-gsplat-with-3dgut/) [[NVIDIA Sweepstakes]](https://www.nvidia.com/en-us/research/3dgut-sweepstakes/)
+- [April 2025] [NVIDIA 3DGUT](https://research.nvidia.com/labs/toronto-ai/3DGUT/) is now integrated in gsplat! Checkout the [3DGUT integration guide](docs/3dgut.md) for more details. [[NVIDIA Tech Blog]](https://developer.nvidia.com/blog/revolutionizing-neural-reconstruction-and-rendering-in-gsplat-with-3dgut/) [[NVIDIA Sweepstakes]](https://www.nvidia.com/en-us/research/3dgut-sweepstakes/)
 
 ## Installation
 
@@ -58,7 +58,7 @@ To build gsplat from source on Windows, please check [this instruction](docs/INS
 
 ## Evaluation
 
-This repo comes with a standalone script that reproduces the official Gaussian Splatting with exactly the same performance on PSNR, SSIM, LPIPS, and converged number of Gaussians. Powered by gsplat’s efficient CUDA implementation, the training takes up to **4x less GPU memory** with up to **15% less time** to finish than the official implementation. Full report can be found [here](https://docs.gsplat.studio/main/tests/eval.html).
+This repo comes with a standalone script that reproduces the official Gaussian Splatting with exactly the same performance on PSNR, SSIM, LPIPS, and converged number of Gaussians. Powered by gsplat’s efficient CUDA implementation, the training takes up to **4x less GPU memory** with up to **15% less time** to finish than the official implementation. Full report can be found in the [evaluation results](https://docs.gsplat.studio/main/tests/eval.html).
 
 ```bash
 cd examples
@@ -110,7 +110,7 @@ This project is developed by the contributors coming from following institutes (
 - Aalto University
 - CMU
 
-We also have a white paper with about the project with benchmarking and mathematical supplement with conventions and derivations, available [here](https://arxiv.org/abs/2409.06765). If you find this library useful in your projects or papers, please consider citing:
+We also have a white paper with about the project with benchmarking and mathematical supplement with conventions and derivations, available [on arXiv](https://arxiv.org/abs/2409.06765). If you find this library useful in your projects or papers, please consider citing:
 
 ```
 @article{ye2025gsplat,

--- a/docs/source/tests/eval.rst
+++ b/docs/source/tests/eval.rst
@@ -141,7 +141,7 @@ within the gsplat repo (commit 6acdce4).
 
 The evaluation of `inria-X` can be 
 reproduced with our forked wersion of the official implementation at 
-`here <https://github.com/liruilong940607/gaussian-splatting/tree/benchmark>`__, 
+`benchmark branch of our gaussian-splatting fork <https://github.com/liruilong940607/gaussian-splatting/tree/benchmark>`__,
 with the command :code:`python full_eval_m360.py` (commit 36546ce).
 
 2DGS
@@ -237,6 +237,6 @@ within the gsplat repo (commit 48abf70).
 
 The evaluation of `inria-X` can be 
 reproduced with our forked wersion of the official implementation at 
-`here <https://github.com/hbb1/diff-surfel-rasterization>`__;
+`diff-surfel-rasterization repo <https://github.com/hbb1/diff-surfel-rasterization>`__;
 you need to change the :code:`--model_type 2dgs` to :code:`--model_type 2dgs-inria` in
 :code:`benchmars/basic_2dgs` and run command :code:`cd examples; bash benchmarks/basic_2dgs.sh` (commit 28c928a).

--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -22,26 +22,9 @@ from typing import Any, Dict, List, Optional
 import cv2
 import imageio.v2 as imageio
 import numpy as np
+import pycolmap
 import torch
 from PIL import Image
-
-# The pinned pycolmap commit uses np.uint64(-1) at class-definition time,
-# which raises OverflowError on numpy >= 2.0. Patch the installed source
-# file before importing so transitive deps (scipy, etc.) are unaffected.
-if int(np.__version__.split(".")[0]) >= 2:
-    import importlib.util as _ilu
-
-    _spec = _ilu.find_spec("pycolmap")
-    if _spec and _spec.submodule_search_locations:
-        _sm_path = os.path.join(
-            next(iter(_spec.submodule_search_locations)), "scene_manager.py"
-        )
-        with open(_sm_path) as _f:
-            _src = _f.read()
-        if "np.uint64(-1)" in _src:
-            with open(_sm_path, "w") as _f:
-                _f.write(_src.replace("np.uint64(-1)", "np.iinfo(np.uint64).max"))
-from pycolmap import SceneManager
 from tqdm import tqdm
 from typing_extensions import assert_never
 
@@ -88,6 +71,52 @@ def _resize_image_folder(image_dir: str, resized_dir: str, factor: int) -> str:
     return resized_dir
 
 
+def _as_dict(map_like: Any) -> Dict[int, Any]:
+    """Convert a pycolmap map view into a regular Python dictionary."""
+    return {int(k): v for k, v in map_like.items()}
+
+
+def _camera_model_name(camera: Any) -> str:
+    model_name = getattr(camera, "model_name", "")
+    if model_name:
+        return str(model_name).replace("CameraModelId.", "")
+
+    model = getattr(camera, "model", "")
+    return getattr(model, "name", str(model)).replace("CameraModelId.", "")
+
+
+def _camera_distortion(camera: Any) -> tuple[np.ndarray, str]:
+    model_name = _camera_model_name(camera)
+    params = np.asarray(camera.params, dtype=np.float64)
+
+    if model_name in {"SIMPLE_PINHOLE", "PINHOLE"}:
+        return np.empty(0, dtype=np.float32), "perspective"
+    if model_name == "SIMPLE_RADIAL":
+        distortion = np.array([params[3], 0.0, 0.0, 0.0], dtype=np.float32)
+        return distortion, "perspective"
+    if model_name == "RADIAL":
+        distortion = np.array([params[3], params[4], 0.0, 0.0], dtype=np.float32)
+        return distortion, "perspective"
+    if model_name == "OPENCV":
+        return np.array(params[4:8], dtype=np.float32), "perspective"
+    if model_name == "OPENCV_FISHEYE":
+        return np.array(params[4:8], dtype=np.float32), "fisheye"
+
+    raise ValueError(
+        f"Only perspective and fisheye cameras are supported, got {model_name}"
+    )
+
+
+def _image_w2c(image: Any) -> np.ndarray:
+    cam_from_world = image.cam_from_world
+    if callable(cam_from_world):
+        cam_from_world = cam_from_world()
+
+    w2c = np.eye(4)
+    w2c[:3, :4] = np.asarray(cam_from_world.matrix(), dtype=np.float64)
+    return w2c
+
+
 class Parser:
     """COLMAP parser."""
 
@@ -112,63 +141,38 @@ class Parser:
             colmap_dir
         ), f"COLMAP directory {colmap_dir} does not exist."
 
-        manager = SceneManager(colmap_dir)
-        manager.load_cameras()
-        manager.load_images()
-        manager.load_points3D()
+        reconstruction = pycolmap.Reconstruction(colmap_dir)
 
         # Extract extrinsic matrices in world-to-camera format.
-        imdata = manager.images
+        cameras = _as_dict(reconstruction.cameras)
+        images = _as_dict(reconstruction.images)
+        image_ids = [int(image_id) for image_id in reconstruction.reg_image_ids()]
+        imdata = {image_id: images[image_id] for image_id in image_ids}
         w2c_mats = []
         camera_ids = []
         Ks_dict = dict()
         params_dict = dict()
+        camtype_dict = dict()
         imsize_dict = dict()  # width, height
         mask_dict = dict()
-        bottom = np.array([0, 0, 0, 1]).reshape(1, 4)
-        for k in imdata:
-            im = imdata[k]
-            rot = im.R()
-            trans = im.tvec.reshape(3, 1)
-            w2c = np.concatenate([np.concatenate([rot, trans], 1), bottom], axis=0)
-            w2c_mats.append(w2c)
+        for image_id in imdata:
+            im = imdata[image_id]
+            w2c_mats.append(_image_w2c(im))
 
             # support different camera intrinsics
-            camera_id = im.camera_id
+            camera_id = int(im.camera_id)
             camera_ids.append(camera_id)
 
             # camera intrinsics
-            cam = manager.cameras[camera_id]
-            fx, fy, cx, cy = cam.fx, cam.fy, cam.cx, cam.cy
-            K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
+            cam = cameras[camera_id]
+            K = np.asarray(cam.calibration_matrix(), dtype=np.float64)
             K[:2, :] /= factor
             Ks_dict[camera_id] = K
 
             # Get distortion parameters.
-            type_ = cam.camera_type
-            if type_ == 0 or type_ == "SIMPLE_PINHOLE":
-                params = np.empty(0, dtype=np.float32)
-                camtype = "perspective"
-            elif type_ == 1 or type_ == "PINHOLE":
-                params = np.empty(0, dtype=np.float32)
-                camtype = "perspective"
-            if type_ == 2 or type_ == "SIMPLE_RADIAL":
-                params = np.array([cam.k1, 0.0, 0.0, 0.0], dtype=np.float32)
-                camtype = "perspective"
-            elif type_ == 3 or type_ == "RADIAL":
-                params = np.array([cam.k1, cam.k2, 0.0, 0.0], dtype=np.float32)
-                camtype = "perspective"
-            elif type_ == 4 or type_ == "OPENCV":
-                params = np.array([cam.k1, cam.k2, cam.p1, cam.p2], dtype=np.float32)
-                camtype = "perspective"
-            elif type_ == 5 or type_ == "OPENCV_FISHEYE":
-                params = np.array([cam.k1, cam.k2, cam.k3, cam.k4], dtype=np.float32)
-                camtype = "fisheye"
-            assert (
-                camtype == "perspective" or camtype == "fisheye"
-            ), f"Only perspective and fisheye cameras are supported, got {type_}"
-
+            params, camtype = _camera_distortion(cam)
             params_dict[camera_id] = params
+            camtype_dict[camera_id] = camtype
             imsize_dict[camera_id] = (cam.width // factor, cam.height // factor)
             mask_dict[camera_id] = None
         print(
@@ -177,7 +181,7 @@ class Parser:
 
         if len(imdata) == 0:
             raise ValueError("No images found in COLMAP.")
-        if not (type_ == 0 or type_ == 1):
+        if any(len(params) > 0 for params in params_dict.values()):
             print("Warning: COLMAP Camera is not PINHOLE. Images have distortion.")
 
         w2c_mats = np.stack(w2c_mats, axis=0)
@@ -236,16 +240,33 @@ class Parser:
         image_paths = [os.path.join(image_dir, colmap_to_image[f]) for f in image_names]
 
         # 3D points and {image_name -> [point_idx]}
-        points = manager.points3D.astype(np.float32)
-        points_err = manager.point3D_errors.astype(np.float32)
-        points_rgb = manager.point3D_colors.astype(np.uint8)
+        points3D = _as_dict(reconstruction.points3D)
+        point3D_ids = sorted(points3D)
+        points = np.array(
+            [points3D[point3D_id].xyz for point3D_id in point3D_ids],
+            dtype=np.float32,
+        ).reshape(-1, 3)
+        points_err = np.array(
+            [points3D[point3D_id].error for point3D_id in point3D_ids],
+            dtype=np.float32,
+        )
+        points_rgb = np.array(
+            [points3D[point3D_id].color for point3D_id in point3D_ids],
+            dtype=np.uint8,
+        ).reshape(-1, 3)
+        point3D_id_to_idx = {
+            point3D_id: idx for idx, point3D_id in enumerate(point3D_ids)
+        }
         point_indices = dict()
 
-        image_id_to_name = {v: k for k, v in manager.name_to_image_id.items()}
-        for point_id, data in manager.point3D_id_to_images.items():
-            for image_id, _ in data:
+        image_id_to_name = {image_id: image.name for image_id, image in imdata.items()}
+        for point3D_id in point3D_ids:
+            for track_element in points3D[point3D_id].track.elements:
+                image_id = int(track_element.image_id)
+                if image_id not in image_id_to_name:
+                    continue
                 image_name = image_id_to_name[image_id]
-                point_idx = manager.point3D_id_to_point3D_idx[point_id]
+                point_idx = point3D_id_to_idx[point3D_id]
                 point_indices.setdefault(image_name, []).append(point_idx)
         point_indices = {
             k: np.array(v).astype(np.int32) for k, v in point_indices.items()
@@ -350,6 +371,7 @@ class Parser:
             params = self.params_dict[camera_id]
             if len(params) == 0:
                 continue  # no distortion
+            camtype = camtype_dict[camera_id]
             assert camera_id in self.Ks_dict, f"Missing K for camera {camera_id}"
             assert (
                 camera_id in self.params_dict

--- a/examples/gsplat_viewer.py
+++ b/examples/gsplat_viewer.py
@@ -61,6 +61,8 @@ class GsplatViewer(Viewer):
         mode: Literal["rendering", "training"] = "rendering",
         render_modes: tuple = ("rgb", "depth(accumulated)", "depth(expected)", "alpha"),
     ):
+        if len(render_modes) == 0:
+            raise ValueError("render_modes must contain at least one mode")
         self._render_modes = render_modes
         super().__init__(server, render_fn, output_dir, mode)
         server.gui.set_panel_label("gsplat viewer")
@@ -163,7 +165,11 @@ class GsplatViewer(Viewer):
                 render_mode_dropdown = server.gui.add_dropdown(
                     "Render Mode",
                     self._render_modes,
-                    initial_value=self.render_tab_state.render_mode,
+                    initial_value=(
+                        self.render_tab_state.render_mode
+                        if self.render_tab_state.render_mode in self._render_modes
+                        else self._render_modes[0]
+                    ),
                     hint="Render mode to use.",
                 )
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -4,8 +4,8 @@
 torch==2.9.1
 nvidia-ncore>=19.0.0
 
-# pycolmap for data parsing
-git+https://github.com/brandonyzhao/pycolmap@a2a5671b0f6ab641957dd4c5a78cabcf220c28ee
+# Official COLMAP Python bindings for data parsing
+pycolmap>=3.10.0
 # (optional) nerfacc for torch version rasterization
 # git+https://github.com/nerfstudio-project/nerfacc
 

--- a/experimental/render/components/gaussian_inference_renderer.py
+++ b/experimental/render/components/gaussian_inference_renderer.py
@@ -226,6 +226,27 @@ class GaussianInferenceRenderer:
         viewmat_t = self._normalize_viewmat(viewmat, viewmats)
         K_t = self._normalize_K(K, Ks)
 
+        # -- Validate camera tensors against scene device ------------------
+        scene_device = self._scene.means_planar.device
+        for name, tensor in (("viewmat", viewmat_t), ("K", K_t)):
+            if not tensor.is_cuda or tensor.device != scene_device:
+                raise ValueError(
+                    f"{name} must be a CUDA tensor on {scene_device}; "
+                    f"got device={tensor.device}"
+                )
+            if not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+        if background is not None and (
+            not background.is_cuda
+            or background.device != scene_device
+            or not background.is_contiguous()
+        ):
+            raise ValueError(
+                f"background must be a contiguous CUDA tensor on {scene_device}; "
+                f"got device={background.device}, "
+                f"contiguous={background.is_contiguous()}"
+            )
+
         # -- tile_size -----------------------------------------------------
         effective_tile_size = tile_size if tile_size is not None else self._tile_size
         if effective_tile_size not in (8, 16):

--- a/experimental/render/kernels/cuda/build.py
+++ b/experimental/render/kernels/cuda/build.py
@@ -271,7 +271,7 @@ def build_and_load_experimental_gaussian_render_inference_scene():
 
     module_exists = os.path.exists(
         os.path.join(build_dir, f"{build_params.name}.so")
-    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.lib"))
+    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.pyd"))
 
     with (
         status_context() if not module_exists or build_params_changed else nullcontext()

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectCommon.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/IntersectCommon.cu
@@ -510,7 +510,9 @@ MTOffsets::MTOffsets(int32_t n_macro_tiles, int32_t gauss_batch_log2)
     , m_numSMs(0)
     , m_barrierExpected(0)
 {
-    cudaDeviceGetAttribute(&m_numSMs, cudaDevAttrMultiProcessorCount, 0);
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceGetAttribute(&m_numSMs, cudaDevAttrMultiProcessorCount, device);
 
     const int32_t n_scan_blocks = (n_macro_tiles + MT_OFFSETS_BLOCK_SIZE - 1) / MT_OFFSETS_BLOCK_SIZE;
     const int32_t n_ctas        = min(n_scan_blocks, m_numSMs);

--- a/experimental/render/kernels/cuda/csrc/gaussian_inference/SegmentedSort.cu
+++ b/experimental/render/kernels/cuda/csrc/gaussian_inference/SegmentedSort.cu
@@ -975,7 +975,9 @@ size_t SegmentedSortSetup(SegmentedSortState &s, int32_t n_segments, int32_t n_i
 
     if (!s.sm_count)
     {
-        cudaDeviceGetAttribute(&s.sm_count, cudaDevAttrMultiProcessorCount, 0);
+        int device = 0;
+        cudaGetDevice(&device);
+        cudaDeviceGetAttribute(&s.sm_count, cudaDevAttrMultiProcessorCount, device);
     }
 
     return total;

--- a/gsplat/cuda/_torch_impl.py
+++ b/gsplat/cuda/_torch_impl.py
@@ -39,6 +39,17 @@ from ._wrapper import CameraModel, RollingShutterType
 from ._constants import MAX_ALPHA, MIN_COMPENSATION
 
 
+def _bits_for_count(count: int) -> int:
+    """Bits to index ``count`` items as 0..count-1 (0 when count <= 1).
+
+    Mirrors ``gsplat::bits_for_count`` (MathUtils.h) so the (image, tile) id is
+    packed/unpacked with the same field widths as the CUDA kernels. ``count -
+    1`` matters for power-of-two counts: ``int.bit_length()`` over-counts them
+    (8 -> 4 bits instead of 3).
+    """
+    return (count - 1).bit_length() if count > 1 else 0
+
+
 def _persp_proj(
     means: Tensor,  # [..., C, N, 3]
     covars: Tensor,  # [..., C, N, 3, 3]
@@ -389,8 +400,8 @@ def _isect_tiles(
     flatten_ids = torch.empty(n_isects, dtype=torch.int32, device=device)
 
     cum_tiles_per_gauss = torch.cumsum(tiles_per_gauss.flatten(), dim=0)
-    image_n_bits = I.bit_length()
-    tile_n_bits = (tile_width * tile_height).bit_length()
+    image_n_bits = _bits_for_count(I)
+    tile_n_bits = _bits_for_count(tile_width * tile_height)
     assert image_n_bits + tile_n_bits + 32 <= 64
 
     def binary(num):
@@ -450,7 +461,7 @@ def _isect_offset_encode(
         This is a minimal implementation of the fully fused version, which has more
         arguments. Not all arguments are supported.
     """
-    tile_n_bits = (tile_width * tile_height).bit_length()
+    tile_n_bits = _bits_for_count(tile_width * tile_height)
     tile_counts = torch.zeros(
         (I, tile_height, tile_width), dtype=torch.int64, device=isect_ids.device
     )

--- a/gsplat/cuda/_torch_impl_lidar.py
+++ b/gsplat/cuda/_torch_impl_lidar.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 import math
 from typing import Tuple, Union, Literal
 from ._lidar import SpinningDirection, relative_sensor_angles
+from ._torch_impl import _bits_for_count
 from ._wrapper import RowOffsetStructuredSpinningLidarModelParametersExt
 import struct
 
@@ -333,10 +334,10 @@ def _isect_tiles_lidar(
     isect_ids_hi = torch.empty(n_isects, dtype=torch.int32, device="cpu")
     flatten_ids = torch.empty(n_isects, dtype=torch.int32, device="cpu")
 
-    image_n_bits = I.bit_length()
-    tile_n_bits = (
+    image_n_bits = _bits_for_count(I)
+    tile_n_bits = _bits_for_count(
         lidar.tiling.n_bins_elevation * lidar.tiling.n_bins_azimuth
-    ).bit_length()
+    )
     assert image_n_bits + tile_n_bits <= 32, "Too many tiles"
 
     depths = depths.reshape(-1)

--- a/gsplat/cuda/build.py
+++ b/gsplat/cuda/build.py
@@ -81,6 +81,20 @@ BUILD_CAMERA_WRAPPERS = os.getenv("BUILD_CAMERA_WRAPPERS", "1" if DEBUG else "0"
 NUM_CHANNELS = os.getenv("NUM_CHANNELS")
 
 
+# nvcc requires escaped commas in -D values.
+def _cuda_num_channels_define(num_channels):
+    return "-DGSPLAT_NUM_CHANNELS=" + num_channels.replace(",", "\\,")
+
+
+def format_jit_cuda_cflags(cuda_cflags):
+    if sys.platform == "win32":
+        return cuda_cflags
+    return [
+        shlex.quote(f) if f.startswith("-DGSPLAT_NUM_CHANNELS=") else f
+        for f in cuda_cflags
+    ]
+
+
 def get_build_parameters():
     name = "gsplat_cuda"
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -237,10 +251,10 @@ def get_build_parameters():
         extra_cflags += ["-Werror"]
 
     if NUM_CHANNELS is not None:
-        # nvcc has a bug where you need to escape the commas in macro values defined with -D.
-        extra_cuda_cflags += [
-            '-DGSPLAT_NUM_CHANNELS="' + NUM_CHANNELS.replace(",", "\\,") + '"'
-        ]
+        # nvcc treats an unescaped comma in a -D value as a second macro identifier,
+        # so escape it as \, here. The AOT path passes this straight to nvcc; the
+        # JIT path additionally shell-quotes it (see format_jit_cuda_cflags).
+        extra_cuda_cflags += [_cuda_num_channels_define(NUM_CHANNELS)]
         # gcc would not grok the backslash, so here we just pass NUM_CHANNELS as is.
         extra_cflags += [f"-DGSPLAT_NUM_CHANNELS={NUM_CHANNELS}"]
 
@@ -438,7 +452,9 @@ def build_and_load_gsplat():
                 name=build_params.name,
                 sources=build_params.sources,
                 extra_cflags=build_params.extra_cflags,
-                extra_cuda_cflags=build_params.extra_cuda_cflags,
+                extra_cuda_cflags=format_jit_cuda_cflags(
+                    build_params.extra_cuda_cflags
+                ),
                 extra_include_paths=build_params.extra_include_paths,
                 extra_ldflags=build_params.extra_ldflags,
                 build_directory=build_dir,
@@ -572,11 +588,6 @@ def _setup_py_extra_cuda_cflags_for_loaded_csrc():
 def _setup_py_build_parameters_mismatch_reason(build_params):
     recorded_cflags = _setup_py_extra_cflags_for_loaded_csrc()
     recorded_cuda_cflags = _setup_py_extra_cuda_cflags_for_loaded_csrc()
-    if NUM_CHANNELS is not None:
-        recorded_cflags += [f"-DGSPLAT_NUM_CHANNELS={NUM_CHANNELS}"]
-        recorded_cuda_cflags += [
-            '-DGSPLAT_NUM_CHANNELS="' + NUM_CHANNELS.replace(",", "\\,") + '"'
-        ]
     # `_setup_py_extra_cuda_cflags_for_loaded_csrc()` drops every torch-injected
     # CUDA flag, including `--expt-relaxed-constexpr`, which build.py also adds.
     # Strip the build_params copy so the two sides remain comparable.
@@ -679,5 +690,6 @@ __all__ = [
     "get_gsplat_core_objects",
     "get_gsplat_link_inputs",
     "get_gsplat_link_inputs_skip_reason",
+    "format_jit_cuda_cflags",
     "get_loaded_csrc_path",
 ]

--- a/gsplat/cuda/build.py
+++ b/gsplat/cuda/build.py
@@ -433,7 +433,7 @@ def build_and_load_gsplat():
     # and we can load it.
     module_exists = os.path.exists(
         os.path.join(build_dir, f"{build_params.name}.so")
-    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.lib"))
+    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.pyd"))
 
     with (
         status_context() if not module_exists or build_params_changed else nullcontext()

--- a/gsplat/cuda/csrc/CameraWrappers.cu
+++ b/gsplat/cuda/csrc/CameraWrappers.cu
@@ -24,6 +24,7 @@
 
 #include "CameraWrappers.h"
 #include "TensorView.h"
+#include "TorchUtils.h"
 #include <c10/cuda/CUDAStream.h>
 
 namespace gsplat {
@@ -282,8 +283,8 @@ c10::intrusive_ptr<PyBaseCameraModel<>> PyBaseCameraModel<>::create(
         TORCH_CHECK_ARG(!focal_lengths, "focal_lengths", "not allowed for ftheta camera model");
 
         // Get FThetaCameraDistortionParameters
-        TORCH_CHECK(ftheta_coeffs.value(), "ftheta_coeffs intrusive_ptr is null");
-        const FThetaCameraDistortionParameters& params = *ftheta_coeffs.value();
+        const FThetaCameraDistortionParameters& params =
+            gsplat::checked_deref(ftheta_coeffs, "ftheta_coeffs");
 
         // Convert polynomial arrays to tensors using from_blob
         torch::Tensor pixeldist_to_angle_poly = torch::from_blob(

--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -113,15 +113,16 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
             c10::nullopt, // isect_ids
             c10::nullopt  // flatten_ids
         );
-        cum_tiles_per_gauss = at::cumsum(tiles_per_gauss.view({-1}), 0);
+        // Explicit int64 to match the kernel's int64 read of cum_tiles_per_gauss.
+        cum_tiles_per_gauss = at::cumsum(tiles_per_gauss.view({-1}), 0, at::kLong);
         n_isects = cum_tiles_per_gauss[-1].item<int64_t>();
         if (segmented) {
             // offsets in the isect_ids and flatten_ids
             offsets = at::cumsum(
-                at::sum(tiles_per_gauss, -1).view({-1}), 0
+                at::sum(tiles_per_gauss, -1).view({-1}), 0, at::kLong
             );
             offsets = at::cat(
-                {at::tensor({0}, opt.dtype(at::kInt)),
+                {at::tensor({0}, opt.dtype(at::kLong)),
                 offsets}
             );
         }
@@ -269,10 +270,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_lidar(
         {
             // offsets in the isect_ids and flatten_ids
             offsets = at::cumsum(
-                at::sum(tiles_per_gauss, -1).view({-1}), 0
+                at::sum(tiles_per_gauss, -1).view({-1}), 0, at::kLong
             );
             offsets = at::cat(
-                {at::tensor({0}, opt.dtype(at::kInt)),
+                {at::tensor({0}, opt.dtype(at::kLong)),
                 offsets}
             );
         }

--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -24,6 +24,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 
+#include "MathUtils.h"
 #include "Common.h"    // where all the macros are defined
 #include "Config.h"
 #include "Intersect.h" // where the launch function is declared
@@ -76,14 +77,15 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
 
     uint32_t n_tiles = tile_width * tile_height;
     // the number of bits needed to encode the image id and tile id
-    // Note: std::bit_width requires C++20
-    // uint32_t tile_n_bits = std::bit_width(n_tiles);
-    // uint32_t image_n_bits = std::bit_width(I);
-    uint32_t image_n_bits = (uint32_t)floor(log2(I)) + 1;
-    uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits = bits_for_count(n_tiles);
     // the first 32 bits are used for the image id and tile id altogether, so
     // check if we have enough bits for them.
-    assert(image_n_bits + tile_n_bits <= 32);
+    TORCH_CHECK(
+        image_n_bits + tile_n_bits <= 32,
+        "intersect_tile: (image, tile) id packing needs ",
+        image_n_bits + tile_n_bits,
+        " bits but only 32 are available (I=", I, ", n_tiles=", n_tiles, ").");
 
     // first pass: compute number of tiles per gaussian
     // TODO: This first pass can be avoided, see todo comment in intersect_tile_lidar_kernel.
@@ -228,14 +230,15 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_lidar(
 
     uint32_t n_tiles = lidar->n_bins_azimuth*lidar->n_bins_elevation;
     // the number of bits needed to encode the image id and tile id
-    // Note: std::bit_width requires C++20
-    // uint32_t tile_n_bits = std::bit_width(n_tiles);
-    // uint32_t image_n_bits = std::bit_width(I);
-    uint32_t image_n_bits = (uint32_t)floor(log2(I)) + 1;
-    uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits = bits_for_count(n_tiles);
     // the first 32 bits are used for the image id and tile id altogether, so
     // check if we have enough bits for them.
-    assert(image_n_bits + tile_n_bits <= 32);
+    TORCH_CHECK(
+        image_n_bits + tile_n_bits <= 32,
+        "intersect_tile_lidar: (image, tile) id packing needs ",
+        image_n_bits + tile_n_bits,
+        " bits but only 32 are available (I=", I, ", n_tiles=", n_tiles, ").");
 
     // first pass: compute number of tiles per gaussian
     // TODO: This first pass can be avoided, see todo comment in intersect_tile_lidar_kernel.

--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -65,6 +65,15 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile(
         CHECK_INPUT(gaussian_ids.value());
     }
 
+    // packed-mode `offsets` (below) reduce a 1-D [nnz] tiles_per_gauss and
+    // collapse to a single [0, total] segment, so a per-image segmented sort
+    // would index past the 2-entry offsets buffer. Reject until packed offsets
+    // are built per image.
+    TORCH_CHECK(
+        !(packed && segmented),
+        "segmented sort is not supported for packed inputs"
+    );
+
     uint32_t n_tiles = tile_width * tile_height;
     // the number of bits needed to encode the image id and tile id
     // Note: std::bit_width requires C++20
@@ -207,6 +216,15 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_lidar(
         CHECK_INPUT(image_ids.value());
         CHECK_INPUT(gaussian_ids.value());
     }
+
+    // packed-mode `offsets` (below) reduce a 1-D [nnz] tiles_per_gauss and
+    // collapse to a single [0, total] segment, so a per-image segmented sort
+    // would index past the 2-entry offsets buffer. Reject until packed offsets
+    // are built per image.
+    TORCH_CHECK(
+        !(packed && segmented),
+        "segmented sort is not supported for packed inputs"
+    );
 
     uint32_t n_tiles = lidar->n_bins_azimuth*lidar->n_bins_elevation;
     // the number of bits needed to encode the image id and tile id

--- a/gsplat/cuda/csrc/Intersect.h
+++ b/gsplat/cuda/csrc/Intersect.h
@@ -19,7 +19,10 @@
 #pragma once
 
 #include <cstdint>
-#include "Ops.h"
+#include "Common.h"
+#include "Cameras.h"
+#include "Lidars.h"
+#include "ExternalDistortion.h"
 
 namespace at {
 class Tensor;

--- a/gsplat/cuda/csrc/IntersectTile.cu
+++ b/gsplat/cuda/csrc/IntersectTile.cu
@@ -18,6 +18,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
 #include <c10/cuda/CUDAStream.h>
+#include <cassert>
 #include <cooperative_groups.h>
 
 // for CUB_WRAPPER
@@ -187,9 +188,17 @@ __global__ void intersect_tile_kernel(
         }
         iid_enc = iid << (32 + tile_n_bits);
 
-        // tolerance for negative depth
-        int32_t depth_i32 = *(int32_t *)&(depths[idx]);  // Bit-level reinterpret
-        depth_id_enc = static_cast<uint32_t>(depth_i32);  // Zero-extend to 64-bit
+        // Narrow to float so the 32-bit key is a monotonic depth ordering for
+        // any scalar_t (a bare 32-bit reinterpret of a double would read only
+        // half its bits). Monotonic for the non-negative depths that reach
+        // here after near-plane culling; the sign bit would invert ordering.
+        float depth_f = static_cast<float>(depths[idx]);
+        // The float-bit key is monotonic only for non-negative depths: a set
+        // sign bit would invert the unsigned ordering. isect_tiles is a
+        // standalone op, so pin the invariant the comment relies on.
+        assert(depth_f >= 0.f);
+        // Bit-level reinterpret, zero-extended into the low 32 bits of the key.
+        depth_id_enc = __float_as_uint(depth_f);
     }
 
     if (conics != nullptr && opacities != nullptr) {

--- a/gsplat/cuda/csrc/IntersectTile.cu
+++ b/gsplat/cuda/csrc/IntersectTile.cu
@@ -25,6 +25,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <cub/cub.cuh>
 
+#include "MathUtils.h"
 #include "Common.h"
 #include "Intersect.h"
 #include "Utils.cuh"
@@ -328,15 +329,17 @@ void launch_intersect_tile_kernel(
     }
 
     uint32_t n_tiles = tile_width * tile_height;
-    // the number of bits needed to encode the image id and tile id
-    // Note: std::bit_width requires C++20
-    // uint32_t tile_n_bits = std::bit_width(n_tiles);
-    // uint32_t image_n_bits = std::bit_width(I);
-    uint32_t image_n_bits = (uint32_t)floor(log2(I)) + 1;
-    uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
+    // the number of bits needed to encode the image id and tile id; must match
+    // the packing in intersect_tile so the (image, tile) id unpacks correctly.
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits = bits_for_count(n_tiles);
     // the first 32 bits are used for the image id and tile id altogether, so
     // check if we have enough bits for them.
-    assert(image_n_bits + tile_n_bits <= 32);
+    TORCH_CHECK(
+        image_n_bits + tile_n_bits <= 32,
+        "intersect_tile: (image, tile) id packing needs ",
+        image_n_bits + tile_n_bits,
+        " bits but only 32 are available (I=", I, ", n_tiles=", n_tiles, ").");
 
     dim3 threads(256);
     dim3 grid((n_elements + threads.x - 1) / threads.x);
@@ -413,8 +416,6 @@ __global__ void intersect_offset_kernel(
     if (idx >= n_isects)
         return;
 
-    uint32_t image_n_bits = (uint32_t)floor(log2f(float(I))) + 1;
-
     int64_t isect_id_curr = isect_ids[idx] >> 32;
     int64_t iid_curr = isect_id_curr >> (tile_n_bits);
     int64_t tid_curr = isect_id_curr & ((1 << tile_n_bits) - 1);
@@ -467,7 +468,9 @@ void launch_intersect_offset_kernel(
     }
 
     uint32_t n_tiles = tile_width * tile_height;
-    uint32_t tile_n_bits = (uint32_t)floor(log2(n_tiles)) + 1;
+    // Must match the packing in launch_intersect_tile_kernel so the (image,
+    // tile) id unpacks with the same field width it was packed with.
+    const uint32_t tile_n_bits = bits_for_count(n_tiles);
     intersect_offset_kernel<<<
         grid,
         threads,

--- a/gsplat/cuda/csrc/IntersectTileLidar.cu
+++ b/gsplat/cuda/csrc/IntersectTileLidar.cu
@@ -455,14 +455,14 @@ void launch_intersect_tile_lidar_kernel(
                     nnz,
                     *lidar,
                     image_ids.has_value()
-                        ? image_ids.value().data_ptr<int64_t>()
+                        ? image_ids.value().const_data_ptr<int64_t>()
                         : nullptr,
                     gaussian_ids.has_value()
-                        ? gaussian_ids.value().data_ptr<int64_t>()
+                        ? gaussian_ids.value().const_data_ptr<int64_t>()
                         : nullptr,
-                    means2d.data_ptr<scalar_t>(),
-                    radii.data_ptr<int32_t>(),
-                    depths.data_ptr<scalar_t>(),
+                    means2d.const_data_ptr<scalar_t>(),
+                    radii.const_data_ptr<int32_t>(),
+                    depths.const_data_ptr<scalar_t>(),
                     cum_tiles_per_gauss.has_value()
                         ? cum_tiles_per_gauss.value().data_ptr<int64_t>()
                         : nullptr,

--- a/gsplat/cuda/csrc/IntersectTileLidar.cu
+++ b/gsplat/cuda/csrc/IntersectTileLidar.cu
@@ -30,6 +30,7 @@
 #include "Ops.h"
 #include "Cameras.cuh"
 #include "Lidars.cuh"
+#include "MathUtils.h"
 
 namespace gsplat {
 
@@ -417,15 +418,18 @@ void launch_intersect_tile_lidar_kernel(
     }
 
     uint32_t n_tiles = lidar->n_bins_azimuth*lidar->n_bins_elevation;
-    // the number of bits needed to encode the image id and tile id
-    // Note: std::bit_width requires C++20
-    // uint32_t tile_n_bits = std::bit_width(n_tiles);
-    // uint32_t image_n_bits = std::bit_width(I);
-    uint32_t image_n_bits = I == 0 ? 0 : ((uint32_t)floor(log2(I)) + 1);
-    uint32_t tile_n_bits = n_tiles == 0 ? 0 : ((uint32_t)floor(log2(n_tiles)) + 1);
+    // Number of bits to encode the image id and tile id; must match the sort
+    // side (intersect_tile_lidar in Intersect.cpp) so the (image, tile) id
+    // round-trips through the radix sort with the same field widths.
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits = bits_for_count(n_tiles);
     // the first 32 bits are used for the image id and tile id altogether, so
     // check if we have enough bits for them.
-    assert(image_n_bits + tile_n_bits <= 32);
+    TORCH_CHECK(
+        image_n_bits + tile_n_bits <= 32,
+        "intersect_tile_lidar: (image, tile) id packing needs ",
+        image_n_bits + tile_n_bits,
+        " bits but only 32 are available (I=", I, ", n_tiles=", n_tiles, ").");
 
     dim3 threads(256);
     dim3 grid((n_elements + threads.x - 1) / threads.x);

--- a/gsplat/cuda/csrc/IntersectTileLidar.cu
+++ b/gsplat/cuda/csrc/IntersectTileLidar.cu
@@ -357,18 +357,17 @@ __global__ void intersect_tile_lidar_kernel(
     }
     const int64_t image_id_enc = image_id << (32 + tile_n_bits);
 
-    int64_t depth_id_enc;
-    if constexpr(sizeof(depths[idxgauss]) == sizeof(uint32_t))
-    {
-        depth_id_enc = reinterpret_cast<const uint32_t &>(depths[idxgauss]);
-    }
-    else
-    {
-        static_assert(sizeof(depths[idxgauss]) == sizeof(uint64_t));
-        depth_id_enc = reinterpret_cast<const uint64_t &>(depths[idxgauss]);
-        assert((depth_id_enc & ~0xFF'FF'FF'FFULL) == 0);
-        depth_id_enc &= 0xFF'FF'FF'FFULL;
-    }
+    // Narrow to float so the 32-bit depth field is a monotonic ordering for
+    // any scalar_t; a 32-bit slice of a double would be its low mantissa bits
+    // (non-monotonic). The float-bit key is monotonic only for non-negative
+    // values, which holds here because lidar range is >= 0. Matches the
+    // __float_as_uint reinterpret in intersect_tile_kernel.
+    const float depth_f = static_cast<float>(depths[idxgauss]);
+    // Pin the non-negativity the float-bit key relies on (a set sign bit would
+    // invert the unsigned ordering).
+    assert(depth_f >= 0.f);
+    const int64_t depth_id_enc =
+        static_cast<int64_t>(__float_as_uint(depth_f));
 
     int64_t idxflatten = (idxgauss == 0) ? 0 : cum_tiles_per_gauss[idxgauss - 1];
     #pragma unroll

--- a/gsplat/cuda/csrc/Lidar.cpp
+++ b/gsplat/cuda/csrc/Lidar.cpp
@@ -19,13 +19,14 @@
 #include <torch/types.h>
 #include "Lidars.cuh"
 #include "Ops.h"
+#include "TorchUtils.h"
 
 RowOffsetStructuredSpinningLidarModelParametersExtDevice::RowOffsetStructuredSpinningLidarModelParametersExtDevice(
     const gsplat::RowOffsetStructuredSpinningLidarModelParametersExt &params)
     : n_rows{static_cast<int>(params.row_elevations_rad.size(0))}
     , n_columns{static_cast<int>(params.column_azimuths_rad.size(0))}
-    , fov_vert_rad{params.fov_vert_rad}
-    , fov_horiz_rad{params.fov_horiz_rad}
+    , fov_vert_rad{gsplat::checked_deref(params.fov_vert_rad, "fov_vert_rad")}
+    , fov_horiz_rad{gsplat::checked_deref(params.fov_horiz_rad, "fov_horiz_rad")}
     , fov_eps_rad{params.fov_eps_rad}
     , row_elevations_rad{params.row_elevations_rad.data_ptr<float>()}
     , column_azimuths_rad{params.column_azimuths_rad.data_ptr<float>()}
@@ -56,9 +57,11 @@ RowOffsetStructuredSpinningLidarModelParametersExtDevice::RowOffsetStructuredSpi
     TORCH_CHECK(params.angles_to_columns_map.size(0) > 1 && params.angles_to_columns_map.size(1) > 1,
                 "angles_to_columns_map dimensions must be > 1");
 
+    // fov_vert_rad / fov_horiz_rad are validated by checked_deref in the
+    // member-init list above, so the FOVDevice members are guaranteed valid here.
     this->map_resolution_rad = {
-        params.fov_horiz_rad->span/(params.angles_to_columns_map.size(1)-1),
-        params.fov_vert_rad->span/(params.angles_to_columns_map.size(0)-1)
+        this->fov_horiz_rad.span/(params.angles_to_columns_map.size(1)-1),
+        this->fov_vert_rad.span/(params.angles_to_columns_map.size(0)-1)
     };
 
     if(params.angles_to_columns_map.dtype() != torch::kInt32)

--- a/gsplat/cuda/csrc/MathUtils.h
+++ b/gsplat/cuda/csrc/MathUtils.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <bit>
+#include <cstdint>
+
+namespace gsplat {
+
+/** Bits needed to index `count` items as 0..count-1 (0 when count <= 1).
+ *
+ * This is the field width used to pack the image id and tile id into the high
+ * 32 bits of an intersection sort key. Every pack and unpack site MUST use this
+ * helper so the (image, tile) id round-trips identically -- `floor(log2)+1`
+ * over-counts power-of-two counts (8 -> 4 bits instead of 3) and yields 1 for a
+ * single item, so a packer and an unpacker that disagree corrupt the decode.
+ *
+ * Requires C++20 (`std::bit_width`); the extension is built as C++20.
+ */
+inline uint32_t bits_for_count(int64_t count) {
+    if (count <= 1) {
+        return 0u;
+    } else {
+        return static_cast<uint32_t>(
+            std::bit_width(static_cast<uint64_t>(count) - 1u));
+    }
+}
+
+} // namespace gsplat

--- a/gsplat/cuda/csrc/Projection.cpp
+++ b/gsplat/cuda/csrc/Projection.cpp
@@ -346,7 +346,7 @@ projection_ewa_3dgs_packed_fwd(
 
     uint32_t N = means.size(-2);          // number of gaussians
     uint32_t C = viewmats.size(-3);       // number of cameras
-    uint32_t B = means.numel() / (N * 3); // number of batches
+    uint32_t B = c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)); // number of batches
     auto opt = means.options();
 
     uint32_t nrows = B * C;
@@ -745,7 +745,7 @@ projection_2dgs_packed_fwd(
     CHECK_INPUT(Ks);
 
     uint32_t N = means.size(-2);          // number of gaussians
-    uint32_t B = means.numel() / (N * 3); // number of batches
+    uint32_t B = c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)); // number of batches
     uint32_t C = viewmats.size(-3);       // number of cameras
     auto opt = means.options();
 

--- a/gsplat/cuda/csrc/Projection.h
+++ b/gsplat/cuda/csrc/Projection.h
@@ -21,9 +21,10 @@
 #include <cstdint>
 
 #include "Cameras.h"
+#include "Common.h"
+#include "Lidars.h"
 #include "ExternalDistortion.h"
 #include "Cameras.cuh"
-#include "Ops.h"
 
 namespace at {
 class Tensor;

--- a/gsplat/cuda/csrc/Projection2DGSFused.cu
+++ b/gsplat/cuda/csrc/Projection2DGSFused.cu
@@ -227,9 +227,13 @@ __global__ void projection_2dgs_fused_fwd_kernel(
     // https://github.com/hbb1/diff-surfel-rasterization/issues/8#issuecomment-2138069016
     const float distance = sum(temp_point * M2 * M2);
 
-    // ill-conditioned primitives will have distance = 0.0f, we ignore them
-    if (distance == 0.0f)
+    // ill-conditioned primitives will have distance = 0.0f, we ignore them;
+    // zero radii so the culled-primitive sentinel matches the other cull paths.
+    if (distance == 0.0f) {
+        radii[idx * 2] = 0;
+        radii[idx * 2 + 1] = 0;
         return;
+    }
 
     const vec3 f = (1 / distance) * temp_point;
     const vec2 mean2d = vec2(sum(f * M0 * M2), sum(f * M1 * M2));

--- a/gsplat/cuda/csrc/Projection2DGSPacked.cu
+++ b/gsplat/cuda/csrc/Projection2DGSPacked.cu
@@ -508,7 +508,7 @@ void launch_projection_2dgs_packed_bwd_kernel(
     at::optional<at::Tensor> v_viewmats // [..., C, 4, 4] Optional
 ) {
     uint32_t N = means.size(-2);          // number of gaussians
-    uint32_t B = means.numel() / (N * 3); // number of batches
+    uint32_t B = (N == 0) ? 0 : means.numel() / (N * 3); // number of batches
     uint32_t C = viewmats.size(-3);       // number of cameras
     uint32_t nnz = camera_ids.size(0);
 

--- a/gsplat/cuda/csrc/Projection2DGSPacked.cu
+++ b/gsplat/cuda/csrc/Projection2DGSPacked.cu
@@ -256,7 +256,16 @@ void launch_projection_2dgs_packed_fwd_kernel(
     uint32_t blocks_per_row = (ncols + N_THREADS_PACKED - 1) / N_THREADS_PACKED;
 
     dim3 threads(N_THREADS_PACKED);
-    // limit on the number of blocks: [2**31 - 1, 65535, 65535]
+    // Each block-row maps one B*C batch-camera onto grid.y, so a larger B*C
+    // would silently issue an invalid launch -- reject it with a clear error.
+    TORCH_CHECK(
+        nrows <= kMaxCudaGridDimY,
+        "packed projection: B*C = ",
+        nrows,
+        " exceeds the CUDA grid.y limit of ",
+        kMaxCudaGridDimY,
+        " batch-camera rows per launch"
+    );
     dim3 grid(blocks_per_row, nrows, 1);
     int64_t shmem_size = 0; // No shared memory used in this kernel
 

--- a/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
+++ b/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
@@ -324,7 +324,16 @@ void launch_projection_ewa_3dgs_packed_fwd_kernel(
     uint32_t blocks_per_row = (ncols + N_THREADS_PACKED - 1) / N_THREADS_PACKED;
 
     dim3 threads(N_THREADS_PACKED);
-    // limit on the number of blocks: [2**31 - 1, 65535, 65535]
+    // Each block-row maps one B*C batch-camera onto grid.y, so a larger B*C
+    // would silently issue an invalid launch -- reject it with a clear error.
+    TORCH_CHECK(
+        nrows <= kMaxCudaGridDimY,
+        "packed projection: B*C = ",
+        nrows,
+        " exceeds the CUDA grid.y limit of ",
+        kMaxCudaGridDimY,
+        " batch-camera rows per launch"
+    );
     dim3 grid(blocks_per_row, nrows, 1);
     int64_t shmem_size = 0; // No shared memory used in this kernel
 

--- a/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
+++ b/gsplat/cuda/csrc/ProjectionEWA3DGSPacked.cu
@@ -714,7 +714,7 @@ void launch_projection_ewa_3dgs_packed_bwd_kernel(
 ) {
     uint32_t N = means.size(-2);          // number of gaussians
     uint32_t C = viewmats.size(-3);       // number of cameras
-    uint32_t B = means.numel() / (N * 3); // number of batches
+    uint32_t B = (N == 0) ? 0 : means.numel() / (N * 3); // number of batches
     uint32_t nnz = batch_ids.size(0);
 
     dim3 threads(256);

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -241,7 +241,7 @@ std::tuple<at::Tensor, at::Tensor> rasterize_to_indices_3dgs(
 
     auto opt = means2d.options();
     uint32_t N = means2d.size(-2); // number of gaussians
-    uint32_t I = means2d.numel() / (2 * N); // number of images
+    uint32_t I = (N == 0) ? 0 : means2d.numel() / (2 * N); // number of images
 
     uint32_t n_isects = flatten_ids.size(0);
 
@@ -558,7 +558,7 @@ std::tuple<at::Tensor, at::Tensor> rasterize_to_indices_2dgs(
 
     auto opt = means2d.options();
     uint32_t N = means2d.size(-2); // number of gaussians
-    uint32_t I = means2d.numel() / (2 * N); // number of images
+    uint32_t I = (N == 0) ? 0 : means2d.numel() / (2 * N); // number of images
 
     uint32_t n_isects = flatten_ids.size(0);
 

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -693,15 +693,6 @@ RasterizeToPixelsFromWorld3DGSFwdResult rasterize_to_pixels_from_world_3dgs_fwd(
         CHECK_INPUT(masks.value());
     }
 
-    if (external_distortion_params.has_value()) {
-        const auto& params = external_distortion_params.value();
-        TORCH_CHECK(params, "external_distortion_params intrusive_ptr is null");
-        CHECK_CONTIGUOUS(params->horizontal_poly);
-        CHECK_CONTIGUOUS(params->vertical_poly);
-        CHECK_CONTIGUOUS(params->horizontal_poly_inverse);
-        CHECK_CONTIGUOUS(params->vertical_poly_inverse);
-    }
-
     if (sample_counts.has_value()) {
         CHECK_INPUT(sample_counts.value());
     }
@@ -1300,15 +1291,6 @@ public:
         }
         if (v_render_normals.has_value()) {
             CHECK_INPUT(v_render_normals.value());
-        }
-
-        if (external_distortion_params.has_value()) {
-            const auto& params = external_distortion_params.value();
-            TORCH_CHECK(params, "external_distortion_params intrusive_ptr is null");
-            CHECK_CONTIGUOUS(params->horizontal_poly);
-            CHECK_CONTIGUOUS(params->vertical_poly);
-            CHECK_CONTIGUOUS(params->horizontal_poly_inverse);
-            CHECK_CONTIGUOUS(params->vertical_poly_inverse);
         }
 
         at::Tensor v_means = at::zeros_like(means);

--- a/gsplat/cuda/csrc/Rasterization.h
+++ b/gsplat/cuda/csrc/Rasterization.h
@@ -21,8 +21,9 @@
 #include <cstdint>
 #include <tuple>
 #include "Cameras.h"
+#include "Common.h"
 #include "Config.h"
-#include "Ops.h"
+#include "Lidars.h"
 #include "ExternalDistortion.h"
 
 namespace at {

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchBwd.cu
@@ -442,6 +442,10 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
             vec3 v_v_M_local = {0.f, 0.f, 0.f};
             vec3 v_w_M_local = {0.f, 0.f, 0.f};
 
+            // densification gradient: depth-scaled ray-transform gradient,
+            // reduced and atomic-accumulated like v_ray_transforms below.
+            vec2 v_densify_local = {0.f, 0.f};
+
             // 2D mean gradients, used if 2d gaussian weight is applied
             vec2 v_xy_local = {0.f, 0.f};
 
@@ -633,6 +637,15 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
                 }
             }
 
+            // Scale each lane's ray-transform z-gradient by depth (w_M.z) while
+            // w_M still holds the valid per-lane value; the reduction and
+            // atomicAdd below then accumulate the full densification gradient.
+            if (valid) {
+                v_densify_local = {
+                    v_u_M_local.z * w_M.z, v_v_M_local.z * w_M.z
+                };
+            }
+
             /**
              * ==================================================
              * Warp-level reduction to compute the sum of the gradients for each
@@ -645,6 +658,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
             warpSum(v_u_M_local, warp);
             warpSum(v_v_M_local, warp);
             warpSum(v_w_M_local, warp);
+            warpSum(v_densify_local, warp);
             if (v_means2d_abs != nullptr) {
                 warpSum(v_xy_abs_local, warp);
             }
@@ -681,6 +695,10 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
                 gpuAtomicAdd(v_ray_transforms_ptr + 7, v_w_M_local.y);
                 gpuAtomicAdd(v_ray_transforms_ptr + 8, v_w_M_local.z);
 
+                float *v_densify_ptr = (float *)(v_densify) + 2 * g;
+                gpuAtomicAdd(v_densify_ptr + 0, v_densify_local.x);
+                gpuAtomicAdd(v_densify_ptr + 1, v_densify_local.y);
+
                 float *v_xy_ptr = (float *)(v_means2d) + 2 * g;
                 gpuAtomicAdd(v_xy_ptr, v_xy_local.x);
                 gpuAtomicAdd(v_xy_ptr + 1, v_xy_local.y);
@@ -694,14 +712,6 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
                 gpuAtomicAdd(v_opacities + g, v_opacity_local);
             }
 
-            if (valid) {
-                float *v_densify_ptr = (float *)(v_densify) + 2 * g;
-                float *v_ray_transforms_ptr =
-                    (float *)(v_ray_transforms) + 9 * g;
-                float depth = w_M.z;
-                v_densify_ptr[0] = v_ray_transforms_ptr[2] * depth;
-                v_densify_ptr[1] = v_ray_transforms_ptr[5] * depth;
-            }
         }
     }
 }

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchFwd.cu
@@ -160,14 +160,25 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     bool inside = (i < image_height && j < image_width);
     bool done = !inside;
 
-    // when the mask is provided, render the background color and return
-    // if this tile is labeled as False
+    // when this tile is masked off (masks[tile_id] == False), write the
+    // background color and zero every other per-pixel output, then return —
+    // so no output buffer is left uninitialized.
     if (masks != nullptr && !masks[tile_id]) {
         if (inside) {
             for (uint32_t k = 0; k < CDIM; ++k) {
                 render_colors[pix_id * CDIM + k] =
                     backgrounds == nullptr ? 0.0f : backgrounds[k];
             }
+            render_alphas[pix_id] = 0.0f;
+            for (uint32_t k = 0; k < 3; ++k) {
+                render_normals[pix_id * 3 + k] = 0.0f;
+            }
+            if (render_distort != nullptr) {
+                render_distort[pix_id] = 0.0f;
+            }
+            render_median[pix_id] = 0.0f;
+            last_ids[pix_id] = 0;
+            median_ids[pix_id] = 0;
         }
         return;
     }

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
@@ -114,10 +114,11 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
         }
     }
 
-    // when the mask is provided, render the background color and return
-    // if this tile is labeled as False. Check each pixel individually: a
-    // single thread can straddle the image boundary when the tile is
-    // partially clipped, so some of its pixels may be in-bounds while
+    // when this tile is masked off (masks[tile_id] == False), write the
+    // background color and zero every other per-pixel output, then return —
+    // so no output buffer is left uninitialized. Check each pixel
+    // individually: a single thread can straddle the image boundary when the
+    // tile is partially clipped, so some of its pixels may be in-bounds while
     // others are OOB.
     if (masks != nullptr && !masks[tile_id]) {
 #pragma unroll
@@ -130,6 +131,8 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
                 render_colors[pix_id[p] * CDIM + k] =
                     backgrounds == nullptr ? 0.0f : backgrounds[k];
             }
+            render_alphas[pix_id[p]] = 0.0f;
+            last_ids[pix_id[p]] = 0;
         }
         return;
     }

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.h
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.h
@@ -21,8 +21,13 @@
 #include <cstdint>
 
 #include "Cameras.h"
+#include "Common.h"
+#include "Lidars.h"
 #include "ExternalDistortion.h"
-#include "Ops.h"
+
+namespace at {
+class Tensor;
+}
 
 namespace gsplat {
 

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
@@ -1030,12 +1030,17 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_bwd_kernel(
     // channels into the kernel functions and avoid necessary global memory
     // writes. This requires moving the channel padding from python to C side.
 
-    TORCH_CHECK(ftheta_coeffs, "ftheta_coeffs intrusive_ptr is null");
-    FThetaCameraDistortionDeviceParams ftheta_device_coeffs(*ftheta_coeffs);
+    FThetaCameraDistortionDeviceParams ftheta_device_coeffs(
+        gsplat::checked_deref(ftheta_coeffs, "ftheta_coeffs"));
     cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params = cuda::std::nullopt;
     if (external_distortion_params.has_value()) {
-        TORCH_CHECK(external_distortion_params.value(), "external_distortion_params intrusive_ptr is null");
-        external_distortion_device_params = extdist::BivariateWindshieldModelDeviceParams(*external_distortion_params.value());
+        const auto& params = gsplat::checked_deref(
+            external_distortion_params.value(), "external_distortion_params");
+        CHECK_CONTIGUOUS(params.horizontal_poly);
+        CHECK_CONTIGUOUS(params.vertical_poly);
+        CHECK_CONTIGUOUS(params.horizontal_poly_inverse);
+        CHECK_CONTIGUOUS(params.vertical_poly_inverse);
+        external_distortion_device_params = extdist::BivariateWindshieldModelDeviceParams(params);
     }
 
     cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_device_coeffs = cuda::std::nullopt;

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
@@ -1007,7 +1007,13 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_bwd_kernel(
     (void)batches_per_tile;  // only used for the shape check below
 
     uint32_t N = packed ? 0 : means.size(-2);   // number of gaussians
-    uint32_t B = means.numel() / (N * 3);       // number of batches
+    // Number of batches: product of the leading dims. Computed this way rather
+    // than means.numel()/(N*3) because:
+    // - the division is undefined for an empty gaussian set (N == 0)
+    // - the leading-dim product matches how the calling op sizes its outputs,
+    //   so an empty input is a clean no-op instead of crashing
+    uint32_t B = static_cast<uint32_t>(
+        c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)));
     uint32_t C = viewmats0.size(-3);            // number of cameras
     uint32_t I = B * C;                         // number of images
     uint32_t tile_height = tile_offsets.size(-2);

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
@@ -1400,7 +1400,13 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
     TORCH_CHECK(!packed, "packed mode not supported for 3DGUT forward rasterization");
 
     const uint32_t N = packed ? 0u : static_cast<uint32_t>(means.size(-2));
-    const uint32_t B = static_cast<uint32_t>(means.numel() / (N * 3));
+    // Number of batches: product of the leading dims. Computed this way rather
+    // than means.numel()/(N*3) because:
+    // - the division is undefined for an empty gaussian set (N == 0)
+    // - the leading-dim product matches how the calling op sizes its outputs,
+    //   so an empty input renders a clean background image instead of crashing
+    const uint32_t B = static_cast<uint32_t>(
+        c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)));
     const uint32_t C = static_cast<uint32_t>(viewmats0.size(-3));
     const uint32_t I = B * C;
     const uint32_t tile_height = static_cast<uint32_t>(tile_offsets.size(-2));

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
@@ -1415,15 +1415,19 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
     const int32_t pixels_per_tile = tile_size * tile_size;
 
     TORCH_CHECK(ut_params, "ut_params intrusive_ptr is null");
-    TORCH_CHECK(ftheta_coeffs, "ftheta_coeffs intrusive_ptr is null");
-    FThetaCameraDistortionDeviceParams ftheta_device_coeffs(*ftheta_coeffs);
+    FThetaCameraDistortionDeviceParams ftheta_device_coeffs(
+        gsplat::checked_deref(ftheta_coeffs, "ftheta_coeffs"));
     DeviceExternalDistortionParamsOpt external_distortion_device_params =
         cuda::std::nullopt;
     if (external_distortion_params.has_value()) {
-        TORCH_CHECK(external_distortion_params.value(),
-                    "external_distortion_params intrusive_ptr is null");
-        external_distortion_device_params = extdist::BivariateWindshieldModelDeviceParams(
-            *external_distortion_params.value());
+        const auto& params = gsplat::checked_deref(
+            external_distortion_params.value(), "external_distortion_params");
+        CHECK_CONTIGUOUS(params.horizontal_poly);
+        CHECK_CONTIGUOUS(params.vertical_poly);
+        CHECK_CONTIGUOUS(params.horizontal_poly_inverse);
+        CHECK_CONTIGUOUS(params.vertical_poly_inverse);
+        external_distortion_device_params =
+            extdist::BivariateWindshieldModelDeviceParams(params);
     }
 
     DeviceLidarParamsOpt lidar_device_coeffs = cuda::std::nullopt;

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
@@ -512,7 +512,13 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_impl(
     TORCH_CHECK(!packed, "packed mode not supported for 3DGUT forward rasterization");
 
     const uint32_t N = packed ? 0 : means.size(-2);   // number of gaussians
-    const uint32_t B = means.numel() / (N * 3);       // number of batches
+    // Number of batches: product of the leading dims. Computed this way rather
+    // than means.numel()/(N*3) because:
+    // - the division is undefined for an empty gaussian set (N == 0)
+    // - the leading-dim product matches how the calling op sizes its outputs,
+    //   so an empty input renders a clean background image instead of crashing
+    const uint32_t B = static_cast<uint32_t>(
+        c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)));
     const uint32_t C = viewmats0.size(-3);            // number of cameras
     const uint32_t I = B * C;                         // number of images
     const uint32_t grid_h = isect_offsets.size(-2);

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
@@ -526,12 +526,17 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_impl(
     const uint32_t n_isects = flatten_ids.size(0);
 
     TORCH_CHECK(ut_params, "ut_params intrusive_ptr is null");
-    TORCH_CHECK(ftheta_coeffs, "ftheta_coeffs intrusive_ptr is null");
-    FThetaCameraDistortionDeviceParams ftheta_device_coeffs(*ftheta_coeffs);
+    FThetaCameraDistortionDeviceParams ftheta_device_coeffs(
+        gsplat::checked_deref(ftheta_coeffs, "ftheta_coeffs"));
     cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params = cuda::std::nullopt;
     if (external_distortion_params.has_value()) {
-        TORCH_CHECK(external_distortion_params.value(), "external_distortion_params intrusive_ptr is null");
-        external_distortion_device_params = extdist::BivariateWindshieldModelDeviceParams(*external_distortion_params.value());
+        const auto& params = gsplat::checked_deref(
+            external_distortion_params.value(), "external_distortion_params");
+        CHECK_CONTIGUOUS(params.horizontal_poly);
+        CHECK_CONTIGUOUS(params.vertical_poly);
+        CHECK_CONTIGUOUS(params.horizontal_poly_inverse);
+        CHECK_CONTIGUOUS(params.vertical_poly_inverse);
+        external_distortion_device_params = extdist::BivariateWindshieldModelDeviceParams(params);
     }
 
     cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_device_coeffs = cuda::std::nullopt;

--- a/gsplat/cuda/csrc/TorchUtils.h
+++ b/gsplat/cuda/csrc/TorchUtils.h
@@ -7,6 +7,7 @@
 
 #include <ATen/core/grad_mode.h>
 #include <ATen/core/Tensor.h>
+#include <c10/util/intrusive_ptr.h>
 #include <type_traits>
 
 namespace gsplat {
@@ -125,6 +126,30 @@ template <class PointerT, class ScalarT>
 inline PointerT *data_ptr_as_or_null(bool enabled, const at::Tensor &tensor)
 {
     return enabled ? data_ptr_as<PointerT, ScalarT>(tensor) : nullptr;
+}
+
+/** Dereference a required intrusive_ptr, or raise a clear error if unset.
+ *
+ * `name` is woven into the error message so a missing field reports itself
+ * by name instead of crashing on a null dereference.
+ */
+template <class T>
+inline const T &checked_deref(const c10::intrusive_ptr<T> &ptr, const char *name)
+{
+    TORCH_CHECK(ptr, name, " must be set");
+    return *ptr;
+}
+
+/** Dereference a required `at::optional<intrusive_ptr>`, or raise a clear error
+ * if the optional is empty or the pointer it holds is null. Both failure modes
+ * report through the same `name`, so the deref site needs no separate presence
+ * check on the optional.
+ */
+template <class T>
+inline const T &checked_deref(const at::optional<c10::intrusive_ptr<T>> &opt, const char *name)
+{
+    TORCH_CHECK(opt.has_value(), name, " must be set");
+    return checked_deref(*opt, name);
 }
 
 } // namespace gsplat

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -84,6 +84,12 @@ enum RendererConfig {
 };
 
 #define N_THREADS_PACKED 256
+
+// CUDA caps grid.y (and grid.z) at 65535; only grid.x reaches 2^31 - 1. Kernels
+// that map a batch (or batch-camera) dimension onto grid.y must reject launches
+// that would exceed this.
+constexpr uint32_t kMaxCudaGridDimY = 65535;
+
 #define ALPHA_THRESHOLD (1.f / 255.f)
 // GAUSSIAN_EXTEND determines where the gaussian is truncated in standard deviations."
 #define GAUSSIAN_EXTEND 3.33f

--- a/gsplat/cuda/include/Lidars.h
+++ b/gsplat/cuda/include/Lidars.h
@@ -43,9 +43,9 @@ struct FOVDevice
 {
     FOVDevice() = default;
 
-    FOVDevice(const c10::intrusive_ptr<FOV> &fov)
-        : start{fov->start}
-        , span{fov->span}
+    FOVDevice(const FOV &fov)
+        : start{fov.start}
+        , span{fov.span}
     {
     }
 

--- a/gsplat/profile.py
+++ b/gsplat/profile.py
@@ -336,7 +336,23 @@ _2DGS_RENDER_MODE_MAP = {
 
 _2DGS_DISTORTION_RENDER_MODE = "RGB+ED"
 _2DGS_DISTORTION_RENDER_MODES = {"D", "ED", "RGB+D", "RGB+ED"}
-_2DGS_COLOR_DEPTH_RENDER_MODES = {"RGB+D", "RGB+ED"}
+
+# Render modes that route a color block through the rasterizer, and those that
+# append a depth channel onto the feature tensor. Mirror the predicates in
+# gsplat.rendering (render_mode_has_color / render_mode_has_depth_channel),
+# kept local so the channel-count math stays importable without the CUDA
+# package (gsplat.rendering pulls in the compiled wrappers).
+_COLOR_RENDER_MODES = {"RGB", "RGB-d", "RGB-Ed", "RGB+D", "RGB+ED"}
+_DEPTH_CHANNEL_RENDER_MODES = {
+    "d",
+    "Ed",
+    "D",
+    "ED",
+    "RGB-d",
+    "RGB-Ed",
+    "RGB+D",
+    "RGB+ED",
+}
 
 _PROFILE_LOSS_ALIASES = {
     "gaussian": "gaussian_fused",
@@ -643,19 +659,14 @@ def _validate_profile_loss_overrides(
 def _normalize_2dgs_replay_inputs(replay_inputs: dict[str, Any]) -> list[str]:
     """Apply final 2DGS tensor-shape conversions after mode/override setup."""
     notes: list[str] = []
-    render_mode = replay_inputs.get("render_mode", "RGB")
     sh_degree = replay_inputs.get("sh_degree")
 
-    # The 2DGS RGB+depth path concatenates `colors` with projected depths.
-    # With unpacked projection, depths are shaped [..., C, N, 1], so a plain
-    # [..., N, D] color tensor must be expanded to [..., C, N, D] once before
-    # the measured loop. Keep the converted tensor as a leaf so repeated
+    # rasterize_to_pixels_2dgs requires per-camera colors [..., C, N, D]. The SH
+    # path produces that shape during SH evaluation, but post-activation colors
+    # (sh_degree=None) arrive scene-shaped [..., N, D], so expand them once
+    # before the measured loop. Keep the converted tensor as a leaf so repeated
     # backward iterations can clear `.grad` through `_clear_replay_grads()`.
-    if (
-        render_mode in _2DGS_COLOR_DEPTH_RENDER_MODES
-        and sh_degree is None
-        and not replay_inputs.get("packed", False)
-    ):
+    if sh_degree is None and not replay_inputs.get("packed", False):
         means = replay_inputs["means"]
         viewmats = replay_inputs["viewmats"]
         colors = replay_inputs["colors"]
@@ -672,8 +683,100 @@ def _normalize_2dgs_replay_inputs(replay_inputs: dict[str, Any]) -> list[str]:
             )
             notes.append(
                 "expanded colors from scene-shaped [..., N, D] to "
-                "camera-shaped [..., C, N, D] for 2DGS RGB+depth replay"
+                "camera-shaped [..., C, N, D] for 2DGS replay"
             )
+
+    return notes
+
+
+def _resize_color_last_dim(tensor: torch.Tensor, target: int) -> torch.Tensor:
+    """Resize ``tensor``'s last dim to ``target`` and return a fresh grad leaf.
+
+    Slices when ``target`` is below the current width, tiles-and-truncates when
+    above it. The result is detached/cloned and carries the source's
+    ``requires_grad`` so repeated backward iterations can clear ``.grad``
+    through ``_clear_replay_grads()`` (mirroring ``_normalize_2dgs_replay_inputs``).
+    """
+    cur = tensor.shape[-1]
+    if target <= cur:
+        resized = tensor[..., :target]
+    else:
+        reps = (target + cur - 1) // cur
+        resized = tensor.repeat(*([1] * (tensor.dim() - 1)), reps)[..., :target]
+    return resized.detach().clone().requires_grad_(tensor.requires_grad)
+
+
+def _apply_channel_override(replay_inputs: dict[str, Any], channels: int) -> list[str]:
+    """Resize the templated channel count (CDIM) of a replay to ``channels``.
+
+    The rasterizer templates on the *concatenated* feature width
+    ``colors.shape[-1] + extra_signals.shape[-1] (+1 for a depth channel)``, so
+    this drives that effective count to ``channels`` for any captured scene.
+    Color SH is dropped (``sh_degree -> None``, DC band kept as the base) so the
+    color block's last dim can be sliced/tiled freely; the extra-signals and
+    background-blend paths are preserved and resized to keep the post-concat
+    width equal to ``channels``. Channel *values* are irrelevant for kernel
+    timing: only the count drives the template / register / shared-memory
+    footprint, and geometry plus opacities (the alpha early-out) are untouched.
+    """
+    if channels < 1:
+        raise ValueError(f"--channels must be >= 1, got {channels}")
+    colors = replay_inputs.get("colors")
+    if colors is None:
+        raise ValueError("--channels requires `colors` in the replay inputs")
+
+    render_mode = replay_inputs.get("render_mode", "RGB")
+    has_depth_channel = render_mode in _DEPTH_CHANNEL_RENDER_MODES
+    has_color = render_mode in _COLOR_RENDER_MODES
+    if has_depth_channel and not has_color:
+        raise ValueError(
+            f"--channels needs a color-bearing render_mode; {render_mode!r} "
+            "renders depth only, so `colors` never reaches the channel template"
+        )
+    # rasterization() appends one depth channel onto the color tensor for
+    # color+depth modes (RGB+D / RGB+ED / RGB-d / RGB-Ed); pure color adds none.
+    depth_extra = 1 if has_depth_channel else 0
+
+    notes: list[str] = []
+    sh_degree = replay_inputs.get("sh_degree")
+    if sh_degree is not None:
+        bands = (sh_degree + 1) ** 2
+        if colors.dim() < 3 or colors.shape[-2] < bands:
+            raise ValueError(
+                f"--channels expects SH colors [N, K, D] with K >= {bands} when "
+                f"sh_degree={sh_degree}, got shape {tuple(colors.shape)}"
+            )
+        colors = colors[..., 0, :]  # [N, K, D] -> DC band [N, D]
+        replay_inputs["sh_degree"] = None
+        notes.append("dropped color SH and took the DC band as the color base")
+
+    cur = colors.shape[-1]
+    if cur < 1:
+        raise ValueError(
+            f"--channels needs a non-empty source color channel dim, got {cur}"
+        )
+
+    extra_signals = replay_inputs.get("extra_signals")
+    e = extra_signals.shape[-1] if extra_signals is not None else 0
+    color_target = channels - e - depth_extra
+    if color_target < 1:
+        raise ValueError(
+            f"--channels={channels} leaves no room for colors after reserving "
+            f"{e} extra-signal + {depth_extra} depth channel(s); "
+            f"needs >= {e + depth_extra + 1}"
+        )
+
+    replay_inputs["colors"] = _resize_color_last_dim(colors, color_target)
+    notes.append(f"resized color channels {cur} -> {color_target}")
+    if extra_signals is not None:
+        notes.append(f"kept {e} extra-signal channel(s); effective CDIM = {channels}")
+
+    backgrounds = replay_inputs.get("backgrounds")
+    if backgrounds is not None:
+        bg_cur = backgrounds.shape[-1]
+        bg_target = channels - depth_extra
+        replay_inputs["backgrounds"] = _resize_color_last_dim(backgrounds, bg_target)
+        notes.append(f"resized background channels {bg_cur} -> {bg_target}")
 
     return notes
 
@@ -1221,6 +1324,21 @@ def main() -> None:
             "override accepts mixedbatch or parallelbatch."
         ),
     )
+    parser.add_argument(
+        "--channels",
+        type=int,
+        default=None,
+        metavar="C",
+        help=(
+            "Resize the replay's templated channel count (CDIM) to C before "
+            "profiling, so one captured scene can drive any compiled channel "
+            "count. The color block is sliced/tiled and color SH is dropped; "
+            "extra_signals and backgrounds are preserved and resized so the "
+            "post-concat width equals C. Errors on depth-only render modes. C "
+            "must be one of the channel counts compiled into the build (set via "
+            "the NUM_CHANNELS build env var)."
+        ),
+    )
     args = parser.parse_args()
     if args.ensure_rays and args.no_rays:
         parser.error("--ensure-rays and --no-rays are mutually exclusive")
@@ -1329,6 +1447,15 @@ def main() -> None:
         print(
             f"[gsplat.profile] override {name}={value!r} " f"({type(value).__name__})"
         )
+
+    if args.channels is not None:
+        try:
+            channel_notes = _apply_channel_override(replay_inputs, args.channels)
+        except ValueError as exc:
+            parser.error(str(exc))
+        workload_notes.extend(channel_notes)
+        for note in channel_notes:
+            print(f"[gsplat.profile] --channels: {note}")
 
     try:
         _validate_profile_loss_overrides(profile_losses, replay_name, replay_inputs)

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -61,10 +61,10 @@ from .distributed import (
 )
 from .utils import depth_to_normal, get_projection_matrix
 
+
 # Gaussian depth modes (D/ED): use projection depth (controlled by global_z_order)
 # Hit distance modes (d/Ed): compute along-ray distance in rasterization
 RenderMode = Literal["RGB", "d", "Ed", "D", "ED", "RGB-d", "RGB-Ed", "RGB+D", "RGB+ED"]
-
 RasterizeMode = Literal["classic", "antialiased"]
 
 
@@ -197,6 +197,52 @@ def _validate_nccl_process_group() -> None:
         )
 
 
+def normalize_features_layout(
+    features: Tensor,
+    batch_dims: tuple,
+    C: int,
+    trailing_dims: tuple,
+    batch_ids: Optional[Tensor] = None,
+    camera_ids: Optional[Tensor] = None,
+    feature_ids: Optional[Tensor] = None,
+) -> Tensor:
+    """Normalize per-view or per-gaussian feature tensor layout to (nnz, *trailing) or (*batch_dims, C, *trailing)."""
+    B = math.prod(batch_dims)
+    N = features.shape[-(len(trailing_dims) + 1)]
+
+    # per-view features?
+    if (
+        features.shape
+        == batch_dims
+        + (
+            C,
+            N,
+        )
+        + trailing_dims
+    ):
+        # packed?
+        if feature_ids is not None:
+            # [..., C, N, *trailing] -> [nnz, *trailing]
+            return features.view(B, C, N, *trailing_dims)[
+                batch_ids, camera_ids, feature_ids
+            ]
+        else:
+            # already (..., C, N, *trailing)
+            return features
+    # per-gaussian features?
+    else:
+        assert features.shape == (*batch_dims, N, *trailing_dims)
+        # packed?
+        if feature_ids is not None:
+            # [..., N, *trailing] -> [nnz, *trailing]
+            return features.view(B, N, *trailing_dims)[batch_ids, feature_ids]
+        else:
+            # (..., N, *trailing) -> (..., C, N, *trailing)
+            return torch.broadcast_to(
+                features.unsqueeze(len(batch_dims)), batch_dims + (C, N, *trailing_dims)
+            )
+
+
 def _compute_view_dirs_packed(
     means: Tensor,  # [..., N, 3]
     campos: Tensor,  # [..., C, 3]
@@ -272,52 +318,6 @@ def _compute_view_dirs_packed(
     return dirs
 
 
-def normalize_features_layout(
-    features: Tensor,
-    batch_dims: tuple,
-    C: int,
-    trailing_dims: tuple,
-    batch_ids: Optional[Tensor] = None,
-    camera_ids: Optional[Tensor] = None,
-    feature_ids: Optional[Tensor] = None,
-) -> Tensor:
-    """Normalize per-view or per-gaussian feature tensor layout to (nnz, *trailing) or (*batch_dims, C, *trailing)."""
-    B = math.prod(batch_dims)
-    N = features.shape[-(len(trailing_dims) + 1)]
-
-    # per-view features?
-    if (
-        features.shape
-        == batch_dims
-        + (
-            C,
-            N,
-        )
-        + trailing_dims
-    ):
-        # packed?
-        if feature_ids is not None:
-            # [..., C, N, *trailing] -> [nnz, *trailing]
-            return features.view(B, C, N, *trailing_dims)[
-                batch_ids, camera_ids, feature_ids
-            ]
-        else:
-            # already (..., C, N, *trailing)
-            return features
-    # per-gaussian features?
-    else:
-        assert features.shape == (*batch_dims, N, *trailing_dims)
-        # packed?
-        if feature_ids is not None:
-            # [..., N, *trailing] -> [nnz, *trailing]
-            return features.view(B, N, *trailing_dims)[batch_ids, feature_ids]
-        else:
-            # (..., N, *trailing) -> (..., C, N, *trailing)
-            return torch.broadcast_to(
-                features.unsqueeze(len(batch_dims)), batch_dims + (C, N, *trailing_dims)
-            )
-
-
 def viewmat_to_camera_position(viewmats: Tensor) -> Tensor:
     """Camera position in world from world-to-camera 4x4 matrix without full inverse.
 
@@ -348,13 +348,20 @@ def compute_directions(
         campos = 0.5 * (campos + campos_rs)
 
     # Compute the direction of each gaussian wrt. its camera
-    if gaussian_ids is None:
+    if gaussian_ids is None and camera_ids is None and batch_ids is None:
         dirs = means[..., None, :, :] - campos[..., None, :]
     else:
         B = math.prod(batch_dims)
         C = campos.shape[-2]
         dirs = _compute_view_dirs_packed(
-            means, campos, batch_ids, camera_ids, gaussian_ids, indptr, B, C
+            means,
+            campos,
+            batch_ids,
+            camera_ids,
+            gaussian_ids,
+            indptr,
+            B,
+            C,
         )  # [nnz, 3]
     return F.normalize(dirs, p=2, dim=-1)
 
@@ -2239,11 +2246,10 @@ def rasterization_2dgs(
         tile_size: The size of the tiles for rasterization. Default is 16.
             (Note: other values are not tested)
         backgrounds: The background colors. [C, D]. Default is None.
-        render_mode: The rendering mode. Supported modes are "RGB", "d", "Ed", "D", "ED",
-            "RGB-d", "RGB-Ed", "RGB+D", and "RGB+ED". "RGB" renders the colored image.
-            Gaussian depth modes (D, ED, RGB+D, RGB+ED) use projection depth. Hit distance
-            modes (d, Ed, RGB-d, RGB-Ed) compute along-ray distance. Expected modes (Ed, ED)
-            are normalized by opacity. Default is "RGB".
+        render_mode: The rendering mode. Supported modes are "RGB", "Ed", "D", "ED",
+            "RGB+D", and "RGB+ED". "RGB" renders the colored image.
+            Gaussian depth modes (D, ED, RGB+D, RGB+ED) use projection depth.
+            Expected modes (Ed, ED) are normalized by opacity. Default is "RGB".
         sparse_grad (Experimental): If true, the gradients for {means, quats, scales} will be stored in
             a COO sparse layout. This can be helpful for saving memory. Default is False.
         absgrad: If true, the absolute gradients of the projected 2D means

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -838,6 +838,7 @@ def rasterization(
         or tangential_coeffs is not None
         or thin_prism_coeffs is not None
         or ftheta_coeffs is not None
+        or external_distortion_coeffs is not None
         or rolling_shutter != RollingShutterType.GLOBAL
     ):
         assert (

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -178,6 +178,25 @@ def _validate_3dgut_rasterize_mode(
         )
 
 
+def _validate_nccl_process_group() -> None:
+    """Validate that the default process group is available and uses NCCL."""
+
+    if not torch.distributed.is_available():
+        raise ValueError("distributed=True requires torch.distributed to be available.")
+    if not torch.distributed.is_initialized():
+        raise ValueError(
+            "distributed=True requires an initialized default torch.distributed "
+            "process group."
+        )
+
+    backend = torch.distributed.get_backend()
+    if str(backend).lower() != "nccl":
+        raise ValueError(
+            "distributed=True currently supports only the default NCCL process "
+            f"group; got backend '{backend}'."
+        )
+
+
 def _compute_view_dirs_packed(
     means: Tensor,  # [..., N, 3]
     campos: Tensor,  # [..., C, 3]
@@ -725,6 +744,49 @@ def rasterization(
     assert Ks.shape == batch_dims + (C, 3, 3), Ks.shape
     if rays is not None:
         assert_shape("rays", rays, batch_dims + (C, H, W, 6))
+
+    if distributed:
+        # Distributed rasterization supports only classic 3DGS pinhole; the other
+        # modes have no correct distributed path, so reject them here.
+        unsupported_reasons = []
+        if batch_dims != ():
+            unsupported_reasons.append("batch dimensions")
+        if sparse_grad:
+            unsupported_reasons.append("sparse_grad=True")
+        if absgrad:
+            unsupported_reasons.append("absgrad=True")
+        if with_ut:
+            unsupported_reasons.append("with_ut=True")
+        if with_eval3d:
+            unsupported_reasons.append("with_eval3d=True")
+        if return_normals:
+            unsupported_reasons.append("return_normals=True")
+        if rays is not None:
+            unsupported_reasons.append("rays")
+        if camera_model != "pinhole":
+            unsupported_reasons.append(f"camera_model='{camera_model}'")
+        if not global_z_order:
+            unsupported_reasons.append("global_z_order=False")
+        if rolling_shutter != RollingShutterType.GLOBAL or viewmats_rs is not None:
+            unsupported_reasons.append("rolling shutter")
+        if (
+            radial_coeffs is not None
+            or tangential_coeffs is not None
+            or thin_prism_coeffs is not None
+            or ftheta_coeffs is not None
+            or external_distortion_coeffs is not None
+        ):
+            unsupported_reasons.append("camera distortion")
+        if lidar_coeffs is not None:
+            unsupported_reasons.append("lidar coefficients")
+        if unsupported_reasons:
+            raise ValueError(
+                "distributed=True currently supports only unbatched classic 3DGS "
+                "pinhole rasterization with the default NCCL process group. "
+                "Unsupported option(s): " + ", ".join(unsupported_reasons) + "."
+            )
+        _validate_nccl_process_group()
+
     assert global_z_order or with_ut, "global_z_order can be false only if with_ut=True"
     assert (camera_model == "lidar") == (
         lidar_coeffs is not None
@@ -752,9 +814,10 @@ def rasterization(
                 and features.shape[:-1] == (*batch_dims, C, N)
             ), f"{name}'s shape {features.shape=} must be either {(*batch_dims, N, channels)} or {(*batch_dims, C, N, channels)}"
             if distributed:
-                assert (
-                    features.dim() == num_batch_dims + 2
-                ), f"Distributed mode only supports per-Gaussian {name}."
+                if features.dim() != num_batch_dims + 2:
+                    raise ValueError(
+                        f"distributed=True only supports per-Gaussian {name}."
+                    )
         else:
             # treat features as SH coefficients in the deduplicated [N, K, D] layout,
             # shared across batch and camera dims. Allowing for activating partial SH bands.
@@ -769,9 +832,6 @@ def rasterization(
 
     if extra_signals is not None:
         check_features(extra_signals, extra_signals_sh_degree, "extra signals")
-
-    if absgrad:
-        assert not distributed, "AbsGrad is not supported in distributed mode."
 
     if (
         radial_coeffs is not None

--- a/libs/geometry/functional/test_quaternion.py
+++ b/libs/geometry/functional/test_quaternion.py
@@ -597,11 +597,10 @@ class TestQuaternionOperations(unittest.TestCase):
         q2_seed = torch.randn(n, 4, device="cuda", dtype=torch.float32)
         proj = (q2_seed * q1_data).sum(dim=-1, keepdim=True) * q1_data
         q2_orthogonal = torch.nn.functional.normalize(q2_seed - proj, dim=-1)
-        # Avoid the nondifferentiable hemisphere boundary at dot(q1, q2) == 0.
-        # The CUDA kernel and PyTorch reference both branch on the dot sign;
-        # keeping a small positive margin makes this a stable backward parity
-        # test instead of a comparison of two valid branch-side choices.
-        q2_data = torch.nn.functional.normalize(q2_orthogonal + 0.25 * q1_data, dim=-1)
+        # Bias q2 toward q1 so dot(q1, q2) is safely positive, keeping the pair
+        # off the slerp shortest-path sign-flip boundary (dot == 0) where the
+        # gradient is ill-conditioned and the CUDA / reference branches diverge.
+        q2_data = torch.nn.functional.normalize(0.3 * q1_data + q2_orthogonal, dim=-1)
         q1 = q1_data.requires_grad_()
         q2 = q2_data.requires_grad_()
         t = (

--- a/libs/geometry/kernels/cuda/build.py
+++ b/libs/geometry/kernels/cuda/build.py
@@ -135,7 +135,7 @@ def build_and_load_geometry_cuda():
 
     module_exists = os.path.exists(
         os.path.join(build_dir, f"{build_params.name}.so")
-    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.lib"))
+    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.pyd"))
 
     ctx = (
         _status_context(

--- a/libs/sensors/kernels/cuda/build.py
+++ b/libs/sensors/kernels/cuda/build.py
@@ -138,7 +138,7 @@ def build_and_load_sensors_cuda():
     file (older than GSPLAT_BUILD_LOCK_AGE_S seconds) is removed before the
     build to avoid blocking on a crashed previous attempt.
 
-    If jit.load() fails but a pre-built .so/.lib already exists, falls back to
+    If jit.load() fails but a pre-built .so/.pyd already exists, falls back to
     importing the cached artefact directly.
 
     Returns:
@@ -182,7 +182,7 @@ def build_and_load_sensors_cuda():
 
     module_exists = os.path.exists(
         os.path.join(build_dir, f"{build_params.name}.so")
-    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.lib"))
+    ) or os.path.exists(os.path.join(build_dir, f"{build_params.name}.pyd"))
     ctx = (
         _status_context("gsplat_sensors: compiling registration extension...")
         if (not module_exists or build_params_changed)

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ if os.path.exists(_version_file):
 URL = "https://github.com/nerfstudio-project/gsplat"
 
 BUILD_NO_CUDA = os.getenv("BUILD_NO_CUDA", "0") == "1"
+BUILD_EXPERIMENTAL = os.getenv("BUILD_EXPERIMENTAL", "1") == "1"
 
 
 def _detect_cupy_requirement() -> str:
@@ -214,6 +215,9 @@ def get_extensions():
         },
         extra_link_args=params.extra_ldflags,
     )
+
+    if not BUILD_EXPERIMENTAL:
+        return [gsplat_ext]
 
     # --- experimental Inference render extension ---
     inference_build = _load_build_module(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,9 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 _LIBS_TESTPATH_TO_PACKAGE = (
     ("libs/geometry/functional", "gsplat_geometry"),
     ("libs/scene/components", "gsplat_scene"),
+    ("libs/scene/functional", "gsplat_scene"),
+    ("libs/scene/test_package_imports.py", "gsplat_scene"),
+    ("libs/sensors", "gsplat_sensors"),
     ("libs/stage/components", "gsplat_stage"),
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,9 +30,7 @@ from typing import List, Optional
 import pytest
 import torch
 import torch.distributed
-
 from tests.av_helpers import av_trainer, make_av_splats, make_av_scene
-
 
 # Default fraction of *post-CUDA-context* free VRAM the test process is
 # allowed to use. Caps the PyTorch caching allocator so an over-allocation

--- a/tests/cpp/test_mathutils.cpp
+++ b/tests/cpp/test_mathutils.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <ostream>
+
+#include "MathUtils.h"
+
+// bits_for_count() is the field width used to pack the (image, tile) id into
+// the high 32 bits of an intersection sort key. Every pack and unpack site
+// must agree on it, so this pins the contract -- especially the power-of-two
+// boundary, where the old floor(log2)+1 formula disagreed by one bit and a
+// packer/unpacker mismatch corrupts the decoded ids.
+//
+// Pytest owns discovery/execution via tests/test_cpp.py; this calls the gsplat
+// C++ helper directly.
+
+namespace {
+
+struct SmallCountCase {
+    int64_t count;
+    uint32_t expected_bits;
+
+    // Let GoogleTest print the case (e.g. in --gtest_list_tests and failure
+    // messages) instead of dumping the raw bytes of the struct. Defined in
+    // class as a hidden friend so it travels with the struct and is found via
+    // ADL.
+    friend std::ostream &operator<<(std::ostream &os, const SmallCountCase &c) {
+        return os << "{count=" << c.count
+                  << ", expected_bits=" << c.expected_bits << "}";
+    }
+};
+
+class BitsForCountSmall : public ::testing::TestWithParam<SmallCountCase> {};
+
+TEST_P(BitsForCountSmall, MatchesExpectedWidth) {
+    const SmallCountCase param = GetParam();
+    EXPECT_EQ(gsplat::bits_for_count(param.count), param.expected_bits)
+        << "count = " << param.count;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SmallCounts,
+    BitsForCountSmall,
+    ::testing::Values(
+        SmallCountCase{0, 0u},
+        SmallCountCase{1, 0u},
+        SmallCountCase{2, 1u},
+        SmallCountCase{3, 2u},
+        SmallCountCase{4, 2u},
+        SmallCountCase{5, 3u},
+        SmallCountCase{7, 3u},
+        SmallCountCase{8, 3u},
+        SmallCountCase{9, 4u}));
+
+TEST(BitsForCount, PowersOfTwoNeedKBits) {
+    // 2^k items use indices 0..2^k-1, which need exactly k bits. The old
+    // floor(log2)+1 formula returned k+1 here -- the regression this guards.
+    for (uint32_t k = 1; k <= 31; ++k) {
+        const int64_t count = int64_t{1} << k;
+        EXPECT_EQ(gsplat::bits_for_count(count), k) << "count = 2^" << k;
+        EXPECT_EQ(gsplat::bits_for_count(count + 1), k + 1)
+            << "count = 2^" << k << " + 1";
+    }
+}
+
+TEST(BitsForCount, WidthMinimallyIndexesMaxValue) {
+    // The width must hold the largest index (count - 1) and be minimal: one
+    // fewer bit must NOT suffice.
+    for (int64_t count = 2; count <= 4096; ++count) {
+        const uint32_t bits = gsplat::bits_for_count(count);
+        const int64_t max_index = count - 1;
+        EXPECT_LE(max_index, (int64_t{1} << bits) - 1) << "count = " << count;
+        EXPECT_GT(max_index, (int64_t{1} << (bits - 1)) - 1) << "count = " << count;
+    }
+}
+
+} // namespace

--- a/tests/cpp/test_raster_eval3d.cpp
+++ b/tests/cpp/test_raster_eval3d.cpp
@@ -14,6 +14,7 @@
 #include <torch/torch.h>
 
 #include "Config.h"
+#include "ExternalDistortion.h"
 #include "Ops.h"
 #include "PrimingChainEncoding.h"
 #include "PrimingChainEncoding.cuh"
@@ -838,4 +839,65 @@ TEST_P(InvalidRayStateTest, SkipsBatchStateForInvalidRays)
     EXPECT_EQ(
         compose_c_stop_i32.max().cpu().item<int32_t>(),
         static_cast<int32_t>(gsplat::COMPOSE_C_STOP_INVALID_RAY));
+}
+
+// The external-distortion contiguity checks live at the launcher deref site
+// rather than the op layer. A non-contiguous polynomial must therefore be
+// rejected by the from-world launcher itself -- this pins that the deref-site
+// consolidation cannot silently drop the guard in a future refactor.
+TEST_P(FwdBatchStateTest, NonContiguousExternalDistortionPolyThrows)
+{
+    Eval3DScene &scene = this->scene();
+
+    const torch::TensorOptions options = torch::TensorOptions()
+                                             .device(torch::kCUDA)
+                                             .dtype(torch::kFloat32);
+    // transpose yields a non-contiguous view without copying the storage.
+    at::Tensor non_contiguous_poly =
+        torch::zeros({2, 6}, options).transpose(0, 1);
+    ASSERT_FALSE(non_contiguous_poly.is_contiguous());
+    at::Tensor contiguous_poly = torch::zeros({6, 2}, options);
+
+    auto external_distortion_params =
+        c10::make_intrusive<gsplat::extdist::BivariateWindshieldModelParameters>();
+    external_distortion_params->horizontal_poly = non_contiguous_poly;
+    external_distortion_params->vertical_poly = contiguous_poly;
+    external_distortion_params->horizontal_poly_inverse = contiguous_poly;
+    external_distortion_params->vertical_poly_inverse = contiguous_poly;
+
+    EXPECT_THROW(
+        gsplat::rasterize_to_pixels_from_world_3dgs_fwd(
+            scene.means,
+            scene.quats,
+            scene.scales,
+            scene.colors,
+            scene.opacities_bc,
+            c10::nullopt, // backgrounds
+            c10::nullopt, // masks
+            scene.width,
+            scene.height,
+            scene.tile_size,
+            scene.viewmats,
+            c10::nullopt, // viewmats1
+            scene.Ks,
+            gsplat::PINHOLE,
+            scene.ut_params,
+            ShutterType::GLOBAL,
+            c10::nullopt, // rays
+            c10::nullopt, // radial_coeffs
+            c10::nullopt, // tangential_coeffs
+            c10::nullopt, // thin_prism_coeffs
+            scene.ftheta_coeffs,
+            c10::nullopt, // lidar_coeffs
+            external_distortion_params,
+            scene.isect_offsets,
+            scene.flatten_ids,
+            false, // use_hit_distance
+            gsplat::RendererConfig::MIXED_BATCH,
+            false, // fwd_only
+            false, // return_last_ids
+            c10::nullopt, // sample_counts
+            c10::nullopt, // normals
+            false), // unsafe_masked_tile_outputs
+        c10::Error);
 }

--- a/tests/cpp/test_torchutils.cpp
+++ b/tests/cpp/test_torchutils.cpp
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <c10/util/Exception.h>
+#include <c10/util/intrusive_ptr.h>
+
+#include "TorchUtils.h"
+
+// Unit coverage for the gsplat::TorchUtils helpers:
+//   - as_optional_tensor / as_tensor: inverse round-trip between
+//     at::optional<at::Tensor> and at::Tensor, with an undefined Tensor as the
+//     nullopt sentinel.
+//   - checked_deref: returns *ptr when set, else raises a TORCH_CHECK error
+//     that names the field (turning a null deref into an attributable failure).
+//
+// Pytest owns discovery/execution via tests/test_cpp.py; this calls the helpers
+// directly.
+
+namespace {
+
+struct Holder : c10::intrusive_ptr_target {
+    int value;
+    explicit Holder(int v) : value(v) {}
+};
+
+} // namespace
+
+TEST(TorchUtils, OptionalTensorRoundTripDefined) {
+    at::Tensor t = at::ones({2, 3});
+    at::optional<at::Tensor> opt = gsplat::as_optional_tensor(t);
+    ASSERT_TRUE(opt.has_value());
+    at::Tensor back = gsplat::as_tensor(opt);
+    EXPECT_TRUE(back.defined());
+    EXPECT_TRUE(back.equal(t));
+}
+
+TEST(TorchUtils, OptionalTensorRoundTripUndefined) {
+    at::Tensor undefined; // .defined() == false -> the nullopt sentinel
+    at::optional<at::Tensor> opt = gsplat::as_optional_tensor(undefined);
+    EXPECT_FALSE(opt.has_value());
+    EXPECT_FALSE(gsplat::as_tensor(opt).defined());
+}
+
+TEST(TorchUtils, AsTensorOfNulloptIsUndefined) {
+    EXPECT_FALSE(gsplat::as_tensor(c10::nullopt).defined());
+}
+
+TEST(TorchUtils, CheckedDerefReturnsReferenceWhenSet) {
+    auto p = c10::make_intrusive<Holder>(42);
+    const Holder &r = gsplat::checked_deref(p, "holder");
+    EXPECT_EQ(r.value, 42);
+    EXPECT_EQ(&r, p.get()); // a reference to the held object, not a copy
+}
+
+TEST(TorchUtils, CheckedDerefThrowsNamedErrorWhenNull) {
+    c10::intrusive_ptr<Holder> p; // null
+    EXPECT_THAT(
+        [&] { gsplat::checked_deref(p, "fov_horiz_rad"); },
+        testing::ThrowsMessage<c10::Error>(
+            testing::HasSubstr("fov_horiz_rad must be set")));
+}

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -726,3 +726,41 @@ def test_rasterize_to_pixels_2dgs_densify_gradient():
     torch.testing.assert_close(
         v_densify[mask], expected[mask], rtol=2e-2, atol=1e-3 * scale
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_2dgs(), reason="2DGS support wasn't built")
+def test_fully_fused_projection_packed_2dgs_empty():
+    # Packed 2DGS projection computed the batch count as numel/(N*3) before the
+    # empty-input guard; with N==0 that divisor is zero (host-side integer
+    # division by zero). An empty gaussian set must be a clean no-op returning
+    # empty packed tensors.
+    from gsplat.cuda._wrapper import fully_fused_projection_2dgs
+
+    W, H = 64, 64
+    means = torch.zeros(0, 3, device=device)
+    quats = torch.zeros(0, 4, device=device)
+    scales = torch.ones(0, 3, device=device)
+    viewmats = torch.eye(4, device=device)[None]
+    Ks = torch.tensor(
+        [[float(W), 0.0, W / 2.0], [0.0, float(W), H / 2.0], [0.0, 0.0, 1.0]],
+        device=device,
+    )[None]
+
+    (
+        batch_ids,
+        camera_ids,
+        gaussian_ids,
+        indptr,
+        radii,
+        means2d,
+        depths,
+        ray_transforms,
+        normals,
+    ) = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, W, H, packed=True
+    )
+
+    assert gaussian_ids.numel() == 0
+    assert means2d.shape[0] == 0
+    assert int(indptr[-1].item()) == 0

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -630,3 +630,99 @@ def test_rasterize_to_pixels_2dgs_masked_tile_outputs_initialized():
     torch.testing.assert_close(render_median, torch.zeros_like(render_median))
     torch.testing.assert_close(last_ids, torch.zeros_like(last_ids))
     torch.testing.assert_close(median_ids, torch.zeros_like(median_ids))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_2dgs(), reason="2DGS support wasn't built")
+def test_rasterize_to_pixels_2dgs_densify_gradient():
+    # The densification gradient is the gradient w.r.t. the `densify` input and
+    # equals the depth-scaled ray-transform z-gradients:
+    #   v_densify[..., 0] == v_ray_transforms[..., 0, 2] * depth
+    #   v_densify[..., 1] == v_ray_transforms[..., 1, 2] * depth
+    # The backward must accumulate it race-free (warp-reduce + atomicAdd), the
+    # same path as v_ray_transforms. Reading the still-accumulating global
+    # v_ray_transforms instead yields a last-writer-wins partial sum that
+    # undercounts whenever a gaussian spans multiple tiles, so the identity
+    # holds only for the race-free accumulation.
+    from gsplat.cuda._wrapper import (
+        fully_fused_projection_2dgs,
+        isect_offset_encode,
+        isect_tiles,
+        rasterize_to_pixels_2dgs,
+    )
+
+    torch.manual_seed(42)
+    C = 1
+    N = 1000
+    means = torch.randn(N, 3, device=device)
+    quats = torch.nn.functional.normalize(torch.randn(N, 4, device=device), dim=-1)
+    scales = torch.ones(N, 3, device=device)
+    scales[..., :2] *= 0.1
+    opacities = torch.rand(C, N, device=device) * 0.5
+    W, H = 640, 480
+    viewmats = torch.broadcast_to(torch.eye(4, device=device), (C, 4, 4))
+    Ks = torch.broadcast_to(
+        torch.tensor(
+            [[float(W), 0.0, W / 2.0], [0.0, float(W), H / 2.0], [0.0, 0.0, 1.0]],
+            device=device,
+        ),
+        (C, 3, 3),
+    )
+    channels = 3
+    colors = torch.rand(C, N, channels, device=device)
+
+    radii, means2d, depths, ray_transforms, normals = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, W, H
+    )
+    colors = torch.cat([colors, depths[..., None]], dim=-1)
+    backgrounds = torch.zeros(C, channels + 1, device=device)
+
+    tile_size = 16
+    tile_width = math.ceil(W / float(tile_size))
+    tile_height = math.ceil(H / float(tile_size))
+    _, isect_ids, flatten_ids = isect_tiles(
+        means2d, radii, depths, tile_size, tile_width, tile_height
+    )
+    isect_offsets = isect_offset_encode(isect_ids, C, tile_width, tile_height)
+    densify = torch.zeros_like(means2d)
+
+    ray_transforms.requires_grad = True
+    densify.requires_grad = True
+
+    render_colors, render_alphas, render_normals, _, _ = rasterize_to_pixels_2dgs(
+        means2d,
+        ray_transforms,
+        colors,
+        opacities,
+        normals,
+        densify,
+        W,
+        H,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+        backgrounds=backgrounds,
+        distloss=True,
+    )
+
+    v_render_colors = torch.randn_like(render_colors)
+    v_densify, v_ray_transforms = torch.autograd.grad(
+        (render_colors * v_render_colors).sum(),
+        (densify, ray_transforms),
+    )
+
+    expected = torch.stack(
+        [
+            v_ray_transforms[..., 0, 2] * depths,
+            v_ray_transforms[..., 1, 2] * depths,
+        ],
+        dim=-1,
+    )
+
+    # The densify gradient is zero for non-contributing gaussians; compare only
+    # entries with meaningful magnitude.
+    scale = expected.abs().max().item()
+    mask = expected.abs() > 1e-4 * scale
+    torch.testing.assert_close(
+        v_densify[mask], expected[mask], rtol=2e-2, atol=1e-3 * scale
+    )

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -568,3 +568,65 @@ def test_rasterization_packed_2dgs_pose_grad_large_nnz():
     render_colors.sum().backward()
     assert viewmats.grad is not None
     assert torch.isfinite(viewmats.grad).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_2dgs(), reason="2DGS support wasn't built")
+def test_rasterize_to_pixels_2dgs_masked_tile_outputs_initialized():
+    # A masked-out tile takes the forward rasterizer's early-return branch,
+    # which must initialize ALL of its pixel outputs (the binding allocates
+    # them with at::empty, leaving render_alphas / render_normals /
+    # render_distort / render_median / last_ids / median_ids uninitialized
+    # otherwise). The low-level fwd op exposes last_ids / median_ids directly.
+    # Stale allocator contents could coincidentally match these defaults, so
+    # this only reliably catches a missing store when uninitialized memory
+    # differs from the default.
+    from gsplat.cuda._wrapper import _make_lazy_cuda_func
+
+    tile_size = 16
+    width = height = tile_size  # single tile
+    channels = 3
+    N = 1
+
+    means2d = torch.tensor([[[width / 2.0, height / 2.0]]], device=device)  # [1, 1, 2]
+    ray_transforms = torch.eye(3, device=device).reshape(1, 1, 3, 3)  # [1, 1, 3, 3]
+    colors = torch.ones((1, N, channels), device=device)
+    opacities = torch.ones((1, N), device=device)
+    normals = torch.zeros((1, N, 3), device=device)
+    backgrounds = torch.zeros((1, channels), device=device)
+    masks = torch.zeros((1, 1, 1), dtype=torch.bool, device=device)  # tile masked off
+    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int32, device=device)
+    flatten_ids = torch.empty((0,), dtype=torch.int32, device=device)
+
+    (
+        render_colors,
+        render_alphas,
+        render_normals,
+        render_distort,
+        render_median,
+        last_ids,
+        median_ids,
+    ) = _make_lazy_cuda_func("rasterize_to_pixels_2dgs_fwd")(
+        means2d,
+        ray_transforms,
+        colors,
+        opacities,
+        normals,
+        backgrounds,
+        masks,
+        width,
+        height,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+    )
+
+    torch.testing.assert_close(
+        render_colors, backgrounds.reshape(1, 1, 1, channels).expand_as(render_colors)
+    )
+    torch.testing.assert_close(render_alphas, torch.zeros_like(render_alphas))
+    torch.testing.assert_close(render_normals, torch.zeros_like(render_normals))
+    torch.testing.assert_close(render_distort, torch.zeros_like(render_distort))
+    torch.testing.assert_close(render_median, torch.zeros_like(render_median))
+    torch.testing.assert_close(last_ids, torch.zeros_like(last_ids))
+    torch.testing.assert_close(median_ids, torch.zeros_like(median_ids))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5542,3 +5542,78 @@ def test_isect_tiles_lidar_double_depth():
     torch.testing.assert_close(tpg64, tpg32)
     torch.testing.assert_close(iid64, iid32)
     torch.testing.assert_close(fid64, fid32)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT/Lidar support isn't built in")
+def test_isect_tiles_packed_segmented_rejected():
+    # In packed mode tiles_per_gauss is 1-D [nnz], so the per-image segment
+    # offsets collapse to a single [0, total] buffer; a segmented radix sort
+    # over n_images segments would read past it. The op must reject the
+    # combination rather than corrupt the sort.
+    from gsplat.cuda._wrapper import isect_tiles
+
+    torch.manual_seed(42)
+    nnz = 8
+    means2d = torch.randn(nnz, 2, device=device) * 40
+    radii = torch.randint(1, 10, (nnz, 2), device=device, dtype=torch.int32)
+    depths = torch.rand(nnz, device=device)
+    image_ids = torch.zeros(nnz, dtype=torch.int32, device=device)
+    gaussian_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+
+    with pytest.raises(
+        RuntimeError, match="segmented sort is not supported for packed inputs"
+    ):
+        isect_tiles(
+            means2d,
+            radii,
+            depths,
+            tile_size=16,
+            tile_width=4,
+            tile_height=4,
+            sort=True,
+            segmented=True,
+            packed=True,
+            n_images=1,
+            image_ids=image_ids,
+            gaussian_ids=gaussian_ids,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT/Lidar support isn't built in")
+def test_isect_tiles_lidar_packed_segmented_rejected():
+    # Lidar sibling of the camera packed+segmented guard.
+    from gsplat.cuda._wrapper import isect_tiles_lidar
+    from tests.test_cameras import parse_lidar_camera
+
+    torch.manual_seed(42)
+    lidar_params, angles_to_columns_map, tiling = parse_lidar_camera(
+        "pandar128", (), 0, 0, device=device
+    )
+    lidar = gsplat.RowOffsetStructuredSpinningLidarModelParametersExt(
+        lidar_params, angles_to_columns_map, tiling
+    )
+
+    nnz = 8
+    means2d = torch.randn(nnz, 2, device=device)
+    radii = torch.randint(1, 10, (nnz, 2), device=device, dtype=torch.int32)
+    depths = torch.rand(nnz, device=device)
+    image_ids = torch.zeros(nnz, dtype=torch.int32, device=device)
+    gaussian_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+
+    with pytest.raises(
+        RuntimeError, match="segmented sort is not supported for packed inputs"
+    ):
+        isect_tiles_lidar(
+            lidar,
+            means2d,
+            radii,
+            depths,
+            sort=True,
+            segmented=True,
+            packed=True,
+            n_images=1,
+            image_ids=image_ids,
+            gaussian_ids=gaussian_ids,
+        )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5725,6 +5725,36 @@ def test_fully_fused_projection_2dgs_packed_empty(C):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
+def test_fully_fused_projection_packed_grid_y_limit():
+    # The packed forward launcher maps B*C onto grid.y, which CUDA caps at
+    # 65535. A larger B*C must raise a clear error instead of issuing an invalid
+    # kernel launch. Here B=1 and C=65536 (one camera over the cap).
+    from gsplat.cuda._wrapper import fully_fused_projection
+
+    W, H = 32, 32
+    N, C = 1, 65536
+    means = torch.randn(N, 3, device=device)
+    means[:, 2] += 5.0
+    quats = torch.nn.functional.normalize(torch.randn(N, 4, device=device), dim=-1)
+    scales = torch.rand(N, 3, device=device) * 0.1
+    viewmats = torch.eye(4, device=device).expand(C, 4, 4).contiguous()
+    Ks = (
+        torch.tensor(
+            [[float(W), 0.0, W / 2.0], [0.0, float(W), H / 2.0], [0.0, 0.0, 1.0]],
+            device=device,
+        )
+        .expand(C, 3, 3)
+        .contiguous()
+    )
+
+    with pytest.raises(RuntimeError, match=r"exceeds the CUDA grid\.y limit"):
+        fully_fused_projection(
+            means, None, quats, scales, viewmats, Ks, W, H, packed=True
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT/Lidar support isn't built in")
 @pytest.mark.parametrize("tile_width,tile_height", [(2, 2), (4, 4), (8, 4)])
 def test_isect_offset_power_of_two_tiles(tile_width: int, tile_height: int):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -799,20 +799,35 @@ def test_fully_fused_projection_ut(
     # ASSERTIONS: Compare outputs with appropriate tolerances
     # ========================================================================
 
-    # Radii: Integer values, allow small differences due to ceil() rounding
-    # With require_all_valid=True, early-exit can cause larger FP32 differences
-    # Rolling shutter uses iterative refinement (10 iterations) which accumulates
-    # numerical differences through the opacity-aware radius computation pipeline
+    # Radii: ceil()'d integer pixel extents.
+    # - GLOBAL shutter: inputs are smooth, so only ceil() rounding differs and a
+    #   tight per-element check (atol=2) holds.
+    # - ROLLING shutter: the iterative refinement amplifies FP32 differences, and
+    #   a sub-pixel difference at a ceil() step tips a boundary Gaussian's extent
+    #   by a whole integer.  Mirror the means2d/conics rolling-shutter checks: a
+    #   tight bulk per-element bound (atol=10) with a small fail-rate cap so
+    #   systematic bias still fails, plus an outlier guard so a single large
+    #   radius error cannot hide inside the fail-rate budget.
     if rolling_shutter == RollingShutterType.GLOBAL:
-        radii_atol = 2.0  # Only ceil() differences for global shutter
-    else:
-        radii_atol = (
-            10.0  # Rolling shutter: iterative refinement amplifies FP32 differences
+        torch.testing.assert_close(
+            radii_cuda[sel].float(), radii_torch[sel].float(), rtol=0, atol=2.0
         )
-
-    torch.testing.assert_close(
-        radii_cuda[sel].float(), radii_torch[sel].float(), rtol=0, atol=radii_atol
-    )
+    else:
+        _diff_r = (radii_cuda[sel].float() - radii_torch[sel].float()).abs()
+        _fail_r = _diff_r > 10.0
+        _fr_r = _fail_r.float().mean().item()
+        # Bulk bound atol=10; worst observed 1/783256 (~0.00013%) tipping over on
+        # L40S (NVRTC).  Cap at 0.01% for GPU/codegen margin.
+        assert _fr_r <= 1e-4, (
+            f"UT radii (rolling): fail-rate {_fr_r:.4%} > cap 0.01% "
+            f"(atol=10, {int(_fail_r.sum().item())}/{_fail_r.numel()})"
+        )
+        # Outlier guard: admitted outliers stay within a few ceil()-steps.
+        _outlier_r = _diff_r > 32.0
+        assert not _outlier_r.any(), (
+            f"UT radii (rolling): {int(_outlier_r.sum().item())} elements exceed "
+            f"outlier bound (atol=32); worst diff {_diff_r.max().item():.1f}"
+        )
 
     # means2d: split by shutter mode.  GLOBAL is smooth in inputs and admits
     # a tight per-element check.  ROLLING does a 10-iter refinement whose

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5768,3 +5768,99 @@ def test_isect_offset_power_of_two_tiles(tile_width: int, tile_height: int):
     torch.testing.assert_close(isect_ids, _isect_ids)
     torch.testing.assert_close(flatten_ids, _gauss_ids)
     torch.testing.assert_close(isect_offsets, _isect_offsets)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
+def test_rasterize_to_indices_in_range_empty():
+    # rasterize_to_indices_3dgs computed the image count as numel/(2*N) before
+    # any emptiness guard; with zero gaussians (N == 0) the divisor is zero -- a
+    # host-side integer division by zero. An empty gaussian set must be a clean
+    # no-op returning empty index tensors.
+    from gsplat.cuda._wrapper import rasterize_to_indices_in_range
+
+    C = 1
+    W = H = 16
+    tile_size = 16
+    means2d = torch.zeros(C, 0, 2, device=device)
+    conics = torch.zeros(C, 0, 3, device=device)
+    opacities = torch.zeros(C, 0, device=device)
+    transmittances = torch.ones(C, H, W, device=device)
+    isect_offsets = torch.zeros(C, 1, 1, dtype=torch.int32, device=device)
+    flatten_ids = torch.empty(0, dtype=torch.int32, device=device)
+
+    gauss_ids, pixel_ids, image_ids = rasterize_to_indices_in_range(
+        0,
+        2**30,
+        transmittances,
+        means2d,
+        conics,
+        opacities,
+        W,
+        H,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+    )
+    assert gauss_ids.numel() == 0
+    assert pixel_ids.numel() == 0
+    assert image_ids.numel() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
+def test_rasterize_to_pixels_eval3d_empty():
+    # The world-space rasterizer computed the batch count as numel/(N*3) before
+    # any emptiness guard; with zero gaussians (N == 0) the divisor is zero -- a
+    # host-side integer division by zero. An empty gaussian set must be a clean
+    # no-op rather than crashing.
+    from gsplat.cuda._wrapper import rasterize_to_pixels_eval3d_extra
+
+    C = 1
+    W = H = 16
+    tile_size = 16
+    channels = 3
+    means = torch.zeros(0, 3, device=device)
+    quats = torch.zeros(0, 4, device=device)
+    scales = torch.ones(0, 3, device=device)
+    colors = torch.zeros(C, 0, channels, device=device)
+    opacities = torch.zeros(C, 0, device=device)
+    viewmats = torch.eye(4, device=device)[None]
+    Ks = torch.tensor(
+        [[[float(W), 0.0, W / 2.0], [0.0, float(H), H / 2.0], [0.0, 0.0, 1.0]]],
+        device=device,
+    )
+    isect_offsets = torch.zeros(C, 1, 1, dtype=torch.int32, device=device)
+    flatten_ids = torch.empty(0, dtype=torch.int32, device=device)
+
+    # Must not crash (pre-fix: host-side division by zero on the empty input),
+    # and every output must hold its empty/safe-default value instead of
+    # uninitialized at::empty memory.
+    (
+        render_colors,
+        render_alphas,
+        last_ids,
+        sample_counts,
+        render_normals,
+    ) = rasterize_to_pixels_eval3d_extra(
+        means,
+        quats,
+        scales,
+        colors,
+        opacities,
+        viewmats,
+        Ks,
+        W,
+        H,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+        return_sample_counts=True,
+        return_normals=True,
+    )
+    assert torch.isfinite(render_colors).all()
+    torch.testing.assert_close(render_colors, torch.zeros_like(render_colors))
+    torch.testing.assert_close(render_alphas, torch.zeros_like(render_alphas))
+    torch.testing.assert_close(render_normals, torch.zeros_like(render_normals))
+    torch.testing.assert_close(last_ids, torch.full_like(last_ids, -1))
+    torch.testing.assert_close(sample_counts, torch.zeros_like(sample_counts))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5722,3 +5722,49 @@ def test_fully_fused_projection_2dgs_packed_empty(C):
     # Backward over the empty projection must not divide by zero in the launcher.
     (means2d.sum() + depths.sum() + ray_transforms.sum() + normals.sum()).backward()
     assert means.grad.shape == means.shape
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT/Lidar support isn't built in")
+@pytest.mark.parametrize("tile_width,tile_height", [(2, 2), (4, 4), (8, 4)])
+def test_isect_offset_power_of_two_tiles(tile_width: int, tile_height: int):
+    # n_tiles = tile_width*tile_height is a power of two here, the case where the
+    # packed (image, tile) id field width disagrees between bits_for_count
+    # (bit_width(n-1)) and the old floor(log2)+1 (off by one bit). A pack/unpack
+    # mismatch corrupts the decoded tile ids and the offset buffer, so the CUDA
+    # packing, the CUDA offset decode, and the Python reference must all agree
+    # at these counts.
+    from gsplat.cuda._torch_impl import _isect_offset_encode, _isect_tiles
+    from gsplat.cuda._wrapper import isect_offset_encode, isect_tiles
+
+    torch.manual_seed(42)
+    # C >= 3 so the image id occupies bits above the tile field: a wrong
+    # tile_n_bits in the offset decode then mis-splits image vs tile bits. With
+    # C <= 2 the off-by-one bit folds back into the flat (image*n_tiles+tile)
+    # index losslessly and would hide the bug.
+    C, N = 4, 800
+    tile_size = 16
+    width = tile_width * tile_size
+    height = tile_height * tile_size
+    I = C
+    n_tiles = tile_width * tile_height
+    assert n_tiles & (n_tiles - 1) == 0, "n_tiles must be a power of two for this test"
+
+    means2d = torch.randn(C, N, 2, device=device) * width
+    radii = torch.randint(0, tile_size, (C, N, 2), device=device, dtype=torch.int32)
+    depths = torch.rand(C, N, device=device)
+
+    tiles_per_gauss, isect_ids, flatten_ids = isect_tiles(
+        means2d, radii, depths, tile_size, tile_width, tile_height
+    )
+    isect_offsets = isect_offset_encode(isect_ids, I, tile_width, tile_height)
+
+    _tiles_per_gauss, _isect_ids, _gauss_ids = _isect_tiles(
+        means2d, radii, depths, tile_size, tile_width, tile_height
+    )
+    _isect_offsets = _isect_offset_encode(_isect_ids, I, tile_width, tile_height)
+
+    torch.testing.assert_close(tiles_per_gauss, _tiles_per_gauss)
+    torch.testing.assert_close(isect_ids, _isect_ids)
+    torch.testing.assert_close(flatten_ids, _gauss_ids)
+    torch.testing.assert_close(isect_offsets, _isect_offsets)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -973,7 +973,8 @@ def test_fully_fused_projection_ut(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT/Lidar support isn't built in")
 @pytest.mark.parametrize("batch_dims", [(), (2,), (1, 2)])
-def test_isect(test_data, batch_dims: Tuple[int, ...]):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_isect(test_data, dtype: torch.dtype, batch_dims: Tuple[int, ...]):
     from gsplat.cuda._torch_impl import _isect_offset_encode, _isect_tiles
     from gsplat.cuda._wrapper import isect_offset_encode, isect_tiles
 
@@ -984,10 +985,16 @@ def test_isect(test_data, batch_dims: Tuple[int, ...]):
     I = B * C
     width, height = 40, 60
 
+    # Cover float64 as well as float32: intersect_tile_kernel is instantiated
+    # for scalar_t=double (dispatch keys on means2d), and its 32-bit depth sort
+    # key must narrow to float32 to stay a monotonic ordering -- a bare 32-bit
+    # reinterpret of a double reads only half its bits and scrambles the
+    # within-tile front-to-back order. The Python reference narrows the key to
+    # float32, so the float64 CUDA path must agree with it.
     test_data = {
-        "means2d": torch.randn(C, N, 2, device=device) * width,
+        "means2d": torch.randn(C, N, 2, device=device, dtype=dtype) * width,
         "radii": torch.randint(0, width, (C, N, 2), device=device, dtype=torch.int32),
-        "depths": torch.rand(C, N, device=device),
+        "depths": torch.rand(C, N, device=device, dtype=dtype),
     }
     test_data = expand(test_data, batch_dims)
     means2d = test_data["means2d"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5442,3 +5442,52 @@ def test_backward_high_opacity_no_nan(tile_size):
         assert torch.isfinite(
             param.grad
         ).all(), f"NaN/Inf in {name}.grad (max={param.grad.abs().max().item():.2e})"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
+def test_rasterize_to_pixels_3dgs_masked_tile_outputs_initialized():
+    # A masked-out tile takes the forward rasterizer's early-return branch,
+    # which must initialize ALL of its pixel outputs (the binding allocates
+    # them with at::empty, leaving render_alphas / last_ids uninitialized
+    # otherwise). The low-level fwd op exposes last_ids directly. Stale
+    # allocator contents could coincidentally match these defaults, so this
+    # only reliably catches a missing store when uninitialized memory differs
+    # from the default.
+    from gsplat.cuda._wrapper import _make_lazy_cuda_func
+
+    tile_size = 16
+    width = height = tile_size  # single tile
+    channels = 3
+    N = 1
+
+    means2d = torch.tensor([[[width / 2.0, height / 2.0]]], device=device)  # [1, 1, 2]
+    conics = torch.tensor([[[1.0, 0.0, 1.0]]], device=device)  # [1, 1, 3]
+    colors = torch.ones((1, N, channels), device=device)
+    opacities = torch.ones((1, N), device=device)
+    backgrounds = torch.zeros((1, channels), device=device)
+    masks = torch.zeros((1, 1, 1), dtype=torch.bool, device=device)  # tile masked off
+    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int32, device=device)
+    flatten_ids = torch.empty((0,), dtype=torch.int32, device=device)
+
+    render_colors, render_alphas, last_ids = _make_lazy_cuda_func(
+        "rasterize_to_pixels_3dgs_fwd"
+    )(
+        means2d,
+        conics,
+        colors,
+        opacities,
+        backgrounds,
+        masks,
+        width,
+        height,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+    )
+
+    torch.testing.assert_close(
+        render_colors, backgrounds.reshape(1, 1, 1, channels).expand_as(render_colors)
+    )
+    torch.testing.assert_close(render_alphas, torch.zeros_like(render_alphas))
+    torch.testing.assert_close(last_ids, torch.zeros_like(last_ids))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5498,3 +5498,47 @@ def test_rasterize_to_pixels_3dgs_masked_tile_outputs_initialized():
     )
     torch.testing.assert_close(render_alphas, torch.zeros_like(render_alphas))
     torch.testing.assert_close(last_ids, torch.zeros_like(last_ids))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT/Lidar support isn't built in")
+def test_isect_tiles_lidar_double_depth():
+    # intersect_tile_lidar_kernel narrows the depth sort key to float32. With
+    # float64 depths a bare 32-bit slice of the double is its low mantissa bits
+    # (non-monotonic), scrambling the within-tile front-to-back order. The
+    # double path is reachable from Python (no dtype cast in the wrapper or
+    # binding), so the float64 result must match the float32 result tile-for-tile.
+    from gsplat.cuda._torch_impl_lidar import ANGLE_TO_PIXEL_SCALING_FACTOR
+    from gsplat.cuda._wrapper import isect_tiles_lidar
+    from tests.test_cameras import parse_lidar_camera
+
+    torch.manual_seed(42)
+
+    lidar_params, angles_to_columns_map, tiling = parse_lidar_camera(
+        "pandar128", (), 0, 0, device=device
+    )
+    lidar = gsplat.RowOffsetStructuredSpinningLidarModelParametersExt(
+        lidar_params, angles_to_columns_map, tiling
+    )
+
+    C, N = 3, 1000
+    means2d = (
+        torch.randn(C, N, 2, device=device)
+        * torch.tensor([2 * math.pi, math.pi], device=device)
+    ) * ANGLE_TO_PIXEL_SCALING_FACTOR
+    radii = torch.ceil(
+        torch.randn(C, N, 2, device=device).abs().clamp(max=1)
+        * torch.tensor([math.pi, lidar.fov_vert_rad.span / 2], device=device)
+        * ANGLE_TO_PIXEL_SCALING_FACTOR
+    ).to(torch.int32)
+    depths = torch.rand(C, N, device=device)
+
+    tpg32, iid32, fid32 = isect_tiles_lidar(lidar, means2d, radii, depths, sort=True)
+    # Same values, double dtype -> exercises the scalar_t=double instantiation.
+    tpg64, iid64, fid64 = isect_tiles_lidar(
+        lidar, means2d.double(), radii, depths.double(), sort=True
+    )
+
+    torch.testing.assert_close(tpg64, tpg32)
+    torch.testing.assert_close(iid64, iid32)
+    torch.testing.assert_close(fid64, fid32)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5617,3 +5617,108 @@ def test_isect_tiles_lidar_packed_segmented_rejected():
             image_ids=image_ids,
             gaussian_ids=gaussian_ids,
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
+@pytest.mark.parametrize("C", [1, 3])
+def test_fully_fused_projection_packed_empty(C):
+    # Packed EWA-3DGS projection computed the batch count as numel/(N*3) before
+    # the empty-input guard; with N==0 that divisor is zero (host-side integer
+    # division by zero) in BOTH the forward and backward launchers. An empty
+    # gaussian set must be a clean no-op (empty packed tensors) through fwd+bwd.
+    # C > 1 also pins the indptr shape contract: a length-1 indptr would pass a
+    # bare indptr[-1] check yet drop the per-camera rows the CSR API promises.
+    from gsplat.cuda._wrapper import fully_fused_projection
+
+    W, H = 64, 64
+    means = torch.zeros(0, 3, device=device, requires_grad=True)
+    quats = torch.zeros(0, 4, device=device, requires_grad=True)
+    scales = torch.ones(0, 3, device=device, requires_grad=True)
+    viewmats = torch.eye(4, device=device)[None].expand(C, 4, 4).contiguous()
+    Ks = (
+        torch.tensor(
+            [[float(W), 0.0, W / 2.0], [0.0, float(W), H / 2.0], [0.0, 0.0, 1.0]],
+            device=device,
+        )[None]
+        .expand(C, 3, 3)
+        .contiguous()
+    )
+
+    (
+        batch_ids,
+        camera_ids,
+        gaussian_ids,
+        indptr,
+        radii,
+        means2d,
+        depths,
+        conics,
+        compensations,
+    ) = fully_fused_projection(
+        means, None, quats, scales, viewmats, Ks, W, H, packed=True
+    )
+
+    assert gaussian_ids.numel() == 0
+    assert means2d.shape[0] == 0
+    assert radii.shape[0] == 0
+    # B == 1 for means.shape == (0, 3), so indptr has B * C + 1 == C + 1 zero
+    # entries -- one row per camera plus the trailing total.
+    assert indptr.shape == (C + 1,)
+    assert bool((indptr == 0).all())
+
+    # Backward over the empty projection must not divide by zero in the launcher.
+    (means2d.sum() + depths.sum() + conics.sum()).backward()
+    assert means.grad.shape == means.shape
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_2dgs(), reason="2DGS support isn't built in")
+@pytest.mark.parametrize("C", [1, 3])
+def test_fully_fused_projection_2dgs_packed_empty(C):
+    # Same empty-input batch-count division-by-zero as the EWA packed projection,
+    # in the 2DGS packed launcher's forward and backward. An empty gaussian set
+    # must be a clean no-op (empty packed tensors) through fwd+bwd.
+    # C > 1 also pins the indptr shape contract: a length-1 indptr would pass a
+    # bare indptr[-1] check yet drop the per-camera rows the CSR API promises.
+    from gsplat.cuda._wrapper import fully_fused_projection_2dgs
+
+    W, H = 64, 64
+    means = torch.zeros(0, 3, device=device, requires_grad=True)
+    quats = torch.zeros(0, 4, device=device, requires_grad=True)
+    scales = torch.ones(0, 3, device=device, requires_grad=True)
+    viewmats = torch.eye(4, device=device)[None].expand(C, 4, 4).contiguous()
+    Ks = (
+        torch.tensor(
+            [[float(W), 0.0, W / 2.0], [0.0, float(W), H / 2.0], [0.0, 0.0, 1.0]],
+            device=device,
+        )[None]
+        .expand(C, 3, 3)
+        .contiguous()
+    )
+
+    (
+        batch_ids,
+        camera_ids,
+        gaussian_ids,
+        indptr,
+        radii,
+        means2d,
+        depths,
+        ray_transforms,
+        normals,
+    ) = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, W, H, packed=True
+    )
+
+    assert gaussian_ids.numel() == 0
+    assert means2d.shape[0] == 0
+    assert radii.shape[0] == 0
+    # B == 1 for means.shape == (0, 3), so indptr has B * C + 1 == C + 1 zero
+    # entries -- one row per camera plus the trailing total.
+    assert indptr.shape == (C + 1,)
+    assert bool((indptr == 0).all())
+
+    # Backward over the empty projection must not divide by zero in the launcher.
+    (means2d.sum() + depths.sum() + ray_transforms.sum() + normals.sum()).backward()
+    assert means.grad.shape == means.shape

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -325,7 +325,11 @@ def _cuda_cflags(build_params) -> list[str]:
     # applies to test-only CUDA TUs -- nvcc spells it `-Xcompiler=-Werror` and
     # `--Werror all-warnings`.
     werror = {"-Xcompiler=-Werror", "--Werror", "all-warnings"}
-    return [flag for flag in build_params.extra_cuda_cflags if flag not in werror]
+    from gsplat.cuda.build import format_jit_cuda_cflags
+
+    return format_jit_cuda_cflags(
+        [flag for flag in build_params.extra_cuda_cflags if flag not in werror]
+    )
 
 
 def _python_link_flags() -> list[str]:

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -316,6 +316,18 @@ def _cflags(build_params) -> list[str]:
     return [flag for flag in build_params.extra_cflags if flag != "-Werror"]
 
 
+def _cuda_cflags(build_params) -> list[str]:
+    """Return CUDA compile flags compatible with both gsplat and test sources."""
+    # Mirror _cflags for nvcc. gsplat's CUDA flags carry the C++ standard, the
+    # gsplat -D defines, and diagnostic suppressions; without them a test .cu
+    # falls back to PyTorch's default nvcc standard (one behind the rest of the
+    # build) and misses gsplat's macros. Drop only the -Werror policy so it never
+    # applies to test-only CUDA TUs -- nvcc spells it `-Xcompiler=-Werror` and
+    # `--Werror all-warnings`.
+    werror = {"-Xcompiler=-Werror", "--Werror", "all-warnings"}
+    return [flag for flag in build_params.extra_cuda_cflags if flag not in werror]
+
+
 def _python_link_flags() -> list[str]:
     """Return Python/torch_python link flags needed by reused pybind objects."""
     # gsplat's reusable objects intentionally come from the Python extension
@@ -395,6 +407,7 @@ def build_cpp_tests() -> str:
                 name=CPP_TEST_TARGET,
                 sources=_gtest_sources() + _test_sources() + [stamp_source],
                 extra_cflags=_cflags(build_params),
+                extra_cuda_cflags=_cuda_cflags(build_params),
                 extra_include_paths=_include_paths(build_params),
                 extra_ldflags=_ldflags(build_params, core_objects),
                 build_directory=build_dir,

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -264,12 +264,16 @@ extern "C" const char *gsplat_cpp_tests_jit_object_digest() {{
 
 
 def _gtest_sources() -> list[str]:
-    """Return vendored GoogleTest sources used by the standalone test binary."""
+    """Return vendored GoogleTest + GoogleMock sources for the test binary."""
     # Build GoogleTest from source inside the same JIT target. That avoids a
     # separate CMake/configure step and lets PyTorch/Ninja use one compiler mode.
+    # gmock-all.cc is compiled in too so tests can use GoogleMock matchers (e.g.
+    # ThrowsMessage); gtest_main provides main() and is sufficient for matchers.
     gtest_root = os.path.join(REPO_ROOT, "third_party", "googletest", "googletest")
+    gmock_root = os.path.join(REPO_ROOT, "third_party", "googletest", "googlemock")
     sources = [
         os.path.join(gtest_root, "src", "gtest-all.cc"),
+        os.path.join(gmock_root, "src", "gmock-all.cc"),
         os.path.join(gtest_root, "src", "gtest_main.cc"),
     ]
     if not all(os.path.exists(source) for source in sources):
@@ -293,12 +297,15 @@ def _include_paths(build_params) -> list[str]:
     # Include both the repository root and csrc directories so tests can include
     # public gsplat CUDA headers without mirroring extension-relative paths.
     gtest_root = os.path.join(REPO_ROOT, "third_party", "googletest", "googletest")
+    gmock_root = os.path.join(REPO_ROOT, "third_party", "googletest", "googlemock")
     return [
         REPO_ROOT,
         os.path.join(REPO_ROOT, "gsplat", "cuda"),
         os.path.join(REPO_ROOT, "gsplat", "cuda", "csrc"),
         os.path.join(gtest_root, "include"),
         gtest_root,
+        os.path.join(gmock_root, "include"),
+        gmock_root,
     ] + build_params.extra_include_paths
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -478,3 +478,135 @@ def test_parse_renderer_config_override_keeps_non_string(load_profile):
 def test_parse_renderer_config_override_rejects_unknown(load_profile, raw):
     with pytest.raises(ValueError, match="renderer_config override"):
         load_profile._parse_renderer_config_override(raw)
+
+
+def test_apply_channel_override_slices_and_tiles(load_profile):
+    # Slice when the target count is below the source channel count, ...
+    inputs = {"colors": torch.zeros(1, 5, 8), "sh_degree": None}
+    load_profile._apply_channel_override(inputs, 3)
+    assert inputs["colors"].shape[-1] == 3
+    # ... tile-and-truncate when above it.
+    inputs = {"colors": torch.zeros(1, 5, 3), "sh_degree": None}
+    load_profile._apply_channel_override(inputs, 8)
+    assert inputs["colors"].shape[-1] == 8
+
+
+def test_apply_channel_override_tiles_by_wrapping_channels(load_profile):
+    # Tiling above the source count repeats the channel block then truncates,
+    # so channels wrap: [c0, c1, c2, c0, c1, c2, c0, c1] for cur=3 -> 8.
+    colors = torch.arange(3, dtype=torch.float32).reshape(1, 1, 3)
+    inputs = {"colors": colors, "sh_degree": None}
+    load_profile._apply_channel_override(inputs, 8)
+    expected = torch.tensor([0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0])
+    assert torch.equal(inputs["colors"].reshape(-1), expected)
+
+
+def test_apply_channel_override_preserves_grad_leaf(load_profile):
+    # The resized tensor must stay a leaf carrying requires_grad so backward
+    # replay can clear `.grad` through `_clear_replay_grads()`.
+    colors = torch.zeros(1, 5, 4, requires_grad=True)
+    inputs = {"colors": colors, "sh_degree": None}
+    load_profile._apply_channel_override(inputs, 8)
+    out = inputs["colors"]
+    assert out.is_leaf and out.requires_grad
+
+
+def test_apply_channel_override_then_normalize_is_camera_shaped(load_profile):
+    # End-to-end shape contract: --channels followed by the 2DGS normalize step
+    # must leave colors camera-shaped [..., C, N, channels], which
+    # rasterize_to_pixels_2dgs requires. This pins the ordering of the two
+    # steps, which is the load-bearing part of the feature.
+    n_gaussians, n_cameras, channels = 5, 2, 3
+    inputs = {
+        "means": torch.zeros(n_gaussians, 3),
+        "viewmats": torch.zeros(n_cameras, 4, 4),
+        "colors": torch.zeros(n_gaussians, 8),
+        "sh_degree": None,
+        "packed": False,
+    }
+    load_profile._apply_channel_override(inputs, channels)
+    load_profile._normalize_2dgs_replay_inputs(inputs)
+    assert inputs["colors"].shape == (n_cameras, n_gaussians, channels)
+
+
+def test_apply_channel_override_collapses_sh_to_dc_band(load_profile):
+    # SH input [N, K, D] collapses to its DC band [N, D] and clears sh_degree
+    # so the rasterizer templates on the post-activation channel count. K=4 is
+    # consistent with sh_degree=1 ((sh_degree+1)**2 == 4).
+    inputs = {"colors": torch.zeros(1, 5, 4, 3), "sh_degree": 1}
+    load_profile._apply_channel_override(inputs, 3)
+    assert inputs["sh_degree"] is None
+    assert inputs["colors"].shape == (1, 5, 3)
+
+
+def test_apply_channel_override_reserves_extra_signal_channels(load_profile):
+    # extra_signals stays at its captured width and the color block absorbs the
+    # remainder, so the post-concat templated count equals --channels exactly.
+    inputs = {
+        "colors": torch.zeros(1, 5, 8),
+        "extra_signals": torch.zeros(1, 5, 2),
+        "sh_degree": None,
+    }
+    load_profile._apply_channel_override(inputs, 6)
+    assert inputs["colors"].shape[-1] == 4  # 6 - 2 extra-signal channels
+    assert inputs["extra_signals"].shape[-1] == 2  # untouched
+
+
+def test_apply_channel_override_resizes_backgrounds(load_profile):
+    # backgrounds is asserted against the pre-depth feature width, so it must
+    # track the color resize or the wrapper's shape assert fires.
+    inputs = {
+        "colors": torch.zeros(1, 5, 8),
+        "backgrounds": torch.zeros(1, 8),
+        "sh_degree": None,
+    }
+    load_profile._apply_channel_override(inputs, 3)
+    assert inputs["backgrounds"].shape[-1] == 3
+
+
+def test_apply_channel_override_accounts_for_depth_channel(load_profile):
+    # A color+depth render_mode appends one depth channel onto the feature
+    # tensor, so the color block is sized to channels - 1.
+    inputs = {"colors": torch.zeros(1, 5, 8), "sh_degree": None, "render_mode": "RGB+D"}
+    load_profile._apply_channel_override(inputs, 4)
+    assert inputs["colors"].shape[-1] == 3
+
+
+def test_apply_channel_override_rejects_depth_only_render_mode(load_profile):
+    # Depth-only modes discard colors before the kernel, so --channels would be
+    # a silent no-op; reject it instead.
+    inputs = {"colors": torch.zeros(1, 5, 8), "sh_degree": None, "render_mode": "D"}
+    with pytest.raises(ValueError):
+        load_profile._apply_channel_override(inputs, 3)
+
+
+def test_apply_channel_override_rejects_channels_too_small(load_profile):
+    # No room left for a color channel after reserving extra-signal + depth.
+    inputs = {
+        "colors": torch.zeros(1, 5, 8),
+        "extra_signals": torch.zeros(1, 5, 2),
+        "sh_degree": None,
+        "render_mode": "RGB+D",
+    }
+    with pytest.raises(ValueError):
+        load_profile._apply_channel_override(inputs, 2)
+
+
+def test_apply_channel_override_rejects_malformed_sh(load_profile):
+    with pytest.raises(ValueError):  # K=4 inconsistent with sh_degree=2 (needs 9)
+        load_profile._apply_channel_override(
+            {"colors": torch.zeros(1, 5, 4, 3), "sh_degree": 2}, 3
+        )
+    with pytest.raises(ValueError):  # already-activated [N, D] is not SH-shaped
+        load_profile._apply_channel_override(
+            {"colors": torch.zeros(5, 3), "sh_degree": 1}, 3
+        )
+
+
+def test_apply_channel_override_rejects_bad_input(load_profile):
+    with pytest.raises(ValueError):  # colors is None
+        load_profile._apply_channel_override({"colors": None}, 3)
+    with pytest.raises(ValueError):  # target count must be >= 1
+        load_profile._apply_channel_override({"colors": torch.zeros(1, 5, 3)}, 0)
+    with pytest.raises(ValueError):  # zero-channel source must not divide by zero
+        load_profile._apply_channel_override({"colors": torch.zeros(1, 5, 0)}, 3)

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -252,9 +252,7 @@ def gaussians(
     return gaussians
 
 
-# Only 3dgs is being tested as per default args with_ut==False and with_eval3d==False
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
-@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
 @pytest.mark.parametrize(
     "per_view_color,sh_degree,render_mode,packed,batch_dims,with_eval3d,with_ut,camera_model,extra_signals_info,distributed,C,N,renderer_config,execution_mode",
     [
@@ -389,6 +387,7 @@ def test_rasterization(
     execution_mode: str,
     sensor_model: SimpleNamespace,
     gaussians: SimpleNamespace,
+    dist_init,
 ):
     if distributed and not torch.distributed.is_initialized():
         pytest.skip("distributed process group not initialized")

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -689,3 +689,17 @@ def test_rasterization_distributed_rejects_unsupported_configs(
 
     with pytest.raises(ValueError, match=match):
         gsplat.rasterization(**kwargs, distributed=True)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
+def test_rasterization_external_distortion_requires_ut():
+    kwargs = _make_distributed_validation_scene()
+    # The validation fires on `external_distortion_coeffs is not None` before
+    # any CUDA call, so any sentinel object suffices here.
+    kwargs["external_distortion_coeffs"] = object()
+    with pytest.raises(
+        (ValueError, AssertionError),
+        match="with_ut=True",
+    ):
+        gsplat.rasterization(**kwargs, with_ut=False)

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -587,3 +587,105 @@ def test_rasterization(
                         f"reference:\n{formatted}"
                     ),
                 )
+
+
+def _make_distributed_validation_scene() -> dict:
+    C = 2
+    N = 8
+    width = 16
+    height = 12
+    means = torch.rand((N, 3), device=device)
+    means[:, 2] = means[:, 2] + 2.0
+    return {
+        "means": means,
+        "quats": torch.randn((N, 4), device=device),
+        "scales": torch.rand((N, 3), device=device) * 0.05 + 0.01,
+        "opacities": torch.rand((N,), device=device),
+        "colors": torch.rand((N, 3), device=device),
+        "viewmats": torch.eye(4, device=device).expand(C, -1, -1).clone(),
+        "Ks": torch.tensor(
+            [[20.0, 0.0, width / 2], [0.0, 20.0, height / 2], [0.0, 0.0, 1.0]],
+            device=device,
+        )
+        .expand(C, -1, -1)
+        .clone(),
+        "width": width,
+        "height": height,
+    }
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
+@pytest.mark.parametrize(
+    "case,match",
+    [
+        ("batch_dims", "batch dimensions"),
+        ("with_eval3d", "with_eval3d=True"),
+        ("with_ut", "with_ut=True"),
+        ("camera_model", "camera_model='ortho'"),
+        ("sparse_grad", "sparse_grad=True"),
+        ("absgrad", "absgrad=True"),
+        ("rolling_shutter", "rolling shutter"),
+        ("distortion", "camera distortion"),
+        ("global_z_order", "global_z_order=False"),
+        ("per_view_color", "per-Gaussian colors"),
+        ("rays", "rays"),
+        ("return_normals", "return_normals=True"),
+        ("lidar", "lidar coefficients"),
+    ],
+)
+def test_rasterization_distributed_rejects_unsupported_configs(
+    case: str,
+    match: str,
+):
+    # Every case raises during pure-Python validation before any distributed
+    # call, so no NCCL process group is needed.
+
+    kwargs = _make_distributed_validation_scene()
+    C = kwargs["viewmats"].shape[0]
+    N = kwargs["means"].shape[0]
+
+    if case == "batch_dims":
+        for key in ("means", "quats", "scales", "opacities", "colors"):
+            kwargs[key] = kwargs[key].expand(2, *kwargs[key].shape).clone()
+        kwargs["viewmats"] = kwargs["viewmats"].expand(2, C, 4, 4).clone()
+        kwargs["Ks"] = kwargs["Ks"].expand(2, C, 3, 3).clone()
+    elif case == "with_eval3d":
+        kwargs["with_eval3d"] = True
+    elif case == "with_ut":
+        kwargs["with_ut"] = True
+    elif case == "camera_model":
+        kwargs["camera_model"] = "ortho"
+    elif case == "sparse_grad":
+        kwargs["sparse_grad"] = True
+    elif case == "absgrad":
+        kwargs["absgrad"] = True
+    elif case == "rays":
+        kwargs["rays"] = torch.zeros(
+            (C, kwargs["height"], kwargs["width"], 6), device=device
+        )
+    elif case == "rolling_shutter":
+        kwargs["rolling_shutter"] = gsplat.RollingShutterType.ROLLING_TOP_TO_BOTTOM
+        kwargs["viewmats_rs"] = kwargs["viewmats"].clone()
+    elif case == "distortion":
+        kwargs["radial_coeffs"] = torch.zeros((C, 6), device=device)
+    elif case == "global_z_order":
+        kwargs["global_z_order"] = False
+    elif case == "per_view_color":
+        kwargs["colors"] = torch.rand((C, N, 3), device=device)
+    elif case == "return_normals":
+        kwargs["return_normals"] = True
+    elif case == "lidar":
+        from types import SimpleNamespace
+
+        # SimpleNamespace satisfies the n_columns/n_rows read that happens before
+        # the distributed-rejection block; the ValueError fires before any deeper
+        # lidar processing that would require a real LiDAR object.
+        kwargs["lidar_coeffs"] = SimpleNamespace(
+            n_columns=kwargs["width"], n_rows=kwargs["height"]
+        )
+    else:
+        raise AssertionError(f"unhandled case {case}")
+
+    with pytest.raises(ValueError, match=match):
+        gsplat.rasterization(**kwargs, distributed=True)

--- a/tests/test_relocation.py
+++ b/tests/test_relocation.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke coverage for the relocation CUDA op (gsplat.relocation.compute_relocation).
+
+The op is reached only through the MCMC densification strategy, which the rest
+of the suite does not exercise, so this gives it direct runtime coverage: that
+it runs end to end and returns finite, correctly-shaped tensors.
+"""
+
+import math
+
+import pytest
+import torch
+
+from gsplat.relocation import compute_relocation
+
+device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+
+
+def _binomial_table(n_max: int, device: torch.device) -> torch.Tensor:
+    # Lower-triangular Pascal's triangle, matching MCMCStrategy's state init.
+    binoms = torch.zeros((n_max, n_max), device=device)
+    for n in range(n_max):
+        for k in range(n + 1):
+            binoms[n, k] = math.comb(n, k)
+    return binoms
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="relocation is a CUDA op")
+@pytest.mark.parametrize("n_max", [5, 51])
+def test_compute_relocation_smoke(n_max: int):
+    torch.manual_seed(0)
+    N = 128
+    binoms = _binomial_table(n_max, device)
+    opacities = torch.rand(N, device=device) * 0.9 + 0.05
+    scales = torch.rand(N, 3, device=device) * 0.9 + 0.1
+    # ratios in [1, n_max] mirrors MCMCStrategy's clamped range; the kernel
+    # indexes binoms by ratio so the table must be (n_max, n_max) or larger.
+    ratios = torch.randint(1, n_max + 1, (N,), device=device).float()
+
+    new_opacities, new_scales = compute_relocation(opacities, scales, ratios, binoms)
+
+    assert new_opacities.shape == (N,)
+    assert new_scales.shape == (N, 3)
+    assert (new_opacities > 0).all() and (new_opacities <= 1).all()
+    assert torch.isfinite(new_scales).all()
+    assert (new_scales >= 0).all()


### PR DESCRIPTION
Main features / fixes:
- Masked-tile init; tile-intersection key/bit-width fixes; packed-launch grid guards; null-deref guards; race-free 2DGS densify
- Distributed-rasterization mode rejection
- GsplatViewer render-mode validation
- Move from the deprecated pycolmap repo to the official PyPI package
- CLI channel-count override; AOT NUM_CHANNELS handling
