### PR TITLE
fix: use parameters.fov_eps_rad in compute_histogram_equalization

### DIFF
--- a/gsplat/cuda/_lidar.py
+++ b/gsplat/cuda/_lidar.py
@@ -761,8 +761,7 @@ def compute_histogram_equalization(
     angles_az = angles[..., 0]
     angles_el = angles[..., 1]
 
-    # TODO: use parameters.fov_eps_rad
-    fov_eps_rad = 2 * torch.finfo(torch.float32).eps
+    fov_eps_rad = parameters.fov_eps_rad
     ranges_azimuth = (-fov_eps_rad, parameters.fov_horiz_rad.span + fov_eps_rad)
     ranges_elevation = (-fov_eps_rad, parameters.fov_vert_rad.span + fov_eps_rad)
     assert torch.all(


### PR DESCRIPTION
compute_histogram_equalization checks sensor angles against a hardcoded tolerance of 2 * torch.finfo(torch.float32).eps, while the lidar model's own tolerance is parameters.fov_eps_rad (fov_eps_factor * eps, default factor 4). Angles within the model's tolerance can therefore trip the azimuths are out of bounds / elevations are out of bounds assertions, and the user-supplied fov_eps_factor has no effect on this check.
This resolves the existing TODO on that line by using parameters.fov_eps_rad, making the histogram-equalization bounds consistent withvalid_sensor_angles and the CUDA side (Lidars.cuh), which already use fov_eps_rad.

Fixes #973