### PR TITLE
Add optional age-gated opacity reset (DefaultStrategy.reset_max_age)

### DIFF
--- a/gsplat/strategy/default.py
+++ b/gsplat/strategy/default.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import torch
 from typing_extensions import Literal
@@ -67,6 +67,15 @@ class DefaultStrategy(Strategy):
         refine_start_iter (int): Start refining GSs after this iteration. Default is 500.
         refine_stop_iter (int): Stop refining GSs after this iteration. Default is 15_000.
         reset_every (int): Reset opacities every this steps. Default is 3000.
+        reset_max_age (Optional[int]): If set, the periodic opacity reset only
+          affects Gaussians created (via duplicate/split) within the last this
+          many steps; mature Gaussians keep their opacities. This avoids the
+          alpha-cutoff gradient deadlock ("support collapse"): after a full
+          reset, a Gaussian's effective per-pixel alpha can fall below the
+          rasterizer's 1/255 cutoff at every contributing pixel, in which case
+          the skipped fragments supply exactly zero image-driven opacity
+          gradient and the Gaussian cannot recover through the image loss.
+          Default is None (reset all Gaussians; previous behavior).
         refine_every (int): Refine GSs every this steps. Default is 100.
         pause_refine_after_reset (int): Pause refining GSs until this number of steps after
           reset, Default is 0 (no pause at all) and one might want to set this number to the
@@ -106,6 +115,7 @@ class DefaultStrategy(Strategy):
     refine_start_iter: int = 500
     refine_stop_iter: int = 15_000
     reset_every: int = 3000
+    reset_max_age: Optional[int] = None
     refine_every: int = 100
     pause_refine_after_reset: int = 0
     absgrad: bool = False
@@ -127,6 +137,10 @@ class DefaultStrategy(Strategy):
         state = {"grad2d": None, "count": None, "scene_scale": scene_scale}
         if self.refine_scale2d_stop_iter > 0:
             state["radii"] = None
+        if self.reset_max_age is not None:
+            # birth step of each Gaussian; maintained generically by
+            # duplicate/split/remove and re-stamped for newly created Gaussians.
+            state["birth_step"] = None
         return state
 
     def check_sanity(
@@ -216,11 +230,17 @@ class DefaultStrategy(Strategy):
             torch.cuda.empty_cache()
 
         if step % self.reset_every == 0 and step > 0:
+            reset_mask = None
+            if self.reset_max_age is not None and isinstance(
+                state.get("birth_step"), torch.Tensor
+            ):
+                reset_mask = (step - state["birth_step"]) <= self.reset_max_age
             reset_opa(
                 params=params,
                 optimizers=optimizers,
                 state=state,
                 value=self.prune_opa * 2.0,
+                mask=reset_mask,
             )
 
     def _update_state(
@@ -255,6 +275,10 @@ class DefaultStrategy(Strategy):
             state["grad2d"] = torch.zeros(n_gaussian, device=grads.device)
         if state["count"] is None:
             state["count"] = torch.zeros(n_gaussian, device=grads.device)
+        if self.reset_max_age is not None and state.get("birth_step") is None:
+            state["birth_step"] = torch.zeros(
+                n_gaussian, dtype=torch.long, device=grads.device
+            )
         if self.refine_scale2d_stop_iter > 0 and state["radii"] is None:
             assert "radii" in info, "radii is required but missing."
             state["radii"] = torch.zeros(n_gaussian, device=grads.device)
@@ -318,6 +342,9 @@ class DefaultStrategy(Strategy):
                 mask=is_dupli,
                 scene=scene,
             )
+            if isinstance(state.get("birth_step"), torch.Tensor):
+                # duplicates are appended at the end
+                state["birth_step"][-n_dupli:] = step
 
         # new GSs added by duplication will not be split
         is_split = torch.cat(
@@ -337,6 +364,9 @@ class DefaultStrategy(Strategy):
                 revised_opacity=self.revised_opacity,
                 scene=scene,
             )
+            if isinstance(state.get("birth_step"), torch.Tensor):
+                # split() reorders to [kept, 2 * n_split new]
+                state["birth_step"][-2 * n_split :] = step
         return n_dupli, n_split
 
     @torch.no_grad()

--- a/gsplat/strategy/ops.py
+++ b/gsplat/strategy/ops.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import numpy as np
-from typing import TYPE_CHECKING, Callable, Dict, List, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import torch
 import torch.nn.functional as F
@@ -259,6 +259,7 @@ def reset_opa(
     optimizers: Dict[str, torch.optim.Optimizer],
     state: Dict[str, Tensor],
     value: float,
+    mask: Optional[Tensor] = None,
 ):
     """Inplace reset the opacities to the given post-sigmoid value.
 
@@ -266,16 +267,24 @@ def reset_opa(
         params: A dictionary of parameters.
         optimizers: A dictionary of optimizers, each corresponding to a parameter.
         value: The value to reset the opacities
+        mask: Optional [N] boolean mask selecting which Gaussians are reset.
+          If None (default), all Gaussians are reset (previous behavior).
     """
 
     def param_fn(name: str, p: Tensor) -> Tensor:
         if name == "opacities":
             opacities = torch.clamp(p, max=torch.logit(torch.tensor(value)).item())
+            if mask is not None:
+                opacities = torch.where(mask, opacities, p)
             return torch.nn.Parameter(opacities, requires_grad=p.requires_grad)
         else:
             raise ValueError(f"Unexpected parameter name: {name}")
 
     def optimizer_fn(key: str, v: Tensor) -> Tensor:
+        if mask is not None:
+            v = v.clone()
+            v[mask] = 0.0
+            return v
         return torch.zeros_like(v)
 
     # update the parameters and the state in the optimizers

--- a/tests/test_reset_max_age.py
+++ b/tests/test_reset_max_age.py
@@ -1,0 +1,83 @@
+"""Tests for age-gated opacity reset (DefaultStrategy.reset_max_age).
+
+CPU-only: exercises the strategy/ops layer, not the rasterizer.
+"""
+
+import torch
+
+from gsplat.strategy import DefaultStrategy
+from gsplat.strategy.ops import reset_opa
+
+
+def _make_params(n: int = 8, opacity: float = 0.9):
+    params = torch.nn.ParameterDict(
+        {
+            "means": torch.nn.Parameter(torch.randn(n, 3)),
+            "scales": torch.nn.Parameter(torch.randn(n, 3)),
+            "quats": torch.nn.Parameter(torch.randn(n, 4)),
+            "opacities": torch.nn.Parameter(
+                torch.logit(torch.full((n,), opacity))
+            ),
+        }
+    )
+    optimizers = {
+        name: torch.optim.Adam([p], lr=1e-3) for name, p in params.items()
+    }
+    # populate optimizer state so reset_opa has something to zero
+    loss = sum(p.sum() for p in params.values())
+    loss.backward()
+    for opt in optimizers.values():
+        opt.step()
+        opt.zero_grad(set_to_none=True)
+    return params, optimizers
+
+
+def test_reset_opa_mask_none_matches_previous_behavior():
+    params, optimizers = _make_params()
+    before = params["opacities"].detach().clone()
+    reset_opa(params, optimizers, state={}, value=0.01)
+    after = torch.sigmoid(params["opacities"].detach())
+    assert (after <= 0.01 + 1e-6).all()
+    assert not torch.equal(before, params["opacities"].detach())
+
+
+def test_reset_opa_mask_selects_subset():
+    params, optimizers = _make_params(n=8)
+    before = params["opacities"].detach().clone()
+    mask = torch.zeros(8, dtype=torch.bool)
+    mask[:3] = True
+    reset_opa(params, optimizers, state={}, value=0.01, mask=mask)
+    after = params["opacities"].detach()
+    assert (torch.sigmoid(after[:3]) <= 0.01 + 1e-6).all(), "masked must reset"
+    assert torch.equal(after[3:], before[3:]), "unmasked must be untouched"
+    # optimizer state zeroed only where masked
+    opt = optimizers["opacities"]
+    st = opt.state[params["opacities"]]
+    assert (st["exp_avg"][:3] == 0).all()
+    assert not (st["exp_avg"][3:] == 0).all()
+
+
+def test_default_strategy_initializes_and_uses_birth_step():
+    strategy = DefaultStrategy(reset_max_age=500)
+    state = strategy.initialize_state(scene_scale=1.0)
+    assert "birth_step" in state and state["birth_step"] is None
+
+    # simulate the lazily-initialized state after some training
+    n = 6
+    params, optimizers = _make_params(n=n)
+    state["birth_step"] = torch.zeros(n, dtype=torch.long)
+    state["birth_step"][-2:] = 2800  # two young Gaussians
+    step = 3000
+
+    reset_mask = (step - state["birth_step"]) <= strategy.reset_max_age
+    before = params["opacities"].detach().clone()
+    reset_opa(params, optimizers, state=state, value=0.01, mask=reset_mask)
+    after = params["opacities"].detach()
+    assert torch.equal(after[:-2], before[:-2]), "mature Gaussians preserved"
+    assert (torch.sigmoid(after[-2:]) <= 0.01 + 1e-6).all(), "young reset"
+
+
+def test_default_strategy_default_is_backward_compatible():
+    strategy = DefaultStrategy()
+    state = strategy.initialize_state(scene_scale=1.0)
+    assert "birth_step" not in state


### PR DESCRIPTION
## Motivation

Fixes the *support collapse* pathology described in #1011: `DefaultStrategy`'s full opacity reset (clamp to 0.01) can push a mature Gaussian's **effective per-pixel alpha** below the rasterizer's hard `1/255` cutoff at every contributing pixel; the cutoff also gates the backward pass, so the image-driven opacity gradient becomes exactly zero and the Gaussian cannot recover through the image loss.

In controlled CUDA probes (repro: https://github.com/randallyanh/gsplat-opacity-reset), full reset causes immediate PSNR drops of 2.7–7.6 dB, vs 0.0–1.8 dB when only the youngest 20% are reset, with the transition isolated exactly at `1/255`.

## Change

Adds an **opt-in** `reset_max_age: Optional[int] = None` to `DefaultStrategy`:

- `None` (default): behavior is unchanged — all opacities reset, no new state.
- Set to `k`: the periodic reset only affects Gaussians created (via duplicate/split) within the last `k` steps; mature Gaussians keep their opacities.

## Implementation notes

- `state["birth_step"]` rides the **existing generic state maintenance** in `duplicate` / `split` / `remove` (`for k, v in state.items(): ...`) — those ops are untouched.
- Newly created Gaussians are re-stamped in `_grow_gs`: duplicates are appended at the end; `split()` reorders to `[kept, 2·n_split new]`, so both tails are exact.
- `ops.reset_opa` gains an optional `mask` (default `None` = previous behavior). With a mask, unmasked opacities and their optimizer state are left untouched (optimizer state is zeroed only for reset Gaussians).
- `MCMCStrategy` is unaffected.

## Tests

`tests/test_reset_max_age.py` (CPU-only, strategy/ops layer):
- `mask=None` matches previous behavior
- masked reset touches exactly the masked subset (params + optimizer state)
- `reset_max_age` gating preserves mature / resets young
- default config remains backward compatible (no `birth_step` state)

## Limitations

Evidence is from controlled synthetic probes, not full-scene benchmarks; the flag is therefore opt-in with unchanged defaults. Happy to adjust naming/placement to match maintainer preferences.
