### PR TITLE
[NV] proj_features SH-kernel fusion, dispatcher-bypass fix, contracts test scoping

### DIFF
--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -33,13 +33,6 @@
 
 namespace gsplat {
 
-template <>
-struct TorchArgDef<TileIntersectResult> {
-    static auto to(const TileIntersectResult &r) {
-        return to_torch_args(r.tiles_per_gauss, r.isect_ids, r.flatten_ids);
-    }
-};
-
 namespace {
 
 // Validates intersect_tile inputs. Each checked assumption is a precondition

--- a/gsplat/cuda/csrc/Intersect.h
+++ b/gsplat/cuda/csrc/Intersect.h
@@ -28,6 +28,7 @@
 #include "Cameras.h"
 #include "Lidars.h"
 #include "ExternalDistortion.h"
+#include "TorchUtils.h"
 
 namespace at {
 class Tensor;
@@ -39,6 +40,21 @@ struct TileIntersectResult {
     at::Tensor tiles_per_gauss;
     at::Tensor isect_ids;
     at::Tensor flatten_ids;
+};
+
+template <> struct TorchArgDef<TileIntersectResult> {
+    static auto to(const TileIntersectResult &r) {
+        return to_torch_args(r.tiles_per_gauss, r.isect_ids, r.flatten_ids);
+    }
+
+    template <class TT>
+    static TileIntersectResult from(TT &&t) {
+        return {
+            .tiles_per_gauss = std::get<0>(std::forward<TT>(t)),
+            .isect_ids = std::get<1>(std::forward<TT>(t)),
+            .flatten_ids = std::get<2>(std::forward<TT>(t)),
+        };
+    }
 };
 
 TileIntersectResult intersect_tile(

--- a/gsplat/cuda/csrc/Projection.cpp
+++ b/gsplat/cuda/csrc/Projection.cpp
@@ -38,12 +38,6 @@
 
 namespace gsplat {
 
-template <> struct TorchArgDef<ProjectionUT3DGSFusedResult> {
-    static auto to(const ProjectionUT3DGSFusedResult &r) { return to_torch_args(
-        r.radii, r.means2d, r.depths, r.conics, r.compensations
-    ); }
-};
-
 #if GSPLAT_BUILD_3DGS
 
 namespace {

--- a/gsplat/cuda/csrc/Projection.h
+++ b/gsplat/cuda/csrc/Projection.h
@@ -28,6 +28,7 @@
 #include "Lidars.h"
 #include "ExternalDistortion.h"
 #include "Cameras.cuh"
+#include "TorchUtils.h"
 
 namespace at {
 class Tensor;
@@ -142,6 +143,23 @@ struct ProjectionUT3DGSFusedResult {
     at::Tensor depths;
     at::Tensor conics;
     at::optional<at::Tensor> compensations;
+};
+
+template <> struct TorchArgDef<ProjectionUT3DGSFusedResult> {
+    static auto to(const ProjectionUT3DGSFusedResult &r) { return to_torch_args(
+        r.radii, r.means2d, r.depths, r.conics, r.compensations
+    ); }
+
+    template <class TT>
+    static ProjectionUT3DGSFusedResult from(TT &&t) {
+        return {
+            .radii = std::get<0>(std::forward<TT>(t)),
+            .means2d = std::get<1>(std::forward<TT>(t)),
+            .depths = std::get<2>(std::forward<TT>(t)),
+            .conics = std::get<3>(std::forward<TT>(t)),
+            .compensations = std::get<4>(std::forward<TT>(t)),
+        };
+    }
 };
 
 ProjectionUT3DGSFusedResult

--- a/gsplat/cuda/csrc/Rasterization.h
+++ b/gsplat/cuda/csrc/Rasterization.h
@@ -369,6 +369,17 @@ template <> struct TorchArgDef<RasterizeToPixelsFromWorld3DGSResult> {
     static auto to(const RasterizeToPixelsFromWorld3DGSResult &r) { return to_torch_args(
         r.renders, r.alphas, r.last_ids, r.sample_counts, r.normals
     ); }
+
+    template <class TT>
+    static RasterizeToPixelsFromWorld3DGSResult from(TT &&t) {
+        return {
+            .renders = std::get<0>(std::forward<TT>(t)),
+            .alphas = std::get<1>(std::forward<TT>(t)),
+            .last_ids = std::get<2>(std::forward<TT>(t)),
+            .sample_counts = std::get<3>(std::forward<TT>(t)),
+            .normals = std::get<4>(std::forward<TT>(t)),
+        };
+    }
 };
 
 // Dispatcher entry for rasterize_to_pixels_from_world_3dgs, registered for both

--- a/gsplat/cuda/csrc/Rendering.cpp
+++ b/gsplat/cuda/csrc/Rendering.cpp
@@ -1007,58 +1007,126 @@ Rasterization3DGSResult rasterization_3dgs(
     // Turn colors/extra signals into [..., C, N, D] or [nnz, D] so the
     // rasterization kernels can process a uniform feature tensor.
     at::Tensor projected_features;
-    const bool needs_dirs =
-        (has_color && sh_degree >= 0) ||
-        (extra_signals.has_value() && extra_signals_sh_degree >= 0);
-    at::Tensor dirs;
-    if (needs_dirs) {
-        dirs = compute_classic_viewdirs(
-            means, proj_viewmats, viewmats_rs,
-            batch_ids_opt, camera_ids_opt, gaussian_ids_opt, indptr_opt,
-            B, C, N
-        );
+
+    // --- Fused fast-path: assemble [SH colors | direct extra | depth] in one
+    // coalesced CUDA kernel (folds SH eval + the +0.5/relu color bias + extra
+    // read + depth write + the cat()s). Eligible for the unpacked, non-
+    // distributed, SH-color path with at most direct (non-SH) float32 extra
+    // signals; numerically identical to the per-step path below. When taken, it
+    // also writes the depth column, so the append-depth concat is skipped.
+    bool fused_assembled = false;
+    const bool fused_eligible =
+        !packed && !distributed && has_color && sh_degree >= 0 &&
+        colors.has_value() && colors.value().dim() == 3 &&
+        means.is_cuda() && means.scalar_type() == at::kFloat &&
+        means.dim() == batch_ndim + 2 && means.size(-1) == 3 &&
+        (!extra_signals.has_value() ||
+         (extra_signals_sh_degree < 0 &&
+          extra_signals.value().scalar_type() == at::kFloat));
+    if (fused_eligible) {
+        at::Tensor campos = viewmat_to_camera_position(proj_viewmats);
+        if (viewmats_rs.has_value()) {
+            campos =
+                0.5 * (campos + viewmat_to_camera_position(viewmats_rs.value()));
+        }
+        const int64_t Dc = colors.value().size(-1);
+        const int64_t E =
+            extra_signals.has_value() ? extra_signals.value().size(-1) : 0;
+
+        bool extra_ok = true;
+        bool extra_has_c = false;
+        at::optional<at::Tensor> extra_in;
+        if (extra_signals.has_value()) {
+            const at::Tensor &es = extra_signals.value();
+            if (es.dim() == batch_ndim + 2 && es.size(batch_ndim) == N &&
+                es.size(-1) == E) {
+                extra_has_c = false; // [*batch, N, E] broadcast over cameras
+            } else if (es.dim() == batch_ndim + 3 &&
+                       es.size(batch_ndim) == C &&
+                       es.size(batch_ndim + 1) == N && es.size(-1) == E) {
+                extra_has_c = true; // [*batch, C, N, E] per-view
+            } else {
+                extra_ok = false;
+            }
+            extra_in = es;
+        }
+
+        const bool has_depth = append_depth;
+        const bool depth_is_zero = use_hit_distance;
+        const bool depth_ok =
+            !has_depth || depth_is_zero || (depths.scalar_type() == at::kFloat);
+        at::optional<at::Tensor> depths_in =
+            (has_depth && !depth_is_zero) ? at::optional<at::Tensor>(depths)
+                                          : c10::nullopt;
+
+        if (extra_ok && depth_ok && campos.is_cuda() &&
+            campos.scalar_type() == at::kFloat) {
+            projected_features = assemble_proj_features(
+                sh_degree, B, C, N, Dc, E,
+                /*color_post=*/2, // shift_relu (matches clamp_after_bias colors)
+                /*extra_post=*/0, // none (direct extra is layout-only, no bias)
+                has_depth, depth_is_zero, extra_has_c,
+                means, campos, colors.value(), extra_in, depths_in,
+                valid_gaussians
+            );
+            fused_assembled = true;
+        }
     }
 
-    std::vector<at::Tensor> feature_list;
-    if (has_color) {
-        TORCH_CHECK(colors.has_value(), "colors must be provided for color render modes");
-        // Colors are post-activation values unless an SH degree is provided.
-        // SH color output is clamped after the +0.5 color bias.
-        at::Tensor projected_colors = sh_degree >= 0
-            ? maybe_evaluate_feature_sh(
-                  sh_degree,
-                  colors.value(), dirs, valid_gaussians,
-                  gaussian_ids_opt,
-                  true // clamp_after_bias
-              )
-            : normalize_features_layout_3dgs(
-                  colors.value(), means,
-                  B, C, N,
-                  batch_ids_opt, camera_ids_opt, gaussian_ids_opt);
-        feature_list.push_back(projected_colors);
-    }
+    if (!fused_assembled) {
+        const bool needs_dirs =
+            (has_color && sh_degree >= 0) ||
+            (extra_signals.has_value() && extra_signals_sh_degree >= 0);
+        at::Tensor dirs;
+        if (needs_dirs) {
+            dirs = compute_classic_viewdirs(
+                means, proj_viewmats, viewmats_rs,
+                batch_ids_opt, camera_ids_opt, gaussian_ids_opt, indptr_opt,
+                B, C, N
+            );
+        }
 
-    if (extra_signals.has_value()) {
-        // Extra signals follow the same feature layout rules as colors, but
-        // unlike RGB SH output they are not clamped after evaluation.
-        at::Tensor projected_extra = extra_signals_sh_degree >= 0
-            ? maybe_evaluate_feature_sh(
-                  extra_signals_sh_degree,
-                  extra_signals.value(), dirs, valid_gaussians,
-                  gaussian_ids_opt,
-                  false // clamp_after_bias
-              )
-            : normalize_features_layout_3dgs(
-                  extra_signals.value(), means,
-                  B, C, N,
-                  batch_ids_opt, camera_ids_opt, gaussian_ids_opt);
-        feature_list.push_back(projected_extra);
-    }
+        std::vector<at::Tensor> feature_list;
+        if (has_color) {
+            TORCH_CHECK(colors.has_value(), "colors must be provided for color render modes");
+            // Colors are post-activation values unless an SH degree is provided.
+            // SH color output is clamped after the +0.5 color bias.
+            at::Tensor projected_colors = sh_degree >= 0
+                ? maybe_evaluate_feature_sh(
+                      sh_degree,
+                      colors.value(), dirs, valid_gaussians,
+                      gaussian_ids_opt,
+                      true // clamp_after_bias
+                  )
+                : normalize_features_layout_3dgs(
+                      colors.value(), means,
+                      B, C, N,
+                      batch_ids_opt, camera_ids_opt, gaussian_ids_opt);
+            feature_list.push_back(projected_colors);
+        }
 
-    if (feature_list.size() == 1) {
-        projected_features = feature_list[0];
-    } else if (feature_list.size() > 1) {
-        projected_features = at::cat(feature_list, -1);
+        if (extra_signals.has_value()) {
+            // Extra signals follow the same feature layout rules as colors, but
+            // unlike RGB SH output they are not clamped after evaluation.
+            at::Tensor projected_extra = extra_signals_sh_degree >= 0
+                ? maybe_evaluate_feature_sh(
+                      extra_signals_sh_degree,
+                      extra_signals.value(), dirs, valid_gaussians,
+                      gaussian_ids_opt,
+                      false // clamp_after_bias
+                  )
+                : normalize_features_layout_3dgs(
+                      extra_signals.value(), means,
+                      B, C, N,
+                      batch_ids_opt, camera_ids_opt, gaussian_ids_opt);
+            feature_list.push_back(projected_extra);
+        }
+
+        if (feature_list.size() == 1) {
+            projected_features = feature_list[0];
+        } else if (feature_list.size() > 1) {
+            projected_features = at::cat(feature_list, -1);
+        }
     }
 
     // Record the returned metadata now: the pre-scatter, rank-local projection
@@ -1114,13 +1182,21 @@ Rasterization3DGSResult rasterization_3dgs(
     }
 
     // --- Append requested depth channel ----------------------------------
+    // The fused fast-path already wrote the depth column into projected_features,
+    // so only the background depth channel needs assembling in that case.
     at::optional<at::Tensor> render_backgrounds = backgrounds;
     if (append_depth) {
-        const bool had_features = projected_features.defined();
-        projected_features =
-            append_depth_channel(projected_features, depths, use_hit_distance);
-        render_backgrounds =
-            append_background_depth_channel(backgrounds, means, C, had_features);
+        if (fused_assembled) {
+            render_backgrounds = append_background_depth_channel(
+                backgrounds, means, C, /*had_features=*/true
+            );
+        } else {
+            const bool had_features = projected_features.defined();
+            projected_features =
+                append_depth_channel(projected_features, depths, use_hit_distance);
+            render_backgrounds =
+                append_background_depth_channel(backgrounds, means, C, had_features);
+        }
     }
     TORCH_CHECK(
         projected_features.defined(),

--- a/gsplat/cuda/csrc/Rendering.cpp
+++ b/gsplat/cuda/csrc/Rendering.cpp
@@ -896,16 +896,36 @@ Rasterization3DGSResult rasterization_3dgs(
     // indices; the dense branch returns per-camera tensors and uses empty index
     // sentinels where the packed batch/camera/gaussian indices would go.
     if (with_ut) {
-        ProjectionUT3DGSFusedResult projection = projection_ut_3dgs_fused(
-            means, quats.value(), scales.value(), opacities,
-            viewmats, viewmats_rs, Ks,
-            image_width, image_height,
-            eps2d, near_plane, far_plane, radius_clip,
-            calc_compensations, camera_model, global_z_order,
-            ut_params, rolling_shutter,
-            radial_coeffs, tangential_coeffs, thin_prism_coeffs,
-            ftheta_coeffs, lidar_coeffs, external_distortion_params
-        );
+        ProjectionUT3DGSFusedResult projection = [&]() {
+            at::AutoGradMode no_grad(false);
+            return call_torch_op<&projection_ut_3dgs_fused>(
+                "gsplat::projection_ut_3dgs_fused",
+                means,
+                quats.value(),
+                scales.value(),
+                opacities,
+                viewmats,
+                viewmats_rs,
+                Ks,
+                image_width,
+                image_height,
+                eps2d,
+                near_plane,
+                far_plane,
+                radius_clip,
+                calc_compensations,
+                camera_model,
+                global_z_order,
+                ut_params,
+                rolling_shutter,
+                radial_coeffs,
+                tangential_coeffs,
+                thin_prism_coeffs,
+                ftheta_coeffs,
+                lidar_coeffs,
+                external_distortion_params
+            );
+        }();
         radii = projection.radii;
         means2d = projection.means2d;
         depths = projection.depths;
@@ -1234,23 +1254,27 @@ Rasterization3DGSResult rasterization_3dgs(
         as_optional_tensor(with_ut ? at::Tensor{} : kernel_opacities);
     TileIntersectResult isects =
         lidar_coeffs.has_value()
-        ? intersect_tile_lidar(
+        ? call_torch_op<&intersect_tile_lidar>(
+              "gsplat::intersect_tile_lidar",
               lidar_coeffs.value(),
               kernel_means2d, kernel_radii, kernel_depths,
               kernel_image_ids, kernel_gaussian_ids,
-              I,
+              std::optional<int64_t>(I),
               true, // sort
               segmented)
-        : intersect_tile(
+        : call_torch_op<&intersect_tile>(
+              "gsplat::intersect_tile",
               kernel_means2d, kernel_radii, kernel_depths,
               intersect_conics, intersect_opacities,
               kernel_image_ids, kernel_gaussian_ids,
-              I, tile_size, tile_width, tile_height,
+              std::optional<int64_t>(I), tile_size, tile_width, tile_height,
               true, // sort
               segmented);
 
-    at::Tensor isect_offsets =
-        intersect_offset(isects.isect_ids, I, tile_width, tile_height);
+    at::Tensor isect_offsets = call_torch_op<&intersect_offset>(
+        "gsplat::intersect_offset",
+        isects.isect_ids, I, tile_width, tile_height
+    );
     std::vector<int64_t> isect_offsets_shape =
         batch_shape_with(means, {C, tile_height, tile_width});
     isect_offsets = isect_offsets.reshape(isect_offsets_shape);
@@ -1277,10 +1301,11 @@ Rasterization3DGSResult rasterization_3dgs(
 
         if (with_eval3d) {
             RasterizeToPixelsFromWorld3DGSResult raster =
-                rasterize_to_pixels_from_world_3dgs(
+                call_torch_op<&rasterize_to_pixels_from_world_3dgs>(
+                "gsplat::rasterize_to_pixels_from_world_3dgs",
                 means, quats.value(), scales.value(),
                 features_chunk, kernel_opacities, backgrounds_chunk,
-                c10::nullopt,
+                at::optional<at::Tensor>(),
                 image_width, image_height, tile_size,
                 viewmats, viewmats_rs, Ks,
                 static_cast<int64_t>(camera_model), ut_params,
@@ -1674,16 +1699,19 @@ Rasterization2DGSResult rasterization_2dgs(
     const int64_t tile_height = static_cast<int64_t>(
         std::ceil(image_height / static_cast<double>(tile_size))
     );
-    TileIntersectResult isects = intersect_tile(
+    TileIntersectResult isects = call_torch_op<&intersect_tile>(
+        "gsplat::intersect_tile",
         means2d.contiguous(), radii.contiguous(), depths.contiguous(),
-        c10::nullopt, c10::nullopt,
+        at::optional<at::Tensor>(), at::optional<at::Tensor>(),
         contiguous_optional(image_ids), contiguous_optional(gaussian_ids_opt),
-        I, tile_size, tile_width, tile_height,
+        std::optional<int64_t>(I), tile_size, tile_width, tile_height,
         true, // sort
         false // segmented
     );
-    at::Tensor isect_offsets =
-        intersect_offset(isects.isect_ids, I, tile_width, tile_height);
+    at::Tensor isect_offsets = call_torch_op<&intersect_offset>(
+        "gsplat::intersect_offset",
+        isects.isect_ids, I, tile_width, tile_height
+    );
     isect_offsets = isect_offsets.reshape(
         batch_shape_with_2dgs(means, {C, tile_height, tile_width})
     );

--- a/gsplat/cuda/csrc/SphericalHarmonics.cpp
+++ b/gsplat/cuda/csrc/SphericalHarmonics.cpp
@@ -211,9 +211,323 @@ at::Tensor spherical_harmonics(
     ).colors;
 }
 
+// Fused forward assembly of proj_features = [SH colors | extra | (depth)] for
+// the unpacked rasterization path. Writes each complete output row in one
+// coalesced pass, replacing the SH-eval + cat(color, extra) + cat(.., depth)
+// chain. Forward-only; backward is handled by the autograd wrapper in C++.
+void assemble_proj_features_unpacked_fwd(
+    int64_t degrees_to_use,
+    int64_t B,
+    int64_t C,
+    int64_t N,
+    int64_t Dc,
+    int64_t E,
+    int64_t color_post,
+    int64_t extra_post,
+    bool has_depth,
+    bool depth_is_zero,
+    bool extra_has_c,
+    const at::Tensor &means,                  // [B, N, 3]
+    const at::Tensor &campos,                 // [B, C, 3]
+    const at::Tensor &coeffs,                 // [N, K, Dc]
+    const at::optional<at::Tensor> &extra,    // [B, C, N, E] or [B, N, E]
+    const at::optional<at::Tensor> &depths,   // [B, C, N]
+    const at::optional<at::Tensor> &masks,    // [B, C, N]
+    at::Tensor &out,                          // [B, C, N, Dc + E + has_depth]
+    const at::optional<at::Tensor> &relu_mask // [B, C, N, Dc]
+) {
+    DEVICE_GUARD(means);
+    CHECK_INPUT(means);
+    CHECK_INPUT(campos);
+    CHECK_INPUT(coeffs);
+    CHECK_CUDA(out);
+    TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+    TORCH_CHECK(means.scalar_type() == at::kFloat, "means must be float32");
+    TORCH_CHECK(campos.scalar_type() == at::kFloat, "campos must be float32");
+    TORCH_CHECK(out.scalar_type() == at::kFloat, "out must be float32");
+    TORCH_CHECK(means.size(-1) == 3, "means must have last dim 3");
+    TORCH_CHECK(campos.size(-1) == 3, "campos must have last dim 3");
+    TORCH_CHECK(coeffs.dim() == 3, "coeffs must be [N, K, Dc], got ", coeffs.sizes());
+    TORCH_CHECK(coeffs.size(-3) == N, "coeffs N (", coeffs.size(-3), ") != N (", N, ")");
+    TORCH_CHECK(coeffs.size(-1) == Dc, "coeffs Dc (", coeffs.size(-1), ") != Dc (", Dc, ")");
+    const int64_t lead = B * C * N;
+    TORCH_CHECK(means.numel() == B * N * 3, "means numel mismatch");
+    TORCH_CHECK(campos.numel() == B * C * 3, "campos numel mismatch");
+    const int64_t width = Dc + E + (has_depth ? 1 : 0);
+    TORCH_CHECK(out.size(-1) == width, "out width (", out.size(-1), ") != ", width);
+    TORCH_CHECK(out.numel() == lead * width, "out numel mismatch");
+    TORCH_CHECK(color_post >= 0 && color_post <= 2, "bad color_post ", color_post);
+    TORCH_CHECK(extra_post >= 0 && extra_post <= 2, "bad extra_post ", extra_post);
+
+    if (E > 0) {
+        TORCH_CHECK(extra.has_value(), "extra required when E > 0");
+        CHECK_INPUT(extra.value());
+        TORCH_CHECK(extra.value().scalar_type() == at::kFloat, "extra must be float32");
+        const int64_t want = (extra_has_c ? lead : B * N) * E;
+        TORCH_CHECK(extra.value().numel() == want, "extra numel ", extra.value().numel(), " != ", want);
+    }
+    if (has_depth && !depth_is_zero) {
+        TORCH_CHECK(depths.has_value(), "depths required when has_depth and !depth_is_zero");
+        CHECK_INPUT(depths.value());
+        TORCH_CHECK(depths.value().scalar_type() == at::kFloat, "depths must be float32");
+        TORCH_CHECK(depths.value().numel() == lead, "depths numel mismatch");
+    }
+    if (masks.has_value()) {
+        CHECK_INPUT(masks.value());
+        TORCH_CHECK(masks.value().numel() == lead, "masks numel mismatch");
+    }
+    if (relu_mask.has_value()) {
+        CHECK_CUDA(relu_mask.value());
+        TORCH_CHECK(relu_mask.value().is_contiguous(), "relu_mask must be contiguous");
+        TORCH_CHECK(relu_mask.value().scalar_type() == at::kBool, "relu_mask must be bool");
+        TORCH_CHECK(relu_mask.value().numel() == lead * Dc, "relu_mask numel mismatch");
+        TORCH_CHECK(color_post == 2, "relu_mask only valid with color_post=shift_relu");
+    }
+
+    launch_assemble_proj_features_unpacked_fwd_kernel(
+        static_cast<uint32_t>(B),
+        static_cast<uint32_t>(C),
+        static_cast<uint32_t>(N),
+        static_cast<uint32_t>(degrees_to_use),
+        static_cast<uint32_t>(Dc),
+        static_cast<uint32_t>(E),
+        static_cast<uint32_t>(color_post),
+        static_cast<uint32_t>(extra_post),
+        has_depth,
+        depth_is_zero,
+        extra_has_c,
+        means,
+        campos,
+        coeffs,
+        (E > 0) ? extra : c10::nullopt,
+        (has_depth && !depth_is_zero) ? depths : c10::nullopt,
+        masks,
+        out,
+        relu_mask
+    );
+}
+
+namespace {
+
+// Autograd wrapper around the fused assembler. Forward runs the single-kernel
+// assembly; backward routes the (relu-masked) color-slice gradient through the
+// SH backward kernel and passes extra/depth gradients straight through. Mirrors
+// the reference path (maybe_evaluate_feature_sh + cat) so the composed
+// rasterization autograd graph is numerically identical.
+class AssembleProjFeaturesAutograd
+    : public torch::autograd::Function<AssembleProjFeaturesAutograd> {
+public:
+    static at::Tensor forward(
+        torch::autograd::AutogradContext *ctx,
+        int64_t degrees_to_use,
+        int64_t B, int64_t C, int64_t N, int64_t Dc, int64_t E,
+        int64_t color_post, int64_t extra_post,
+        bool has_depth, bool depth_is_zero, bool extra_has_c,
+        const at::Tensor &means,
+        const at::Tensor &campos,
+        const at::Tensor &coeffs,
+        const at::optional<at::Tensor> &extra,
+        const at::optional<at::Tensor> &depths,
+        const at::optional<at::Tensor> &masks
+    ) {
+        at::Tensor means_c = means.contiguous();
+        at::Tensor campos_c = campos.contiguous();
+        at::Tensor coeffs_c = coeffs.contiguous();
+        at::optional<at::Tensor> extra_c =
+            (extra.has_value() && E > 0)
+                ? at::optional<at::Tensor>(extra.value().contiguous())
+                : c10::nullopt;
+        at::optional<at::Tensor> depths_c =
+            (has_depth && !depth_is_zero && depths.has_value())
+                ? at::optional<at::Tensor>(depths.value().contiguous())
+                : c10::nullopt;
+        at::optional<at::Tensor> masks_c =
+            masks.has_value()
+                ? at::optional<at::Tensor>(masks.value().contiguous())
+                : c10::nullopt;
+
+        const int64_t width = Dc + E + (has_depth ? 1 : 0);
+        // out layout: means leading batch dims, then (C, N, width).
+        std::vector<int64_t> out_shape(
+            means_c.sizes().begin(), means_c.sizes().end() - 2
+        );
+        out_shape.push_back(C);
+        out_shape.push_back(N);
+        out_shape.push_back(width);
+        at::Tensor out = at::empty(out_shape, means_c.options());
+
+        // Capture grad requirements now (the contiguous() copies above were made
+        // under the Function's no-grad forward, so their requires_grad is false).
+        const bool need_means = means.requires_grad();
+        const bool need_campos = campos.requires_grad();
+        const bool need_coeffs = coeffs.requires_grad();
+        const bool need_extra = extra.has_value() && extra.value().requires_grad();
+        const bool need_depths = depths.has_value() && depths.value().requires_grad();
+
+        // relu Jacobian mask (needed in backward for shift_relu) is emitted by
+        // the kernel when any color input requires grad.
+        at::optional<at::Tensor> relu_mask;
+        if (color_post == 2 && (need_means || need_campos || need_coeffs)) {
+            std::vector<int64_t> rm_shape(
+                means_c.sizes().begin(), means_c.sizes().end() - 2
+            );
+            rm_shape.push_back(C);
+            rm_shape.push_back(N);
+            rm_shape.push_back(Dc);
+            relu_mask = at::empty(
+                rm_shape, means_c.options().dtype(at::kBool)
+            );
+        }
+
+        launch_assemble_proj_features_unpacked_fwd_kernel(
+            static_cast<uint32_t>(B), static_cast<uint32_t>(C),
+            static_cast<uint32_t>(N), static_cast<uint32_t>(degrees_to_use),
+            static_cast<uint32_t>(Dc), static_cast<uint32_t>(E),
+            static_cast<uint32_t>(color_post), static_cast<uint32_t>(extra_post),
+            has_depth, depth_is_zero, extra_has_c,
+            means_c, campos_c, coeffs_c, extra_c, depths_c, masks_c,
+            out, relu_mask
+        );
+
+        ctx->save_for_backward(
+            {means_c, campos_c, coeffs_c,
+             masks_c.has_value() ? masks_c.value() : at::Tensor(),
+             relu_mask.has_value() ? relu_mask.value() : at::Tensor()}
+        );
+        ctx->saved_data["degrees_to_use"] = degrees_to_use;
+        ctx->saved_data["Dc"] = Dc;
+        ctx->saved_data["E"] = E;
+        ctx->saved_data["color_post"] = color_post;
+        ctx->saved_data["has_depth"] = has_depth;
+        ctx->saved_data["depth_is_zero"] = depth_is_zero;
+        ctx->saved_data["extra_has_c"] = extra_has_c;
+        ctx->saved_data["need_means"] = need_means;
+        ctx->saved_data["need_campos"] = need_campos;
+        ctx->saved_data["need_coeffs"] = need_coeffs;
+        ctx->saved_data["need_extra"] = need_extra;
+        ctx->saved_data["need_depths"] = need_depths;
+        return out;
+    }
+
+    static torch::autograd::variable_list backward(
+        torch::autograd::AutogradContext *ctx,
+        torch::autograd::variable_list grad_outputs
+    ) {
+        const auto saved = ctx->get_saved_variables();
+        const at::Tensor &means_c = saved[0];
+        const at::Tensor &campos_c = saved[1];
+        const at::Tensor &coeffs_c = saved[2];
+        const at::Tensor &masks_t = saved[3];
+        const at::Tensor &relu_mask = saved[4];
+        at::optional<at::Tensor> masks =
+            masks_t.defined() ? at::optional<at::Tensor>(masks_t) : c10::nullopt;
+
+        const int64_t degrees_to_use = ctx->saved_data["degrees_to_use"].toInt();
+        const int64_t Dc = ctx->saved_data["Dc"].toInt();
+        const int64_t E = ctx->saved_data["E"].toInt();
+        const int64_t color_post = ctx->saved_data["color_post"].toInt();
+        const bool has_depth = ctx->saved_data["has_depth"].toBool();
+        const bool depth_is_zero = ctx->saved_data["depth_is_zero"].toBool();
+        const bool extra_has_c = ctx->saved_data["extra_has_c"].toBool();
+
+        at::Tensor g = grad_outputs[0].contiguous();
+
+        const bool need_means = ctx->saved_data["need_means"].toBool();
+        const bool need_campos = ctx->saved_data["need_campos"].toBool();
+        const bool need_coeffs = ctx->saved_data["need_coeffs"].toBool();
+        const bool need_extra = ctx->saved_data["need_extra"].toBool();
+        const bool need_depths = ctx->saved_data["need_depths"].toBool();
+        const bool need_dir = need_means || need_campos;
+
+        at::Tensor v_means, v_campos, v_coeffs, v_extra, v_depths;
+
+        if (need_means || need_campos || need_coeffs) {
+            const int64_t batch_ndim = means_c.dim() - 2;
+            // dirs = means[..., None, :, :] - campos[..., None, :] -> [*b, C, N, 3]
+            at::Tensor dirs =
+                means_c.unsqueeze(batch_ndim)
+                    .sub(campos_c.unsqueeze(-2))
+                    .contiguous();
+            at::Tensor g_color = g.narrow(-1, 0, Dc);
+            if (color_post == 2 && relu_mask.defined()) {
+                g_color = g_color.mul(relu_mask);
+            }
+            g_color = g_color.contiguous();
+
+            at::Tensor v_coeffs_accum =
+                at::zeros(coeffs_c.sizes(), coeffs_c.options().dtype(at::kFloat));
+            at::Tensor v_dirs;
+            if (need_dir) {
+                v_dirs = at::zeros_like(dirs);
+            }
+            launch_spherical_harmonics_bwd_kernel(
+                static_cast<uint32_t>(degrees_to_use),
+                dirs, coeffs_c, masks, g_color,
+                v_coeffs_accum,
+                need_dir ? at::optional<at::Tensor>(v_dirs) : c10::nullopt
+            );
+            if (need_coeffs) {
+                v_coeffs = (coeffs_c.scalar_type() == at::kFloat)
+                    ? v_coeffs_accum
+                    : v_coeffs_accum.to(coeffs_c.scalar_type());
+            }
+            if (need_dir) {
+                if (need_means) {
+                    v_means = v_dirs.sum(batch_ndim); // reduce over C
+                }
+                if (need_campos) {
+                    v_campos = v_dirs.sum(-2).neg(); // reduce over N
+                }
+            }
+        }
+
+        if (E > 0 && need_extra) {
+            at::Tensor g_extra = g.narrow(-1, Dc, E);
+            v_extra = extra_has_c
+                ? g_extra.contiguous()
+                : g_extra.sum(means_c.dim() - 2); // reduce broadcast over C
+        }
+
+        if (has_depth && !depth_is_zero && need_depths) {
+            v_depths = g.narrow(-1, Dc + E, 1).squeeze(-1).contiguous();
+        }
+
+        // grads in forward-input order (non-tensor inputs -> undefined Tensor).
+        torch::autograd::variable_list grads(17);
+        grads[11] = v_means;
+        grads[12] = v_campos;
+        grads[13] = v_coeffs;
+        grads[14] = v_extra;
+        grads[15] = v_depths;
+        return grads;
+    }
+};
+
+} // namespace
+
+at::Tensor assemble_proj_features(
+    int64_t degrees_to_use,
+    int64_t B, int64_t C, int64_t N, int64_t Dc, int64_t E,
+    int64_t color_post, int64_t extra_post,
+    bool has_depth, bool depth_is_zero, bool extra_has_c,
+    const at::Tensor &means,
+    const at::Tensor &campos,
+    const at::Tensor &coeffs,
+    const at::optional<at::Tensor> &extra,
+    const at::optional<at::Tensor> &depths,
+    const at::optional<at::Tensor> &masks
+) {
+    return AssembleProjFeaturesAutograd::apply(
+        degrees_to_use, B, C, N, Dc, E, color_post, extra_post,
+        has_depth, depth_is_zero, extra_has_c,
+        means, campos, coeffs, extra, depths, masks
+    );
+}
+
 void register_spherical_harmonics_cuda_impl(torch::Library &m) {
     m.impl("spherical_harmonics", to_torch_op<&spherical_harmonics_fwd>);
     m.impl("spherical_harmonics_bwd", to_torch_op<&spherical_harmonics_bwd>);
+    m.impl("assemble_proj_features_unpacked_fwd", &assemble_proj_features_unpacked_fwd);
 }
 
 } // namespace gsplat

--- a/gsplat/cuda/csrc/SphericalHarmonics.h
+++ b/gsplat/cuda/csrc/SphericalHarmonics.h
@@ -56,4 +56,79 @@ void launch_spherical_harmonics_bwd_kernel(
     at::optional<at::Tensor> v_dirs // [..., N, 3]
 );
 
+// Fused forward assembly of proj_features = [SH colors | extra | (depth)] for
+// the unpacked rasterization path. Writes each complete output row in one
+// coalesced pass, replacing the SH-eval + cat(color, extra) + cat(.., depth)
+// chain.
+void launch_assemble_proj_features_unpacked_fwd_kernel(
+    const uint32_t B,
+    const uint32_t C,
+    const uint32_t N,
+    const uint32_t degrees_to_use,
+    const uint32_t Dc,
+    const uint32_t E,
+    const uint32_t color_post,
+    const uint32_t extra_post,
+    const bool has_depth,
+    const bool depth_is_zero,
+    const bool extra_has_c,
+    const at::Tensor means,                  // [B, N, 3]
+    const at::Tensor campos,                 // [B, C, 3]
+    const at::Tensor coeffs,                 // [N, K, Dc]
+    const at::optional<at::Tensor> extra,    // [B, C, N, E] or [B, N, E]
+    const at::optional<at::Tensor> depths,   // [B, C, N]
+    const at::optional<at::Tensor> masks,    // [B, C, N]
+    at::Tensor out,                          // [B, C, N, Dc + E + has_depth]
+    const at::optional<at::Tensor> relu_mask // [B, C, N, Dc]
+);
+
+// Autograd-aware fused assembly of proj_features = [SH colors | extra | (depth)]
+// for the unpacked rasterization path. Forward writes the whole tensor in one
+// coalesced kernel (folding SH eval + the +0.5/relu post-op + extra read + depth
+// write); backward routes the color-slice gradient through the SH backward and
+// passes extra/depth gradients straight through. Declared for cross-TU callers
+// (Rendering.cpp orchestration). Returns proj_features [*batch, C, N, width].
+at::Tensor assemble_proj_features(
+    int64_t degrees_to_use,
+    int64_t B,
+    int64_t C,
+    int64_t N,
+    int64_t Dc,
+    int64_t E,
+    int64_t color_post,
+    int64_t extra_post,
+    bool has_depth,
+    bool depth_is_zero,
+    bool extra_has_c,
+    const at::Tensor &means,
+    const at::Tensor &campos,
+    const at::Tensor &coeffs,
+    const at::optional<at::Tensor> &extra,
+    const at::optional<at::Tensor> &depths,
+    const at::optional<at::Tensor> &masks
+);
+
+// Forward-only dispatcher op: assembles proj_features in place into `out`.
+void assemble_proj_features_unpacked_fwd(
+    int64_t degrees_to_use,
+    int64_t B,
+    int64_t C,
+    int64_t N,
+    int64_t Dc,
+    int64_t E,
+    int64_t color_post,
+    int64_t extra_post,
+    bool has_depth,
+    bool depth_is_zero,
+    bool extra_has_c,
+    const at::Tensor &means,
+    const at::Tensor &campos,
+    const at::Tensor &coeffs,
+    const at::optional<at::Tensor> &extra,
+    const at::optional<at::Tensor> &depths,
+    const at::optional<at::Tensor> &masks,
+    at::Tensor &out,
+    const at::optional<at::Tensor> &relu_mask
+);
+
 } // namespace gsplat

--- a/gsplat/cuda/csrc/SphericalHarmonicsCUDA.cu
+++ b/gsplat/cuda/csrc/SphericalHarmonicsCUDA.cu
@@ -19,6 +19,7 @@
 #include <ATen/OpMathType.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/cuda/Atomic.cuh>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAStream.h>
 #include <cooperative_groups.h>
 #include <type_traits>
@@ -712,6 +713,394 @@ void launch_spherical_harmonics_bwd_kernel(
         at::kFloat,
         at::kHalf
     );
+}
+
+// ===========================================================================
+// Fused proj_features assembly (forward)
+// ===========================================================================
+// Fused post-transform applied to each SH output element before it is written,
+// matching the per-feature adjustment the caller used to do as separate strided
+// elementwise kernels. 0: none; 1: shift (+0.5); 2: shift_relu (max(x+0.5, 0)).
+enum SHPostOp : uint32_t { SH_POST_NONE = 0, SH_POST_SHIFT = 1, SH_POST_SHIFT_RELU = 2 };
+
+template <typename T>
+__device__ __forceinline__ T apply_sh_post(T v, const uint32_t post_op) {
+    if (post_op == SH_POST_SHIFT) {
+        return v + T(0.5);
+    }
+    if (post_op == SH_POST_SHIFT_RELU) {
+        T s = v + T(0.5);
+        return s > T(0) ? s : T(0);
+    }
+    return v;
+}
+
+// K=16, D=3 SH evaluation for the RGB hot path: wide uint4 / ushort4 loads of a
+// single Gaussian's 48 coefficients, then evaluate all 3 channels. DEGREE is a
+// template parameter so sh_coeffs[] is sized to exactly what it needs. Shared by
+// the standalone SH kernel and the fused proj-features assembly kernel.
+template <typename scalar_t, typename opmath_t, int DEGREE>
+__device__ __forceinline__ void sh16_3channel_eval(
+    const scalar_t *__restrict__ coeffs_gaussian, // coeffs + gaussian_id * 16 * 3
+    const vec3 &dir,
+    opmath_t out_color[3]
+) {
+    constexpr bool COEFFS_FP32 = std::is_same_v<scalar_t, float>;
+
+    // Wide-load shape per (DEGREE, coeff dtype):
+    //  DEGREE 0/1 (small payload): ushort4 for fp16, uint4 for fp32, PACK_SIZE = 4.
+    //  DEGREE 2/3 (larger payload): always uint4, PACK_SIZE = 4 (fp32) or 8 (fp16).
+    constexpr int PACK_SIZE = (DEGREE <= 1) ? 4 : (COEFFS_FP32 ? 4 : 8);
+    constexpr int LOAD_COUNT =
+        (DEGREE == 0) ? 1 :
+        (DEGREE == 1) ? 3 :
+        (DEGREE == 2) ? (COEFFS_FP32 ? 7 : 4) :
+                        (COEFFS_FP32 ? 12 : 6);
+    constexpr int N_COEFFS = LOAD_COUNT * PACK_SIZE;
+
+    using V = std::conditional_t<(DEGREE <= 1) && !COEFFS_FP32, ushort4, uint4>;
+
+    opmath_t sh_coeffs[N_COEFFS];
+    #pragma unroll
+    for (int i = 0; i < LOAD_COUNT; ++i) {
+        alignas(alignof(V)) scalar_t mem[PACK_SIZE];
+        reinterpret_cast<V *>(mem)[0] = reinterpret_cast<const V *>(coeffs_gaussian)[i];
+        #pragma unroll
+        for (int j = 0; j < PACK_SIZE; ++j) {
+            sh_coeffs[i * PACK_SIZE + j] = static_cast<opmath_t>(mem[j]);
+        }
+    }
+
+    sh_coeffs_to_color_fast<opmath_t>(DEGREE, 3, 0, dir, sh_coeffs, out_color);
+    sh_coeffs_to_color_fast<opmath_t>(DEGREE, 3, 1, dir, sh_coeffs, out_color);
+    sh_coeffs_to_color_fast<opmath_t>(DEGREE, 3, 2, dir, sh_coeffs, out_color);
+}
+
+// Unified fused assembler: proj_features = [SH colors | extra | (depth)] for the
+// unpacked rasterization path. A block stages TILE_ROWS consecutive Gaussians of
+// one (batch, camera) pair through shared memory so every global access is fully
+// coalesced. This single kernel subsumes the generic / k16 variants via
+// compile-time specialization:
+//   * K16FAST=true  -> wide-load RGB SH (sh16_3channel_eval), K==16, Dc==3.
+//   * K16FAST=false -> generic per-channel SH (sh_coeffs_to_color_fast), any K/Dc.
+// The optional tensors are lifted to compile-time "soft booleans" (HAS_DEPTH,
+// DEPTH_ZERO, HAS_MASK, EMIT_RELU) so an absent tensor's branch and its global
+// traffic vanish entirely from the corresponding instantiation. `scalar_t` is the
+// coeff dtype (fp16/fp32); means/campos/extra/depths/out are opmath_t (fp32).
+template <
+    typename scalar_t, typename opmath_t, int DEGREE, bool K16FAST,
+    bool HAS_DEPTH, bool DEPTH_ZERO, bool HAS_MASK, bool EMIT_RELU>
+__global__ void __launch_bounds__(256)
+assemble_proj_features_kernel(
+    const uint32_t B,
+    const uint32_t C,
+    const uint32_t N,
+    const uint32_t degrees_to_use,           // runtime SH degree (generic path only)
+    const uint32_t K,                        // SH bands (coeffs dim -2); 16 when K16FAST
+    const uint32_t Dc,                       // SH color channels; 3 when K16FAST
+    const uint32_t E,                        // extra-signal channels
+    const uint32_t width,                    // dc + E + (HAS_DEPTH ? 1 : 0)
+    const uint32_t color_post,               // SHPostOp applied to colors
+    const uint32_t extra_post,               // SHPostOp applied to extra
+    const bool extra_has_c,                  // extra indexed by (b,c,n) vs broadcast (b,n)
+    const float *__restrict__ means,         // [B, N, 3]
+    const float *__restrict__ campos,        // [B, C, 3]
+    const scalar_t *__restrict__ coeffs,     // [N, K, Dc]
+    const opmath_t *__restrict__ extra,      // [B, C, N, E] or [B, N, E]; null if E == 0
+    const opmath_t *__restrict__ depths,     // [B, C, N]; null when DEPTH_ZERO or !HAS_DEPTH
+    const bool *__restrict__ masks,          // [B, C, N]; null when !HAS_MASK
+    opmath_t *__restrict__ out,              // [B, C, N, width]
+    bool *__restrict__ relu_mask             // [B, C, N, dc]; null when !EMIT_RELU
+) {
+    constexpr uint32_t TILE_ROWS = 64;
+    constexpr uint32_t THREADS = 256;
+    // dc / cstride collapse to compile-time constants on the K16FAST path so the
+    // color loops fully unroll; on the generic path they track the runtime K/Dc.
+    const uint32_t dc = K16FAST ? 3u : Dc;
+    const uint32_t cstride = K16FAST ? 48u : (K * Dc);  // coeff elems per gaussian
+    const uint32_t tid = threadIdx.x;
+
+    // blockIdx.x -> n-tile within a (b,c); blockIdx.y -> flattened (b*C + c).
+    const uint32_t bc = blockIdx.y;
+    const uint32_t b = bc / C;
+    const uint32_t rowBase = blockIdx.x * TILE_ROWS;
+    if (rowBase >= N) {
+        return;
+    }
+    const uint32_t rows = (N - rowBase < TILE_ROWS) ? (N - rowBase) : TILE_ROWS;
+
+    // Dynamic shared layout (16B-aligned base; per-coeff-row alignment preserved):
+    //   [coeffs: TILE_ROWS*cstride scalar_t][means: TILE_ROWS*3 float][out: TILE_ROWS*width float]
+    extern __shared__ __align__(16) char smem_raw[];
+    scalar_t *smem_coeffs = reinterpret_cast<scalar_t *>(smem_raw);
+    float *smem_means =
+        reinterpret_cast<float *>(smem_coeffs + TILE_ROWS * cstride);
+    float *smem_out = smem_means + TILE_ROWS * 3;
+
+    // --- coalesced loads into shared ---
+    // coeffs are indexed by gaussian n only (shared across cameras).
+    for (uint32_t i = tid; i < rows * cstride; i += THREADS) {
+        smem_coeffs[i] = coeffs[static_cast<size_t>(rowBase) * cstride + i];
+    }
+    for (uint32_t i = tid; i < rows * 3u; i += THREADS) {
+        smem_means[i] = means[(static_cast<size_t>(b) * N + rowBase) * 3 + i];
+    }
+    if (E > 0) {
+        const opmath_t eshift =
+            (extra_post == SH_POST_SHIFT) ? opmath_t(0.5) : opmath_t(0);
+        const size_t ebase = extra_has_c
+            ? (static_cast<size_t>(bc) * N + rowBase) * E
+            : (static_cast<size_t>(b) * N + rowBase) * E;
+        for (uint32_t i = tid; i < rows * E; i += THREADS) {
+            const uint32_t lr = i / E;
+            const uint32_t e = i % E;
+            smem_out[lr * width + dc + e] = extra[ebase + i] + eshift;
+        }
+    }
+    if constexpr (HAS_DEPTH) {
+        for (uint32_t i = tid; i < rows; i += THREADS) {
+            opmath_t d;
+            if constexpr (DEPTH_ZERO) {
+                d = opmath_t(0);
+            } else {
+                d = depths[static_cast<size_t>(bc) * N + rowBase + i];
+            }
+            smem_out[i * width + dc + E] = d;
+        }
+    }
+    __syncthreads();
+
+    // --- per-row SH evaluation out of shared ---
+    const float cx = campos[static_cast<size_t>(bc) * 3 + 0];
+    const float cy = campos[static_cast<size_t>(bc) * 3 + 1];
+    const float cz = campos[static_cast<size_t>(bc) * 3 + 2];
+    for (uint32_t lr = tid; lr < rows; lr += THREADS) {
+        const uint32_t n = rowBase + lr;
+        const size_t gidx = static_cast<size_t>(bc) * N + n;
+        float *dst = smem_out + lr * width;
+        bool active = true;
+        if constexpr (HAS_MASK) {
+            active = masks[gidx];
+        }
+        if (active) {
+            // View direction = gaussian center - camera position (un-normalized;
+            // SH normalizes internally). Folds compute_directions in.
+            const float *mp = smem_means + lr * 3;
+            const vec3 dir = vec3(mp[0] - cx, mp[1] - cy, mp[2] - cz);
+            if constexpr (K16FAST) {
+                opmath_t col[3];
+                sh16_3channel_eval<scalar_t, opmath_t, DEGREE>(
+                    smem_coeffs + lr * 48, dir, col
+                );
+                dst[0] = apply_sh_post<opmath_t>(col[0], color_post);
+                dst[1] = apply_sh_post<opmath_t>(col[1], color_post);
+                dst[2] = apply_sh_post<opmath_t>(col[2], color_post);
+            } else {
+                const scalar_t *crow = smem_coeffs + lr * cstride;
+                for (uint32_t ch = 0; ch < dc; ++ch) {
+                    sh_coeffs_to_color_fast<scalar_t>(
+                        degrees_to_use, dc, ch, dir, crow, dst
+                    );
+                }
+                if (color_post != SH_POST_NONE) {
+                    for (uint32_t ch = 0; ch < dc; ++ch) {
+                        dst[ch] = apply_sh_post<opmath_t>(dst[ch], color_post);
+                    }
+                }
+            }
+            // Emit the relu Jacobian mask inline (clamped value already in a
+            // register), folding away the separate strided compare kernel.
+            if constexpr (EMIT_RELU) {
+                bool *m = relu_mask + gidx * dc;
+                for (uint32_t ch = 0; ch < dc; ++ch) {
+                    m[ch] = dst[ch] > opmath_t(0);
+                }
+            }
+        } else {
+            for (uint32_t ch = 0; ch < dc; ++ch) {
+                dst[ch] = opmath_t(0);
+            }
+        }
+    }
+    __syncthreads();
+
+    // --- coalesced bulk store ---
+    const size_t obase = (static_cast<size_t>(bc) * N + rowBase) * width;
+    for (uint32_t i = tid; i < rows * width; i += THREADS) {
+        out[obase + i] = smem_out[i];
+    }
+}
+
+void launch_assemble_proj_features_unpacked_fwd_kernel(
+    const uint32_t B,
+    const uint32_t C,
+    const uint32_t N,
+    const uint32_t degrees_to_use,
+    const uint32_t Dc,
+    const uint32_t E,
+    const uint32_t color_post,
+    const uint32_t extra_post,
+    const bool has_depth,
+    const bool depth_is_zero,
+    const bool extra_has_c,
+    const at::Tensor means,                // [B, N, 3]
+    const at::Tensor campos,               // [B, C, 3]
+    const at::Tensor coeffs,               // [N, K, Dc]
+    const at::optional<at::Tensor> extra,  // [B, C, N, E] or [B, N, E]
+    const at::optional<at::Tensor> depths, // [B, C, N]
+    const at::optional<at::Tensor> masks,  // [B, C, N]
+    at::Tensor out,                        // [B, C, N, width]
+    const at::optional<at::Tensor> relu_mask // [B, C, N, Dc]
+) {
+    const int64_t n_threads = static_cast<int64_t>(B) * C * N;
+    if (n_threads == 0) {
+        return;
+    }
+    const uint32_t K = coeffs.size(-2);
+    const uint32_t width = static_cast<uint32_t>(out.size(-1));
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    auto *masks_ptr =
+        masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr;
+    auto *extra_ptr =
+        extra.has_value() ? extra.value().const_data_ptr<float>() : nullptr;
+    auto *depths_ptr =
+        depths.has_value() ? depths.value().const_data_ptr<float>() : nullptr;
+    auto *means_ptr = means.const_data_ptr<float>();
+    auto *campos_ptr = campos.const_data_ptr<float>();
+    auto *out_ptr = out.data_ptr<float>();
+    auto *relu_mask_ptr =
+        relu_mask.has_value() ? relu_mask.value().data_ptr<bool>() : nullptr;
+
+    // Single tiled kernel for every shape: a block stages one (b,c) n-tile
+    // through shared memory, so global coeff alignment is irrelevant (the wide
+    // SH loads come from shared, which is always 16B aligned per row).
+    constexpr uint32_t TILE_ROWS = 64;
+    dim3 threads(256);
+    dim3 grid((N + TILE_ROWS - 1) / TILE_ROWS, B * C);
+
+    std::variant<float, at::Half> coeff_variant;
+    switch (coeffs.scalar_type()) {
+    case at::kFloat: coeff_variant.emplace<float>(); break;
+    case at::kHalf:  coeff_variant.emplace<at::Half>(); break;
+    default:
+        TORCH_CHECK(false, "assemble_proj_features: unsupported coeffs dtype ", coeffs.scalar_type());
+    }
+
+    // Lift the optional tensors to compile-time "soft booleans". depth_mode
+    // folds (has_depth, depth_is_zero) into one 3-state so the impossible
+    // (!has_depth && depth_is_zero) instantiation is never generated.
+    const int depth_mode = !has_depth ? 0 : (depth_is_zero ? 2 : 1);
+    const int mask_on = (masks_ptr != nullptr) ? 1 : 0;
+    const int relu_on = (relu_mask_ptr != nullptr) ? 1 : 0;
+    const bool k16 = (K == 16 && Dc == 3);
+
+    if (k16) {
+        // RGB SH hot path: DEGREE is specialized so the wide-load evaluator
+        // unrolls to exactly its coefficient count.
+        const int deg = std::min<int>(degrees_to_use, 3);
+        const bool dispatched = dispatch::dispatch(
+            dispatch::TypeParam<float, at::Half>{coeff_variant},
+            dispatch::IntParam<0, 1, 2, 3>{deg},
+            dispatch::IntParam<0, 1, 2>{depth_mode},
+            dispatch::IntParam<0, 1>{mask_on},
+            dispatch::IntParam<0, 1>{relu_on},
+            [&]<typename CoeffT, typename Deg, typename Dm, typename Mk, typename Rl>() {
+                constexpr int DEGREE = Deg::value;
+                constexpr bool HAS_DEPTH = Dm::value != 0;
+                constexpr bool DEPTH_ZERO = Dm::value == 2;
+                constexpr bool HAS_MASK = Mk::value != 0;
+                constexpr bool EMIT_RELU = Rl::value != 0;
+                const size_t smem =
+                    static_cast<size_t>(TILE_ROWS) * 48 * sizeof(CoeffT) +
+                    static_cast<size_t>(TILE_ROWS) * 3 * sizeof(float) +
+                    static_cast<size_t>(TILE_ROWS) * width * sizeof(float);
+                // Opt in to >48KB dynamic shared memory (and surface an actionable
+                // error if the shape exceeds the device budget). The attribute is
+                // set once per kernel specialization: the request only grows with
+                // width, which is constant across a run, so the per-launch driver
+                // roundtrip is amortized to a single call.
+                static int configured_smem = -1;
+                if (static_cast<int>(smem) > configured_smem) {
+                    if (cudaFuncSetAttribute(
+                            assemble_proj_features_kernel<
+                                CoeffT, float, DEGREE, /*K16FAST=*/true,
+                                HAS_DEPTH, DEPTH_ZERO, HAS_MASK, EMIT_RELU>,
+                            cudaFuncAttributeMaxDynamicSharedMemorySize,
+                            static_cast<int>(smem)
+                        ) != cudaSuccess) {
+                        AT_ERROR(
+                            "assemble_proj_features: failed to set dynamic shared "
+                            "memory (requested ", smem, " bytes; width=", width,
+                            "); shape exceeds this device's shared-memory budget."
+                        );
+                    }
+                    configured_smem = static_cast<int>(smem);
+                }
+                assemble_proj_features_kernel<
+                    CoeffT, float, DEGREE, /*K16FAST=*/true,
+                    HAS_DEPTH, DEPTH_ZERO, HAS_MASK, EMIT_RELU>
+                    <<<grid, threads, smem, stream>>>(
+                        B, C, N, degrees_to_use, K, Dc, E, width,
+                        color_post, extra_post, extra_has_c,
+                        means_ptr, campos_ptr, coeffs.const_data_ptr<CoeffT>(),
+                        extra_ptr, depths_ptr, masks_ptr, out_ptr, relu_mask_ptr
+                    );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+        );
+        TORCH_CHECK(dispatched, "assemble_proj_features: dispatch failed for sh_degree=", degrees_to_use);
+    } else {
+        // Generic path: any K/Dc; the SH degree stays a runtime argument so this
+        // is not specialized per degree.
+        const bool dispatched = dispatch::dispatch(
+            dispatch::TypeParam<float, at::Half>{coeff_variant},
+            dispatch::IntParam<0, 1, 2>{depth_mode},
+            dispatch::IntParam<0, 1>{mask_on},
+            dispatch::IntParam<0, 1>{relu_on},
+            [&]<typename CoeffT, typename Dm, typename Mk, typename Rl>() {
+                constexpr bool HAS_DEPTH = Dm::value != 0;
+                constexpr bool DEPTH_ZERO = Dm::value == 2;
+                constexpr bool HAS_MASK = Mk::value != 0;
+                constexpr bool EMIT_RELU = Rl::value != 0;
+                const size_t smem =
+                    static_cast<size_t>(TILE_ROWS) * K * Dc * sizeof(CoeffT) +
+                    static_cast<size_t>(TILE_ROWS) * 3 * sizeof(float) +
+                    static_cast<size_t>(TILE_ROWS) * width * sizeof(float);
+                // Set the dynamic-smem opt-in once per kernel specialization
+                // (see the k16 branch above for the amortization rationale).
+                static int configured_smem = -1;
+                if (static_cast<int>(smem) > configured_smem) {
+                    if (cudaFuncSetAttribute(
+                            assemble_proj_features_kernel<
+                                CoeffT, float, /*DEGREE=*/0, /*K16FAST=*/false,
+                                HAS_DEPTH, DEPTH_ZERO, HAS_MASK, EMIT_RELU>,
+                            cudaFuncAttributeMaxDynamicSharedMemorySize,
+                            static_cast<int>(smem)
+                        ) != cudaSuccess) {
+                        AT_ERROR(
+                            "assemble_proj_features: failed to set dynamic shared "
+                            "memory (requested ", smem, " bytes; width=", width,
+                            ", K=", K, ", Dc=", Dc, "); shape exceeds this device's "
+                            "shared-memory budget."
+                        );
+                    }
+                    configured_smem = static_cast<int>(smem);
+                }
+                assemble_proj_features_kernel<
+                    CoeffT, float, /*DEGREE=*/0, /*K16FAST=*/false,
+                    HAS_DEPTH, DEPTH_ZERO, HAS_MASK, EMIT_RELU>
+                    <<<grid, threads, smem, stream>>>(
+                        B, C, N, degrees_to_use, K, Dc, E, width,
+                        color_post, extra_post, extra_has_c,
+                        means_ptr, campos_ptr, coeffs.const_data_ptr<CoeffT>(),
+                        extra_ptr, depths_ptr, masks_ptr, out_ptr, relu_mask_ptr
+                    );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+        );
+        TORCH_CHECK(dispatched, "assemble_proj_features: dispatch failed for sh_degree=", degrees_to_use);
+    }
 }
 
 } // namespace gsplat

--- a/gsplat/cuda/ext.cpp
+++ b/gsplat/cuda/ext.cpp
@@ -947,6 +947,7 @@ TORCH_LIBRARY(gsplat, m) {
 
     m.def("spherical_harmonics(int degrees_to_use, Tensor dirs, Tensor coeffs, Tensor? masks) -> Tensor");
     m.def("spherical_harmonics_bwd(int degrees_to_use, Tensor dirs, Tensor coeffs, Tensor? masks, Tensor v_colors, bool compute_v_dirs) -> (Tensor, Tensor?)");
+    m.def("assemble_proj_features_unpacked_fwd(int degrees_to_use, int B, int C, int N, int Dc, int E, int color_post, int extra_post, bool has_depth, bool depth_is_zero, bool extra_has_c, Tensor means, Tensor campos, Tensor coeffs, Tensor? extra, Tensor? depths, Tensor? masks, Tensor(a!) out, Tensor(b!)? relu_mask) -> ()");
 
     m.def("intersect_tile(Tensor means2d, Tensor radii, Tensor depths, Tensor? conics, Tensor? opacities, Tensor? image_ids, Tensor? gaussian_ids, int? n_images, int tile_size, int tile_width, int tile_height, bool sort, bool segmented) -> (Tensor, Tensor, Tensor)");
     m.def("intersect_offset(Tensor isect_ids, int I, int tile_width, int tile_height) -> Tensor");

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -54,6 +54,11 @@ from .cuda._wrapper import (
 from .utils import depth_to_normal, get_projection_matrix
 
 
+# Fused post-transform codes for the proj_features assembler (SHPostOp in CUDA):
+# none -> identity, shift -> +0.5, shift_relu -> max(x + 0.5, 0).
+_POST_CODE = {"none": 0, "shift": 1, "shift_relu": 2}
+
+
 # Gaussian depth modes (D/ED): use projection depth (controlled by global_z_order)
 # Hit distance modes (d/Ed): compute along-ray distance in rasterization
 RenderMode = Literal["RGB", "d", "Ed", "D", "ED", "RGB-d", "RGB-Ed", "RGB+D", "RGB+ED"]

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -23,8 +23,6 @@ import torch.nn.functional as F
 
 import gsplat.losses as _losses_module
 
-_losses_module.ENFORCE_CONTRACTS = True
-
 from gsplat.losses import (
     create_ssim_window,
     depth_l1_loss,
@@ -40,6 +38,23 @@ from gsplat.losses import (
     torch_ssim_loss,
     total_variation_loss,
 )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _enforce_contracts():
+    """Enable losses-module contract checks for this module's tests only.
+
+    pytest imports every test module during collection, so setting
+    ``ENFORCE_CONTRACTS = True`` at module scope leaks into unrelated test
+    modules for the whole session. Scoping the override to an autouse fixture
+    (and restoring the prior, env-driven value on teardown) keeps it local.
+    """
+    prev = _losses_module.ENFORCE_CONTRACTS
+    _losses_module.ENFORCE_CONTRACTS = True
+    try:
+        yield
+    finally:
+        _losses_module.ENFORCE_CONTRACTS = prev
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stage 04 - projection-features perf + CUDA fixes

Three small, independent MRs merged consecutively on the source branch:
- `fix(tests): scope ENFORCE_CONTRACTS override to the test_losses module` - avoids leaking the contracts-enforcement flag into other test modules.
- `perf(render): fuse proj_features assembly into a single SH kernel`.
- `Fix rendering ops incorrectly bypassing the dispatcher`.

**Tests:** full dev:10 suite - 2534 passed. Only the pre-existing Blackwell eval3d lidar flakes remain (byte-identical to base); no new failures.

Stacked on stage 03.