### PR TITLE
Add MSVC support for function in RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu

### DIFF
--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
@@ -20,6 +20,10 @@
 
 #if GSPLAT_BUILD_3DGUT
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 #include <ATen/Dispatch.h>
 #include <ATen/Functions.h>
 #include <ATen/core/Tensor.h>
@@ -186,7 +190,15 @@ uint32_t ceil_log2_u64(uint64_t x) {
     if (x <= 1) {
         return 0;
     }
+
+#if defined(_MSC_VER)
+    unsigned long index;
+    _BitScanReverse64(&index, x - 1);
+    return static_cast<uint32_t>(index) + 1u;
+#else
     return 64u - static_cast<uint32_t>(__builtin_clzll(x - 1));
+#endif
+
 }
 
 } // namespace


### PR DESCRIPTION
Fixes #1007 

This fixes a Windows/MSVC build failure because `__builtin_clzll` is GCC/Clang-specific. On MSVC, the code now uses `_BitScanReverse64` from `<intrin.h>`. The existing `x <= 1` guard ensures the intrinsic is only called with a nonzero value.