### PR TITLE
Enable PPISP post-processing for all densification strategies

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -29,4 +29,4 @@ matplotlib
 git+https://github.com/rahul-goel/fused-ssim@a7c48d6dd7ac6dc39a7958c7c4452e0b10418f38
 git+https://github.com/harry7557558/fused-bilagrid@49f0ef06c9f81810fb9b5dd9027cf1844950cc16
 splines
-ppisp @ git+https://github.com/nv-tlabs/ppisp@v1.0.0
+ppisp @ git+https://github.com/nv-tlabs/ppisp@v1.2.1

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -469,10 +469,6 @@ class Runner:
                 f"Post-processing ({cfg.post_processing}) requires single-GPU training, "
                 f"but world_size={world_size}."
             )
-        if cfg.post_processing == "ppisp" and isinstance(cfg.strategy, DefaultStrategy):
-            raise ValueError(
-                f"PPISP post-processing requires MCMCStrategy at the moment."
-            )
 
         # Model
         feature_dim = 32 if cfg.app_opt else None
@@ -932,13 +928,17 @@ class Runner:
                 bkgd = torch.rand(1, 3, device=device)
                 colors = colors + bkgd * (1.0 - alphas)
 
-            self.cfg.strategy.step_pre_backward(
-                params=self.splats,
-                optimizers=self.optimizers,
-                state=self.strategy_state,
-                step=step,
-                info=info,
-            )
+            # While Gaussians are frozen for PPISP controller distillation the render
+            # output has requires_grad=False, so densification bookkeeping (e.g.
+            # DefaultStrategy's retain_grad) is both invalid and unnecessary.
+            if not self._gaussians_frozen:
+                self.cfg.strategy.step_pre_backward(
+                    params=self.splats,
+                    optimizers=self.optimizers,
+                    state=self.strategy_state,
+                    step=step,
+                    info=info,
+                )
 
             # loss
             if masks is not None:
@@ -1145,8 +1145,11 @@ class Runner:
             for scheduler in schedulers:
                 scheduler.step()
 
-            # Run post-backward steps after backward and optimizer
-            if isinstance(self.cfg.strategy, DefaultStrategy):
+            # Run post-backward steps after backward and optimizer.
+            # Skip structural updates while Gaussians are frozen for PPISP controller distillation.
+            if self._gaussians_frozen:
+                pass
+            elif isinstance(self.cfg.strategy, DefaultStrategy):
                 self.cfg.strategy.step_post_backward(
                     params=self.splats,
                     optimizers=self.optimizers,


### PR DESCRIPTION
## Summary
- **Enable PPISP with all densification strategies.** Remove the guard in `examples/simple_trainer.py` that hard-rejected `--post_processing ppisp` with `DefaultStrategy` (`"PPISP post-processing requires MCMCStrategy at the moment"`), so the 3DGS example works with both the `default` and `mcmc` subcommands.
- **Fix the underlying DefaultStrategy incompatibility.** When PPISP controller distillation freezes the Gaussians, the render output has `requires_grad=False`; `DefaultStrategy.step_pre_backward` then calls `retain_grad()` and raises `RuntimeError`. Skip the strategy densification callbacks (`step_pre_backward` / `step_post_backward`) while the Gaussians are frozen — this is strategy-agnostic and only affects the distillation phase, so non-distillation runs are byte-for-byte unchanged.
- **Bump the pinned `ppisp` dependency to v1.2.1**, the latest published release, which ships CUDA regularization kernels for faster regularization losses.

## Test plan
Trained all four combinations on the Tanks and Temples `train` sequence at full resolution — controller-off for 10k steps, controller-on for 13k steps (controller activated at step 10k = 3k distillation steps) — and rendered held-out novel views:

| Strategy | Controller | PSNR | SSIM | LPIPS |
|----------|-----------|------|------|-------|
| default  | off | 19.51 | 0.748 | 0.304 |
| default  | on  | 21.82 | 0.764 | 0.291 |
| mcmc     | off | 20.32 | 0.777 | 0.257 |
| mcmc     | on  | 23.00 | 0.791 | 0.250 |

All four configurations train to completion and render novel views successfully; the controller-distillation freeze works for both strategies.

Addresses nv-tlabs/ppisp#1.