### PR TITLE
[NV] Perturbation/relocation params, dynamic content, Blackwell tolerance fix, distributed schema, 3DGUT proj perf, SE3 helpers, mGPU

### DIFF
--- a/examples/AV_TRAINER.md
+++ b/examples/AV_TRAINER.md
@@ -61,6 +61,7 @@ python examples/av_trainer.py \
 | `--cameras` | all | Comma-separated camera IDs (NCore) |
 | `--duration` | full | Clip duration in seconds (NCore) |
 | `--downscale` | 1 | Image downscale factor (NCore) |
+| `--rigid-dynamic-track-class-ids` | unset | Comma-separated NCore cuboid class IDs to load as rigid dynamic tracks; moving-object returns remain in static init |
 | `--max-lidar` | 150000 | Max LiDAR init points |
 | `--max-steps` | 15000 | Training iterations |
 | `--lr` | 0.005 | Base learning rate |

--- a/examples/av_trainer.py
+++ b/examples/av_trainer.py
@@ -683,6 +683,7 @@ def train(
     duration: float | None = None,
     max_lidar: int = 150_000,
     downscale: int = 1,
+    rigid_dynamic_track_class_ids: list[str] | None = None,
     # LiDAR rendering (addition over simple_trainer)
     lidar_render: bool = False,
     lidar_render_subsample: int = 112,
@@ -715,7 +716,16 @@ def train(
             camera_ids=cameras or None,
             duration_sec=duration,
             max_lidar_points=max_lidar,
+            rigid_dynamic_track_class_ids=rigid_dynamic_track_class_ids,
         )
+        if rigid_dynamic_track_class_ids is not None:
+            n_dyn_pts = sum(len(t.points_local) for t in parser.rigid_dynamic_tracks)
+            print(
+                f"  Rigid dynamic: {len(parser.rigid_dynamic_tracks)} tracks "
+                f"({n_dyn_pts} local points) for class IDs "
+                f"{sorted(rigid_dynamic_track_class_ids)}. Moving-object returns "
+                f"are kept in the static background."
+            )
         # Pre-stacking below requires every selected camera to share (W, H).
         # Mixed-resolution surround-view rigs (e.g. wide 120fov + tele 30fov)
         # would raise at torch.stack time; fail early with a clear message.
@@ -1178,6 +1188,15 @@ def main():
     p.add_argument(
         "--duration", type=float, default=None, help="clip duration in seconds (NCore)"
     )
+    p.add_argument(
+        "--rigid-dynamic-track-class-ids",
+        type=str,
+        default=None,
+        help=(
+            "comma-separated NCore cuboid class IDs to load as rigid dynamic "
+            "tracks; moving returns stay in static init"
+        ),
+    )
     p.add_argument("--max-lidar", type=int, default=150_000)
     p.add_argument("--downscale", type=int, default=1)
     p.add_argument("--max-steps", type=int, default=15000)
@@ -1217,6 +1236,15 @@ def main():
         raise RuntimeError("CUDA required for gsplat rasterization.")
 
     cameras_list = args.cameras.split(",") if args.cameras else None
+    rigid_dynamic_track_class_ids = (
+        [
+            class_id.strip()
+            for class_id in args.rigid_dynamic_track_class_ids.split(",")
+            if class_id.strip()
+        ]
+        if args.rigid_dynamic_track_class_ids
+        else None
+    )
     train(
         scene_path=args.scene or default_scene_path,
         max_steps=args.max_steps,
@@ -1233,6 +1261,7 @@ def main():
         duration=args.duration,
         max_lidar=args.max_lidar,
         downscale=args.downscale,
+        rigid_dynamic_track_class_ids=rigid_dynamic_track_class_ids,
         lidar_render=args.lidar_render,
         lidar_render_subsample=args.lidar_render_subsample,
         lidar_render_weight=args.lidar_render_weight,

--- a/examples/benchmarks/geometry/se3_interpolate_tracks_bench.py
+++ b/examples/benchmarks/geometry/se3_interpolate_tracks_bench.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark fused batched SE(3) pose-track interpolation.
+
+This is a standalone CUDA benchmark, not a pytest test. It measures the public
+``gsplat.geometry.functional.se3_interpolate_tracks`` helper against a
+benchmark-only naive Python loop.
+
+Run directly::
+
+    python examples/benchmarks/geometry/se3_interpolate_tracks_bench.py
+    python examples/benchmarks/geometry/se3_interpolate_tracks_bench.py --iters 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import torch
+
+import gsplat.geometry.functional as geom
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark SE(3) packed track interpolation.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--device", default="cuda:0", help="CUDA device to use.")
+    parser.add_argument("--dtype", default="float32", choices=["float32", "float64"])
+    parser.add_argument("--iters", type=int, default=20, help="Timed iterations.")
+    parser.add_argument("--warmup", type=int, default=5, help="Warmup iterations.")
+    return parser.parse_args()
+
+
+def _make_counts(
+    n_tracks: int, keyframes: int, *, skewed: bool, device: torch.device
+) -> torch.Tensor:
+    counts = torch.full((n_tracks,), keyframes, device=device, dtype=torch.int32)
+    if skewed and n_tracks > 1:
+        counts.fill_(2)
+        counts[0] = keyframes
+    return counts
+
+
+def make_case(
+    n_tracks: int,
+    keyframes: int,
+    *,
+    skewed: bool,
+    per_track_query: bool,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
+    counts = _make_counts(n_tracks, keyframes, skewed=skewed, device=device)
+    offsets = torch.cumsum(counts, dim=0) - counts
+    total_keyframes = int(counts.sum().item())
+
+    torch.manual_seed(1234 + n_tracks * 17 + keyframes)
+    translations = torch.randn(total_keyframes, 3, device=device, dtype=dtype)
+    rotations = torch.nn.functional.normalize(
+        torch.randn(total_keyframes, 4, device=device, dtype=dtype), dim=-1
+    )
+
+    pose_times = torch.empty(total_keyframes, device=device, dtype=dtype)
+    counts_list = [int(x) for x in counts.cpu().tolist()]
+    offsets_list = [int(x) for x in offsets.cpu().tolist()]
+    for start, count in zip(offsets_list, counts_list):
+        pose_times[start : start + count] = torch.linspace(
+            0.0, 1.0, count, device=device, dtype=dtype
+        )
+
+    if per_track_query:
+        query_time = torch.linspace(0.1, 0.9, n_tracks, device=device, dtype=dtype)
+    else:
+        query_time = torch.tensor(0.37, device=device, dtype=dtype)
+
+    return translations, rotations, pose_times, offsets, counts, query_time
+
+
+def naive_se3_interpolate_tracks(
+    inputs: tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    offsets_list: list[int],
+    counts_list: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Benchmark-only Python loop reference for fused interpolation speedups."""
+
+    (
+        pose_translations,
+        pose_rotations,
+        pose_times,
+        _pose_offsets,
+        _pose_counts,
+        query_time,
+    ) = inputs
+    if not offsets_list:
+        return pose_translations.new_empty((0, 3)), pose_rotations.new_empty((0, 4))
+
+    times = pose_times.reshape(-1)
+    query_times = (
+        query_time.expand(len(offsets_list))
+        if query_time.ndim == 0
+        else query_time.reshape(-1)
+    )
+
+    out_translations: list[torch.Tensor] = []
+    out_rotations: list[torch.Tensor] = []
+    for track_idx, (start, count) in enumerate(zip(offsets_list, counts_list)):
+        track_times = times[start : start + count]
+        track_translations = pose_translations[start : start + count]
+        track_rotations = pose_rotations[start : start + count]
+        if count == 1:
+            out_translations.append(track_translations[0])
+            out_rotations.append(track_rotations[0])
+            continue
+
+        clamped_query = torch.clamp(
+            query_times[track_idx], track_times[0], track_times[-1]
+        )
+        right = int(torch.searchsorted(track_times, clamped_query, right=False).item())
+        if right <= 0:
+            left = right = 0
+        elif right >= count:
+            left = right = count - 1
+        elif bool((track_times[right] == clamped_query).item()):
+            left = right
+        else:
+            left = right - 1
+
+        if left == right:
+            out_translations.append(track_translations[left])
+            out_rotations.append(track_rotations[left])
+            continue
+
+        left_time = track_times[left]
+        right_time = track_times[right]
+        alpha = (clamped_query - left_time) / (right_time - left_time)
+        out_translations.append(
+            track_translations[left]
+            + alpha * (track_translations[right] - track_translations[left])
+        )
+        out_rotations.append(
+            geom.quat_slerp(
+                track_rotations[left : left + 1],
+                track_rotations[right : right + 1],
+                alpha.reshape(1, 1),
+            )[0]
+        )
+
+    return torch.stack(out_translations, dim=0), torch.stack(out_rotations, dim=0)
+
+
+def latency_benchmark(fn, *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    samples_ms: list[float] = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        samples_ms.append((time.perf_counter() - start) * 1000.0)
+    return statistics.median(samples_ms)
+
+
+def fmt(value: float | None) -> str:
+    return "" if value is None else f"{value:.6f}"
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+
+    device = torch.device(args.device)
+    dtype = torch.float32 if args.dtype == "float32" else torch.float64
+    cases = [
+        ("tiny uniform", 16, 2, False, False),
+        ("small uniform", 128, 8, False, True),
+        ("medium uniform", 512, 8, False, True),
+        ("skewed", 128, 512, True, True),
+    ]
+
+    header = [
+        "case",
+        "n_tracks",
+        "keyframes",
+        "skewed",
+        "total_keyframes",
+        "query",
+        "fused_latency_ms",
+        "naive_latency_ms",
+        "speedup",
+    ]
+    writer = csv.writer(sys.stdout)
+    writer.writerow(header)
+
+    for name, n_tracks, keyframes, skewed, per_track_query in cases:
+        inputs = make_case(
+            n_tracks,
+            keyframes,
+            skewed=skewed,
+            per_track_query=per_track_query,
+            device=device,
+            dtype=dtype,
+        )
+        total_keyframes = int(inputs[4].sum().item())
+        fused_fn = lambda: geom.se3_interpolate_tracks(*inputs)
+        fused_fn()
+
+        fused_latency_ms = latency_benchmark(
+            fused_fn, warmup=args.warmup, iters=args.iters
+        )
+        offsets_list = [int(x) for x in inputs[3].cpu().tolist()]
+        counts_list = [int(x) for x in inputs[4].cpu().tolist()]
+        naive_fn = lambda: naive_se3_interpolate_tracks(
+            inputs, offsets_list, counts_list
+        )
+        fused_out = fused_fn()
+        naive_out = naive_fn()
+        torch.cuda.synchronize()
+        if not torch.allclose(
+            fused_out[0], naive_out[0], atol=1e-5
+        ) or not torch.allclose(fused_out[1], naive_out[1], atol=1e-5):
+            raise RuntimeError(f"naive reference mismatch for benchmark case {name!r}")
+        naive_latency_ms = latency_benchmark(
+            naive_fn, warmup=args.warmup, iters=args.iters
+        )
+        speedup = naive_latency_ms / fused_latency_ms
+
+        query_kind = "per-track" if per_track_query else "scalar"
+        row = [
+            name,
+            n_tracks,
+            keyframes,
+            skewed,
+            total_keyframes,
+            query_kind,
+            fmt(fused_latency_ms),
+            fmt(naive_latency_ms),
+            fmt(speedup),
+        ]
+        writer.writerow(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/datasets/ncore.py
+++ b/examples/datasets/ncore.py
@@ -16,7 +16,7 @@
 import dataclasses
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Collection, Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -28,6 +28,12 @@ import ncore.data
 import ncore.data.v4
 import ncore.sensors
 from ncore.data import PointCloudsSourceProtocol
+from ncore.impl.common.transformations import (
+    bbox_pose,
+    is_within_3d_bboxes,
+    se3_inverse,
+    transform_point_cloud,
+)
 
 from gsplat.rendering import FThetaCameraDistortionParameters, FThetaPolynomialType
 
@@ -56,6 +62,28 @@ class CameraRenderData:
     radial_coeffs: Optional[np.ndarray]  # (4,) fisheye or (4|6,) pinhole; float32
     tangential_coeffs: Optional[np.ndarray]  # (2,) pinhole only; float32 or None
     thin_prism_coeffs: Optional[np.ndarray]  # (4,) pinhole only; float32 or None
+
+
+@dataclasses.dataclass
+class RigidDynamicTrack:
+    """A single dynamic object reconstructed as a rigid component.
+
+    Gaussians are initialised from lidar points expressed in the object's local
+    (centroid-centred, axis-aligned) frame. The per-frame SE(3) poses map that
+    local frame into the scene frame at each annotated timestamp.
+    """
+
+    track_id: str
+    class_id: str
+    points_local: np.ndarray  # (P, 3) float32 — init points in object-local frame
+    points_rgb: np.ndarray  # (P, 3) uint8
+    frame_timestamps_us: np.ndarray  # (F,) int64, sorted — pose keyframe times
+    poses_local_to_scene: np.ndarray  # (F, 4, 4) float32 — local -> scene per frame
+
+
+def _normalize_track_class_id(class_id: Any) -> str:
+    """Normalize NCore cuboid class IDs before matching them."""
+    return str(class_id).strip().lower()
 
 
 def _build_pinhole_K(
@@ -143,10 +171,26 @@ class NCoreParser:
         n_camera_mask_dilation_iterations: int = 30,
         lidar_color_generic_data_name: str = "rgb",
         normalize_world_space: bool = False,
+        rigid_dynamic_track_class_ids: Optional[Collection[str]] = None,
     ) -> None:
         self.test_every = test_every
         self.factor = factor
         self.normalize_world_space = normalize_world_space
+        self.rigid_dynamic_track_class_ids = (
+            frozenset(
+                _normalize_track_class_id(class_id)
+                for class_id in rigid_dynamic_track_class_ids
+            )
+            if rigid_dynamic_track_class_ids is not None
+            else None
+        )
+        if (
+            self.rigid_dynamic_track_class_ids is not None
+            and not self.rigid_dynamic_track_class_ids
+        ):
+            raise ValueError(
+                "rigid_dynamic_track_class_ids must be non-empty when provided"
+            )
         self.poses_component_group = poses_component_group
         self.intrinsics_component_group = intrinsics_component_group
         self.masks_component_group = masks_component_group
@@ -188,6 +232,16 @@ class NCoreParser:
 
         self.points, self.points_rgb = self._load_point_clouds(
             sequence_loader, max_lidar_points, lidar_step_frame
+        )
+
+        # Rigid dynamic objects: per-track local Gaussians + per-frame poses.
+        # Loaded before normalization so the same similarity transform is applied
+        # to the tracks and the static points/cameras, keeping their scene-frame
+        # poses consistent.
+        self.rigid_dynamic_tracks: List[RigidDynamicTrack] = (
+            self._load_rigid_dynamic_tracks(sequence_loader, lidar_step_frame)
+            if self.rigid_dynamic_track_class_ids is not None
+            else []
         )
 
         # Normalize the world space (orient, centre, and rescale).
@@ -581,6 +635,29 @@ class NCoreParser:
             self.points = points.astype(np.float32)
         self.transform = transform
 
+        # Carry the same similarity onto rigid dynamic tracks so objects stay
+        # aligned with the normalized background/cameras.
+        if self.rigid_dynamic_tracks:
+            self._normalize_rigid_dynamic_tracks(transform)
+
+    def _normalize_rigid_dynamic_tracks(self, transform: np.ndarray) -> None:
+        """Apply the world-space normalization similarity to rigid dynamic tracks.
+
+        ``transform`` is a similarity ``x -> sQx + b`` (uniform scale ``s``,
+        rotation ``Q``). A track renders as ``x = R_pose · p_local + t_pose``, so
+        the normalized placement is ``(QR_pose)(s·p_local) + (sQ·t_pose + b)``:
+        local points scale by ``s`` and each pose is left-multiplied by the
+        similarity then re-orthonormalized (mirrors ``transform_cameras``).
+        """
+        # Uniform scale carried by the similarity (rows/cols of sQ have norm s).
+        scale = float(np.linalg.norm(transform[0, :3]))
+        for track in self.rigid_dynamic_tracks:
+            track.points_local = (track.points_local * scale).astype(np.float32)
+            poses = transform @ track.poses_local_to_scene.astype(np.float64)
+            rot_scale = np.linalg.norm(poses[:, 0, :3], axis=1)  # (F,) == s
+            poses[:, :3, :3] = poses[:, :3, :3] / rot_scale[:, None, None]
+            track.poses_local_to_scene = poses.astype(np.float32)
+
     # ------------------------------------------------------------------
     # Private runtime helpers
     # ------------------------------------------------------------------
@@ -647,28 +724,27 @@ class NCoreParser:
                 )
                 xyz_world = pc_world.xyz
 
-                # Color: check point cloud attributes first, then source generic data
-                color: Optional[np.ndarray] = None
-                if pc.has_attribute(self.lidar_color_generic_data_name):
-                    color = pc.get_attribute(self.lidar_color_generic_data_name)
-                elif source.has_pc_generic_data(
-                    pc_idx, self.lidar_color_generic_data_name
-                ):
-                    color = source.get_pc_generic_data(
-                        pc_idx, self.lidar_color_generic_data_name
-                    )
-                if color is not None:
-                    if color.shape != xyz_world.shape:
-                        raise ValueError(
-                            "Color data length does not match point cloud length "
-                            "(expecting 3-channel RGB color per point)"
-                        )
-                    if color.dtype != np.uint8:
-                        raise ValueError("Expected color data in uint8 format")
+                # Color: per-point uint8 RGB (validated), or None if unavailable.
+                color = self._get_pc_color(
+                    pc,
+                    source,
+                    pc_idx,
+                    self.lidar_color_generic_data_name,
+                    len(xyz_world),
+                )
 
-                # Dynamic flag filtering
+                # Dynamic-flag handling. By default NCore drops moving-object
+                # returns (dynamic_flag == 1) so they don't smear the static
+                # background. When rigid dynamic tracks are requested we keep
+                # those returns for now so the static trainer still sees the
+                # complete point cloud. The same points are also picked up
+                # independently by _load_rigid_dynamic_tracks and exposed on
+                # parser.rigid_dynamic_tracks.
                 point_filter = ...
-                if source.has_pc_generic_data(pc_idx, "dynamic_flag"):
+                if (
+                    self.rigid_dynamic_track_class_ids is None
+                    and source.has_pc_generic_data(pc_idx, "dynamic_flag")
+                ):
                     point_filter = (
                         source.get_pc_generic_data(pc_idx, "dynamic_flag") != 1
                     )
@@ -705,6 +781,227 @@ class NCoreParser:
             f"[NCoreParser] Loaded {len(points)} point cloud points from {source_names}"
         )
         return points, points_rgb
+
+    @staticmethod
+    def _get_pc_color(
+        pc: Any,
+        source: PointCloudsSourceProtocol,
+        pc_idx: int,
+        color_name: str,
+        n_points: int,
+    ) -> Optional[np.ndarray]:
+        """Return per-point uint8 RGB for a point cloud, or None if unavailable."""
+        color: Optional[np.ndarray] = None
+        if pc.has_attribute(color_name):
+            color = pc.get_attribute(color_name)
+        elif source.has_pc_generic_data(pc_idx, color_name):
+            color = source.get_pc_generic_data(pc_idx, color_name)
+        if color is None:
+            return None
+        if color.shape != (n_points, 3):
+            raise ValueError(
+                "Color data length does not match point cloud length "
+                "(expecting 3-channel RGB color per point)"
+            )
+        if color.dtype != np.uint8:
+            raise ValueError("Expected color data in uint8 format")
+        return color
+
+    def _load_rigid_dynamic_tracks(
+        self,
+        sequence_loader: ncore.data.SequenceLoaderProtocol,
+        step_frame: int,
+    ) -> List[RigidDynamicTrack]:
+        """Load moving objects as rigid tracks for dynamic-rigid training.
+
+        Reads NCore cuboid track observations, derives a per-frame SE(3) pose for
+        each track (object-local -> scene frame), associates the ``dynamic_flag``
+        lidar points with their owning cuboid, and stores those points in each
+        object's local frame.
+
+        This reads the dynamic returns independently of ``_load_point_clouds``.
+        When ``rigid_dynamic_track_class_ids`` is provided, those returns are
+        *also* kept in the static background for now, while track-local copies
+        are exposed on ``parser.rigid_dynamic_tracks``.
+        """
+        assert self.rigid_dynamic_track_class_ids is not None
+        pose_graph = sequence_loader.pose_graph
+
+        # 1) Group rigid cuboid observations by track and build per-frame world
+        # bboxes. NCore class IDs are dataset-specific strings, so callers must
+        # explicitly identify which classes they want to model as rigid.
+        all_track_obs: Dict[str, List[ncore.data.CuboidTrackObservation]] = {}
+        for obs in sequence_loader.get_cuboid_track_observations(self.time_range_us):
+            all_track_obs.setdefault(obs.track_id, []).append(obs)
+
+        skipped_by_class: Dict[str, int] = {}
+        track_obs: Dict[str, List[ncore.data.CuboidTrackObservation]] = {}
+        for track_id, obs_list in all_track_obs.items():
+            class_ids = {_normalize_track_class_id(obs.class_id) for obs in obs_list}
+            if class_ids <= self.rigid_dynamic_track_class_ids:
+                track_obs[track_id] = obs_list
+                continue
+            for class_id in sorted(class_ids - self.rigid_dynamic_track_class_ids):
+                skipped_by_class[class_id] = skipped_by_class.get(class_id, 0) + len(
+                    obs_list
+                )
+
+        if not track_obs:
+            print(
+                "[NCoreParser] rigid dynamic tracks: no matching cuboid track "
+                "observations in time range"
+            )
+            return []
+
+        if skipped_by_class:
+            skipped = ", ".join(
+                f"{class_id}={count}"
+                for class_id, count in sorted(skipped_by_class.items())
+            )
+            print(
+                "[NCoreParser] rigid dynamic tracks: skipped cuboid observations "
+                f"outside configured class IDs: {skipped}"
+            )
+
+        tracks_world: Dict[str, Dict[str, np.ndarray]] = {}
+        for track_id, obs_list in track_obs.items():
+            # Key on reference_frame_timestamp_us: cuboids are parameterised in a
+            # sensor frame at the capture (lidar/render) timestamp, which aligns
+            # with the point-cloud frames. obs.timestamp_us is the label time and
+            # does NOT line up with frames.
+            obs_list.sort(key=lambda o: o.reference_frame_timestamp_us)
+            timestamps: List[int] = []
+            bboxes_world: List[np.ndarray] = []
+            for obs in obs_list:
+                obs_world = obs.transform(
+                    "world", obs.reference_frame_timestamp_us, pose_graph
+                )
+                timestamps.append(int(obs.reference_frame_timestamp_us))
+                bboxes_world.append(
+                    np.asarray(obs_world.bbox3.to_array(), dtype=np.float64)
+                )
+            ts = np.asarray(timestamps, dtype=np.int64)
+            bbox_world = np.stack(bboxes_world, axis=0)  # (F, 9)
+
+            # Per-frame local->world pose -> local->scene pose.
+            poses_local_world = np.stack(
+                [bbox_pose(b) for b in bbox_world], axis=0
+            ).astype(
+                np.float32
+            )  # (F, 4, 4)
+            poses_local_scene = self._ncore_world_to_scene_poses(poses_local_world)
+            if poses_local_scene.ndim == 2:
+                poses_local_scene = poses_local_scene[np.newaxis]
+
+            tracks_world[track_id] = {
+                "class_id": _normalize_track_class_id(obs_list[0].class_id),
+                "ts": ts,
+                "bbox_world": bbox_world,
+                "pose_scene": poses_local_scene.astype(np.float32),
+            }
+
+        # Match tolerance: half a frame interval. Cuboid reference timestamps align
+        # with the lidar frames, so the nearest match is normally exact; half an
+        # interval guards float/int jitter without ever matching an adjacent frame
+        # (which would associate points to the wrong, missing-this-frame keyframe).
+        all_ts = np.unique(np.concatenate([tw["ts"] for tw in tracks_world.values()]))
+        ts_tol = (
+            max(1_000, int(0.5 * np.median(np.diff(all_ts))))
+            if len(all_ts) > 1
+            else 100_000
+        )
+
+        # 2) Associate dynamic points (per pc frame) with the nearest cuboid and
+        #    accumulate them in each track's local frame.
+        local_pts: Dict[str, List[np.ndarray]] = {tid: [] for tid in tracks_world}
+        local_rgb: Dict[str, List[np.ndarray]] = {tid: [] for tid in tracks_world}
+
+        for source_id in self.point_clouds_source_ids:
+            source: PointCloudsSourceProtocol = sequence_loader.get_point_clouds_source(
+                source_id
+            )
+            pc_timestamps = source.pc_timestamps_us
+            for pc_idx in range(source.pcs_count):
+                pc_ts = int(pc_timestamps[pc_idx])
+                if not (self.time_range_us.start <= pc_ts < self.time_range_us.stop):
+                    continue
+                if pc_idx % step_frame != 0:
+                    continue
+                if not source.has_pc_generic_data(pc_idx, "dynamic_flag"):
+                    continue
+                try:
+                    pc = source.get_pc(pc_idx)
+                except Exception as exc:
+                    print(
+                        f"[NCoreParser] rigid dynamic tracks: failed to load "
+                        f"point cloud {pc_idx} from '{source_id}': {exc}"
+                    )
+                    continue
+
+                dyn_mask = source.get_pc_generic_data(pc_idx, "dynamic_flag") == 1
+                if not np.any(dyn_mask):
+                    continue
+
+                pc_world = pc.transform(
+                    "world", pc.reference_frame_timestamp_us, pose_graph
+                )
+                xyz_world = pc_world.xyz
+                color = self._get_pc_color(
+                    pc,
+                    source,
+                    pc_idx,
+                    self.lidar_color_generic_data_name,
+                    len(xyz_world),
+                )
+                xyz_world = xyz_world[dyn_mask]
+                color = color[dyn_mask] if color is not None else None
+
+                # Assign each dynamic point to at most one track (first match wins).
+                remaining = np.ones(len(xyz_world), dtype=bool)
+                for track_id, tw in tracks_world.items():
+                    nearest = int(np.argmin(np.abs(tw["ts"] - pc_ts)))
+                    if abs(int(tw["ts"][nearest]) - pc_ts) > ts_tol:
+                        continue
+                    bbox = tw["bbox_world"][nearest]
+                    inside = is_within_3d_bboxes(xyz_world, bbox[np.newaxis])[:, 0]
+                    # Points expressed in the box-local (centroid-centred) frame.
+                    local = transform_point_cloud(
+                        xyz_world, se3_inverse(bbox_pose(bbox))
+                    )
+                    sel = inside & remaining
+                    if not np.any(sel):
+                        continue
+                    local_pts[track_id].append(local[sel].astype(np.float32))
+                    if color is not None:
+                        local_rgb[track_id].append(color[sel])
+                    else:
+                        local_rgb[track_id].append(
+                            np.full((int(sel.sum()), 3), 128, dtype=np.uint8)
+                        )
+                    remaining &= ~sel
+
+        # 3) Emit tracks that picked up at least one point.
+        tracks: List[RigidDynamicTrack] = []
+        for track_id, tw in tracks_world.items():
+            if not local_pts[track_id]:
+                continue
+            tracks.append(
+                RigidDynamicTrack(
+                    track_id=track_id,
+                    class_id=str(tw["class_id"]),
+                    points_local=np.vstack(local_pts[track_id]).astype(np.float32),
+                    points_rgb=np.vstack(local_rgb[track_id]).astype(np.uint8),
+                    frame_timestamps_us=tw["ts"],
+                    poses_local_to_scene=tw["pose_scene"],
+                )
+            )
+
+        total_pts = sum(len(t.points_local) for t in tracks)
+        print(
+            f"[NCoreParser] rigid dynamic tracks: {len(tracks)}/{len(track_obs)} "
+            f"configured tracks with associated points ({total_pts} init points)"
+        )
+        return tracks
 
 
 # ---------------------------------------------------------------------------

--- a/examples/simple_trainer.py
+++ b/examples/simple_trainer.py
@@ -106,6 +106,9 @@ class Config:
     camera_model: CameraModel = "pinhole"
     # Load EXIF exposure metadata from images (if available)
     load_exposure: bool = True
+    # Backend to train on: "cuda" for standard multi-process training,
+    # or "dgx" for torch-dgx single-process multi-GPU training.
+    backend: str = "cuda"
 
     # --- NCore-specific options (only used when data_type="ncore") ---
     # Camera sensor IDs to load (auto-detected from sequence if empty)
@@ -387,7 +390,7 @@ class Runner:
         self.world_rank = world_rank
         self.local_rank = local_rank
         self.world_size = world_size
-        self.device = f"cuda:{local_rank}"
+        self.device = f"{cfg.backend}:{local_rank}"
 
         # Where to dump results.
         os.makedirs(cfg.result_dir, exist_ok=True)
@@ -1586,6 +1589,8 @@ if __name__ == "__main__":
         ),
     }
     cfg = tyro.extras.overridable_config_cli(configs)
+    if cfg.backend == "dgx":
+        import torch_dgx  # noqa: F401
     cfg.adjust_steps(cfg.steps_scaler)
 
     # try import extra dependencies

--- a/gsplat/cuda/csrc/DistributedCollectives.cpp
+++ b/gsplat/cuda/csrc/DistributedCollectives.cpp
@@ -16,14 +16,15 @@
  */
 
 #include "DistributedCollectives.h"
-#include "TorchUtils.h"
 
 #include <ATen/Functions.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/core/ivalue.h>
 #include <c10/core/SymInt.h>
 #include <c10/util/ArrayRef.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/version.h>
 
 #include <numeric>
 
@@ -31,6 +32,22 @@ namespace gsplat
 {
 namespace
 {
+#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 12)
+    using C10dGroupNameArg = c10::IValue;
+
+    C10dGroupNameArg c10d_group_name_arg(const std::string &pg)
+    {
+        return c10::IValue(pg);
+    }
+#else
+    using C10dGroupNameArg = std::string;
+
+    C10dGroupNameArg c10d_group_name_arg(const std::string &pg)
+    {
+        return pg;
+    }
+#endif
+
     // --- The only irreducible job: reach the dispatcher-registered functional ---
     // collective and synchronize the async result. We always call the `_autograd`
     // variant: torch records a backward (the reverse collective) only when grad is
@@ -39,10 +56,13 @@ namespace
     // autograd-vs-plain choice to make.
     at::Tensor all_gather_into_tensor(const at::Tensor &input, int64_t world_size, const std::string &pg)
     {
-        using Sig = at::Tensor(const at::Tensor &, int64_t, const std::string &);
+        using Sig = at::Tensor(const at::Tensor &, int64_t, const C10dGroupNameArg &);
 
-        at::Tensor gathered
-            = call_torch_op<Sig>("_c10d_functional_autograd::all_gather_into_tensor", input, world_size, pg);
+        C10dGroupNameArg group_name = c10d_group_name_arg(pg);
+        auto op                     = c10::Dispatcher::singleton()
+                                          .findSchemaOrThrow("_c10d_functional_autograd::all_gather_into_tensor", "")
+                                          .typed<Sig>();
+        at::Tensor gathered         = op.call(input, world_size, group_name);
 
         return c10d::wait_tensor(gathered);
     }
@@ -54,11 +74,13 @@ namespace
         const std::string &pg
     )
     {
-        using Sig = at::Tensor(const at::Tensor &, at::SymIntArrayRef, at::SymIntArrayRef, const std::string &);
+        using Sig = at::Tensor(const at::Tensor &, at::SymIntArrayRef, at::SymIntArrayRef, const C10dGroupNameArg &);
 
-        at::Tensor scattered = call_torch_op<Sig>(
-            "_c10d_functional_autograd::all_to_all_single", input, output_splits, input_splits, pg
-        );
+        C10dGroupNameArg group_name = c10d_group_name_arg(pg);
+        auto op                     = c10::Dispatcher::singleton()
+                                          .findSchemaOrThrow("_c10d_functional_autograd::all_to_all_single", "")
+                                          .typed<Sig>();
+        at::Tensor scattered        = op.call(input, output_splits, input_splits, group_name);
 
         return c10d::wait_tensor(scattered);
     }

--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -328,6 +328,63 @@ TileIntersectResult intersect_tile(
     }
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_privateuseone(
+    const at::Tensor &means2d,                    // [..., N, 2] or [nnz, 2]
+    const at::Tensor &radii,                      // [..., N, 2] or [nnz, 2]
+    const at::Tensor &depths,                     // [..., N] or [nnz]
+    const at::optional<at::Tensor> &conics,       // [..., N, 3] or [nnz, 3]
+    const at::optional<at::Tensor> &opacities,    // [..., N] or [nnz]
+    const at::optional<at::Tensor> &image_ids,    // [nnz]
+    const at::optional<at::Tensor> &gaussian_ids, // [nnz]
+    const std::optional<int64_t> &n_images,
+    int64_t tile_size,
+    int64_t tile_width,
+    int64_t tile_height,
+    bool sort,
+    bool segmented
+)
+{
+    DEVICE_GUARD(means2d);
+    bool packed = means2d.dim() == 2;
+    check_intersect_tile_inputs(means2d, radii, depths, conics, opacities, image_ids, gaussian_ids, packed);
+    if(packed)
+    {
+        TORCH_CHECK(n_images.has_value(), "n_images is required when means2d is packed ([nnz, 2]).");
+    }
+    TORCH_CHECK(!segmented, "segmented mGPU intersect_tile is not supported");
+
+    int64_t I = packed ? n_images.value() : c10::multiply_integers(means2d.sizes().slice(0, means2d.dim() - 2));
+
+    uint32_t n_tiles            = tile_width * tile_height;
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits  = bits_for_count(n_tiles);
+    TORCH_CHECK(
+        image_n_bits + tile_n_bits <= 32,
+        "intersect_tile: (image, tile) id packing needs ",
+        image_n_bits + tile_n_bits,
+        " bits but only 32 are available (I=",
+        I,
+        ", n_tiles=",
+        n_tiles,
+        ")."
+    );
+
+    return intersect_tile_kernels_privateuseone(
+        means2d,
+        radii,
+        depths,
+        conics,
+        opacities,
+        packed ? image_ids : c10::nullopt,
+        packed ? gaussian_ids : c10::nullopt,
+        I,
+        tile_size,
+        tile_width,
+        tile_height,
+        sort
+    );
+}
+
 TileIntersectResult intersect_tile_lidar(
     const c10::intrusive_ptr<gsplat::RowOffsetStructuredSpinningLidarModelParametersExt> &lidar,
     const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
@@ -731,6 +788,22 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> build_spa
     return std::make_tuple(active_tiles.to(at::kInt), active_tile_mask, tile_pixel_mask, tile_pixel_cumsum, pixel_map);
 }
 
+at::Tensor intersect_offset_privateuseone(
+    const at::Tensor &isect_ids, // [n_isects]
+    int64_t I,
+    int64_t tile_width,
+    int64_t tile_height
+)
+{
+    DEVICE_GUARD(isect_ids);
+    CHECK_INPUT(isect_ids);
+
+    auto opt           = isect_ids.options();
+    at::Tensor offsets = at::empty({I, tile_height, tile_width}, opt.dtype(at::kInt));
+    launch_intersect_offset_kernels(isect_ids, I, tile_width, tile_height, offsets);
+    return offsets;
+}
+
 void register_intersect_cuda_impl(torch::Library &m)
 {
     m.impl("intersect_tile", to_torch_op<&intersect_tile>);
@@ -738,5 +811,11 @@ void register_intersect_cuda_impl(torch::Library &m)
     m.impl("intersect_offset", to_torch_op<&intersect_offset>);
     m.impl("intersect_tile_sparse", &intersect_tile_sparse);
     m.impl("build_sparse_tile_layout", &build_sparse_tile_layout);
+}
+
+void register_intersect_privateuseone_impl(torch::Library &m)
+{
+    m.impl("intersect_tile", to_torch_op<&intersect_tile_privateuseone>);
+    m.impl("intersect_offset", to_torch_op<&intersect_offset_privateuseone>);
 }
 } // namespace gsplat

--- a/gsplat/cuda/csrc/Intersect.h
+++ b/gsplat/cuda/csrc/Intersect.h
@@ -147,6 +147,43 @@ void launch_intersect_tile_kernel(
     // tile_width] bool). nullopt keeps the original dense behavior.
     const at::optional<at::Tensor> tile_mask = c10::nullopt
 );
+
+void launch_intersect_tile_kernels(
+    // inputs
+    const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
+    const at::Tensor radii,                      // [..., N, 2] or [nnz, 2]
+    const at::Tensor depths,                     // [..., N] or [nnz]
+    const at::optional<at::Tensor> conics,       // [..., N, 3] or [nnz, 3]
+    const at::optional<at::Tensor> opacities,    // [..., N] or [nnz]
+    const at::optional<at::Tensor> image_ids,    // [nnz]
+    const at::optional<at::Tensor> gaussian_ids, // [nnz]
+    const uint32_t I,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const at::optional<at::Tensor> cum_tiles_per_gauss, // [..., N] or [nnz]
+    // outputs
+    at::optional<at::Tensor> tiles_per_gauss, // [..., N] or [nnz]
+    at::optional<at::Tensor> isect_ids,       // [n_isects]
+    at::optional<at::Tensor> flatten_ids      // [n_isects]
+);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_kernels_privateuseone(
+    // inputs
+    const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
+    const at::Tensor radii,                      // [..., N, 2] or [nnz, 2]
+    const at::Tensor depths,                     // [..., N] or [nnz]
+    const at::optional<at::Tensor> conics,       // [..., N, 3] or [nnz, 3]
+    const at::optional<at::Tensor> opacities,    // [..., N] or [nnz]
+    const at::optional<at::Tensor> image_ids,    // [nnz]
+    const at::optional<at::Tensor> gaussian_ids, // [nnz]
+    const uint32_t I,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const bool sort
+);
+
 void launch_intersect_tile_lidar_kernel(
     // inputs
     const c10::intrusive_ptr<RowOffsetStructuredSpinningLidarModelParametersExt> &lidar,
@@ -225,6 +262,16 @@ void launch_build_tile_bitmask_kernel(
     const int64_t pos_bits,
     // output
     at::Tensor out_bitmask // [num_active_tiles, words_per_tile] int64 (zeroed)
+);
+
+void launch_intersect_offset_kernels(
+    // inputs
+    const at::Tensor isect_ids, // [n_isects]
+    const uint32_t I,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    // outputs
+    at::Tensor offsets // [..., tile_height, tile_width]
 );
 
 void radix_sort_double_buffer(

--- a/gsplat/cuda/csrc/IntersectTile.cu
+++ b/gsplat/cuda/csrc/IntersectTile.cu
@@ -16,10 +16,14 @@
  */
 
 #include <ATen/Dispatch.h>
+#include <ATen/Functions.h>
 #include <ATen/core/Tensor.h>
 #include <c10/cuda/CUDAStream.h>
 #include <cassert>
 #include <cooperative_groups.h>
+#include <cuda/std/functional>
+#include <tuple>
+#include <vector>
 
 // for CUB_WRAPPER
 #include <c10/cuda/CUDACachingAllocator.h>
@@ -33,6 +37,44 @@
 namespace gsplat
 {
 namespace cg = cooperative_groups;
+
+#define CUB_WRAPPER_ASYNC(stream, func, ...)                                         \
+    do                                                                               \
+    {                                                                                \
+        size_t temp_storage_bytes = 0;                                               \
+        void *temp_storage        = nullptr;                                         \
+        C10_CUDA_CHECK(func(temp_storage, temp_storage_bytes, __VA_ARGS__, stream)); \
+        C10_CUDA_CHECK(cudaMallocAsync(&temp_storage, temp_storage_bytes, stream));  \
+        C10_CUDA_CHECK(func(temp_storage, temp_storage_bytes, __VA_ARGS__, stream)); \
+        C10_CUDA_CHECK(cudaFreeAsync(temp_storage, stream));                         \
+    } while(false)
+
+struct TileColumnRange
+{
+    int32_t start;
+    int32_t end;
+    bool done;
+};
+
+inline __device__ TileColumnRange row_key_column_range(
+    const int64_t image_id,
+    const int32_t row,
+    const uint32_t tile_width,
+    const uint32_t n_tiles,
+    const int2 rect_min,
+    const int2 rect_max,
+    const int64_t key_start,
+    const int64_t key_end
+)
+{
+    const int64_t row_key_offset = image_id * n_tiles + static_cast<int64_t>(row) * tile_width;
+    const bool done              = row_key_offset + rect_min.x >= key_end;
+    const int64_t col_start
+        = min(static_cast<int64_t>(rect_max.x), max(static_cast<int64_t>(rect_min.x), key_start - row_key_offset));
+    const int64_t col_end
+        = max(static_cast<int64_t>(rect_min.x), min(static_cast<int64_t>(rect_max.x), key_end - row_key_offset));
+    return {static_cast<int32_t>(col_start), static_cast<int32_t>(col_end), done};
+}
 
 // ============================================================
 // SNUGBOX + AccuTile helper functions as propsed by SpeedySplat: https://arxiv.org/pdf/2412.00578
@@ -66,7 +108,11 @@ inline __device__ uint32_t accutile_process_tiles(
     int2 rect_max,
     uint32_t tile_size,
     uint32_t tile_width,
+    uint32_t n_tiles,
     bool isY,
+    int64_t image_id,
+    int64_t key_start,
+    int64_t key_end,
     int64_t iid_enc,
     uint32_t tile_n_bits,
     int64_t depth_id_enc,
@@ -135,14 +181,19 @@ inline __device__ uint32_t accutile_process_tiles(
         int min_tile_v = max(rect_min.y, min(rect_max.y, (int)(ellipse_min / BLOCK)));
         int max_tile_v = min(rect_max.y, max(rect_min.y, (int)(ellipse_max / BLOCK + 1)));
 
-        tiles_count += max_tile_v - min_tile_v;
-
-        if(isect_ids != nullptr)
-        {
 #pragma unroll 1
-            for(int v = min_tile_v; v < max_tile_v; v++)
+        for(int v = min_tile_v; v < max_tile_v; v++)
+        {
+            int64_t tile_id  = isY ? (int64_t)(u * tile_width + v) : (int64_t)(v * tile_width + u);
+            int64_t tile_key = image_id * n_tiles + tile_id;
+            if(tile_key < key_start || tile_key >= key_end)
             {
-                int64_t tile_id       = isY ? (int64_t)(u * tile_width + v) : (int64_t)(v * tile_width + u);
+                continue;
+            }
+            ++tiles_count;
+
+            if(isect_ids != nullptr)
+            {
                 isect_ids[*cur_idx]   = iid_enc | (tile_id << 32) | depth_id_enc;
                 flatten_ids[*cur_idx] = static_cast<int32_t>(flatten_idx);
                 ++(*cur_idx);
@@ -161,6 +212,8 @@ inline __device__ uint32_t accutile_process_tiles(
 
 template<typename scalar_t>
 __global__ void intersect_tile_kernel(
+    const int64_t offset,
+    const int64_t count,
     // if the data is [...,  N, ...] or [nnz, ...] (packed)
     const bool packed,
     // parallelize over I * N, only used if packed is False
@@ -182,6 +235,8 @@ __global__ void intersect_tile_kernel(
     const uint32_t tile_height,
     const uint32_t tile_n_bits,
     const uint32_t image_n_bits,
+    const int64_t key_start,
+    const int64_t key_end,
     const bool *__restrict__ tile_mask,    // [I, tile_height, tile_width] optional
     int32_t *__restrict__ tiles_per_gauss, // [..., N] or [nnz]
     int64_t *__restrict__ isect_ids,       // [n_isects]
@@ -191,10 +246,11 @@ __global__ void intersect_tile_kernel(
     // parallelize over I * N.
     uint32_t idx    = cg::this_grid().thread_rank();
     bool first_pass = cum_tiles_per_gauss == nullptr;
-    if(idx >= (packed ? nnz : I * N))
+    if(idx >= count)
     {
         return;
     }
+    idx += offset;
 
     const float radius_x = radii[idx * 2];
     const float radius_y = radii[idx * 2 + 1];
@@ -209,21 +265,11 @@ __global__ void intersect_tile_kernel(
 
     float2 mean2d = {(float)means2d[2 * idx], (float)means2d[2 * idx + 1]};
 
+    int64_t iid          = packed ? image_ids[idx] : idx / N;
     int64_t iid_enc      = 0;
     int64_t depth_id_enc = 0;
     if(!first_pass)
     {
-        int64_t iid;
-        if(packed)
-        {
-            // parallelize over nnz
-            iid = image_ids[idx];
-        }
-        else
-        {
-            // parallelize over I * N
-            iid = idx / N;
-        }
         iid_enc = iid << (32 + tile_n_bits);
 
         // Narrow to float so the 32-bit key is a monotonic depth ordering for
@@ -306,7 +352,11 @@ __global__ void intersect_tile_kernel(
             rect_max,
             tile_size,
             tile_width,
+            tile_width * tile_height,
             isY,
+            iid,
+            key_start,
+            key_end,
             iid_enc,
             tile_n_bits,
             depth_id_enc,
@@ -349,32 +399,53 @@ __global__ void intersect_tile_kernel(
 
         if(first_pass)
         {
-            if(mask_img == nullptr)
+            int32_t count = 0;
+            for(int32_t i = tile_min.y; i < tile_max.y; ++i)
             {
-                tiles_per_gauss[idx] = static_cast<int32_t>((tile_max.y - tile_min.y) * (tile_max.x - tile_min.x));
-            }
-            else
-            {
-                int32_t count = 0;
-                for(int32_t i = tile_min.y; i < tile_max.y; ++i)
+                TileColumnRange range = row_key_column_range(
+                    iid, i, tile_width, tile_width * tile_height, tile_min, tile_max, key_start, key_end
+                );
+                if(range.done)
                 {
-                    for(int32_t j = tile_min.x; j < tile_max.x; ++j)
+                    break;
+                }
+                if(range.start < range.end)
+                {
+                    if(mask_img == nullptr)
                     {
-                        if(mask_img[i * tile_width + j])
+                        count += range.end - range.start;
+                    }
+                    else
+                    {
+                        for(int32_t j = range.start; j < range.end; ++j)
                         {
-                            ++count;
+                            if(mask_img[i * tile_width + j])
+                            {
+                                ++count;
+                            }
                         }
                     }
                 }
-                tiles_per_gauss[idx] = count;
             }
+            tiles_per_gauss[idx] = count;
             return;
         }
 
         int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
         for(int32_t i = tile_min.y; i < tile_max.y; ++i)
         {
-            for(int32_t j = tile_min.x; j < tile_max.x; ++j)
+            TileColumnRange range = row_key_column_range(
+                iid, i, tile_width, tile_width * tile_height, tile_min, tile_max, key_start, key_end
+            );
+            if(range.done)
+            {
+                break;
+            }
+            if(range.start >= range.end)
+            {
+                continue;
+            }
+            for(int32_t j = range.start; j < range.end; ++j)
             {
                 if(mask_img != nullptr && !mask_img[i * tile_width + j])
                 {
@@ -417,7 +488,7 @@ void launch_intersect_tile_kernel(
 {
     bool packed = means2d.dim() == 2;
 
-    uint32_t N, nnz;
+    uint32_t N = 0, nnz = 0;
     int64_t n_elements;
     if(packed)
     {
@@ -430,11 +501,13 @@ void launch_intersect_tile_kernel(
         n_elements = I * N;
     }
 
-    uint32_t n_tiles            = tile_width * tile_height;
+    const uint32_t n_tiles      = tile_width * tile_height;
     // the number of bits needed to encode the image id and tile id; must match
     // the packing in intersect_tile so the (image, tile) id unpacks correctly.
     const uint32_t image_n_bits = bits_for_count(I);
     const uint32_t tile_n_bits  = bits_for_count(n_tiles);
+    const int64_t key_start     = 0;
+    const int64_t key_end       = static_cast<int64_t>(I) * n_tiles;
     // the first 32 bits are used for the image id and tile id altogether, so
     // check if we have enough bits for them.
     TORCH_CHECK(
@@ -448,9 +521,8 @@ void launch_intersect_tile_kernel(
         ")."
     );
 
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -458,12 +530,15 @@ void launch_intersect_tile_kernel(
         return;
     }
 
+    auto stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES(
         means2d.scalar_type(),
         "intersect_tile_kernel",
         [&]()
         {
-            intersect_tile_kernel<scalar_t><<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
+            intersect_tile_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                0,
+                n_elements,
                 packed,
                 I,
                 N,
@@ -481,16 +556,375 @@ void launch_intersect_tile_kernel(
                 tile_height,
                 tile_n_bits,
                 image_n_bits,
+                key_start,
+                key_end,
                 tile_mask.has_value() ? tile_mask.value().const_data_ptr<bool>() : nullptr,
                 tiles_per_gauss.has_value() ? tiles_per_gauss.value().data_ptr<int32_t>() : nullptr,
                 isect_ids.has_value() ? isect_ids.value().data_ptr<int64_t>() : nullptr,
                 flatten_ids.has_value() ? flatten_ids.value().data_ptr<int32_t>() : nullptr
             );
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     );
 }
 
+void launch_intersect_tile_kernels(
+    // inputs
+    const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
+    const at::Tensor radii,                      // [..., N, 2] or [nnz, 2]
+    const at::Tensor depths,                     // [..., N] or [nnz]
+    const at::optional<at::Tensor> conics,       // [..., N, 3] or [nnz, 3]
+    const at::optional<at::Tensor> opacities,    // [..., N] or [nnz]
+    const at::optional<at::Tensor> image_ids,    // [nnz]
+    const at::optional<at::Tensor> gaussian_ids, // [nnz]
+    const uint32_t I,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const at::optional<at::Tensor> cum_tiles_per_gauss, // [..., N] or [nnz]
+    // outputs
+    at::optional<at::Tensor> tiles_per_gauss, // [..., N] or [nnz]
+    at::optional<at::Tensor> isect_ids,       // [n_isects]
+    at::optional<at::Tensor> flatten_ids      // [n_isects]
+)
+{
+    bool packed = means2d.dim() == 2;
+
+    uint32_t N = 0, nnz = 0;
+    int64_t n_elements;
+    if(packed)
+    {
+        nnz        = means2d.size(0);
+        n_elements = nnz;
+    }
+    else
+    {
+        N          = means2d.size(-2);
+        n_elements = I * N;
+    }
+
+    const uint32_t n_tiles      = tile_width * tile_height;
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits  = bits_for_count(n_tiles);
+    const int64_t key_start     = 0;
+    const int64_t key_end       = static_cast<int64_t>(I) * n_tiles;
+    assert(image_n_bits + tile_n_bits <= 32);
+
+    constexpr unsigned int threads = 256;
+    if(n_elements == 0)
+    {
+        return;
+    }
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t offset, count;
+        std::tie(offset, count) = chunk(n_elements, device_id);
+        unsigned int blocks     = ::cuda::ceil_div(count, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_FLOATING_TYPES(
+                means2d.scalar_type(),
+                "intersect_tile_kernel",
+                [&]()
+                {
+                    intersect_tile_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                        offset,
+                        count,
+                        packed,
+                        I,
+                        N,
+                        nnz,
+                        image_ids.has_value() ? image_ids.value().const_data_ptr<int64_t>() : nullptr,
+                        gaussian_ids.has_value() ? gaussian_ids.value().const_data_ptr<int64_t>() : nullptr,
+                        means2d.const_data_ptr<scalar_t>(),
+                        radii.const_data_ptr<int32_t>(),
+                        depths.const_data_ptr<scalar_t>(),
+                        conics.has_value() ? conics.value().const_data_ptr<float>() : nullptr,
+                        opacities.has_value() ? opacities.value().const_data_ptr<float>() : nullptr,
+                        cum_tiles_per_gauss.has_value() ? cum_tiles_per_gauss.value().const_data_ptr<int64_t>()
+                                                        : nullptr,
+                        tile_size,
+                        tile_width,
+                        tile_height,
+                        tile_n_bits,
+                        image_n_bits,
+                        key_start,
+                        key_end,
+                        nullptr,
+                        tiles_per_gauss.has_value() ? tiles_per_gauss.value().data_ptr<int32_t>() : nullptr,
+                        isect_ids.has_value() ? isect_ids.value().data_ptr<int64_t>() : nullptr,
+                        flatten_ids.has_value() ? flatten_ids.value().data_ptr<int32_t>() : nullptr
+                    );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            );
+        }
+    }
+    merge_streams();
+}
+
+__global__ void add_counts_kernel(
+    const int64_t count, const int32_t *__restrict__ local_counts, int32_t *__restrict__ tiles_per_gauss
+)
+{
+    int64_t idx = cg::this_grid().thread_rank();
+    if(idx >= count)
+    {
+        return;
+    }
+    int32_t local_count = local_counts[idx];
+    if(local_count > 0)
+    {
+        atomicAdd_system(tiles_per_gauss + idx, local_count);
+    }
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_kernels_privateuseone(
+    // inputs
+    const at::Tensor means2d,                    // [..., N, 2] or [nnz, 2]
+    const at::Tensor radii,                      // [..., N, 2] or [nnz, 2]
+    const at::Tensor depths,                     // [..., N] or [nnz]
+    const at::optional<at::Tensor> conics,       // [..., N, 3] or [nnz, 3]
+    const at::optional<at::Tensor> opacities,    // [..., N] or [nnz]
+    const at::optional<at::Tensor> image_ids,    // [nnz]
+    const at::optional<at::Tensor> gaussian_ids, // [nnz]
+    const uint32_t I,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const bool sort
+)
+{
+    bool packed = means2d.dim() == 2;
+
+    uint32_t N = 0, nnz = 0;
+    int64_t n_elements;
+    if(packed)
+    {
+        nnz        = means2d.size(0);
+        n_elements = nnz;
+    }
+    else
+    {
+        N          = means2d.size(-2);
+        n_elements = static_cast<int64_t>(I) * N;
+    }
+
+    auto opt                   = depths.options();
+    at::Tensor tiles_per_gauss = at::zeros_like(depths, opt.dtype(at::kInt));
+    at::Tensor isect_ids;
+    at::Tensor flatten_ids;
+    if(n_elements == 0)
+    {
+        isect_ids   = at::empty({0}, opt.dtype(at::kLong));
+        flatten_ids = at::empty({0}, opt.dtype(at::kInt));
+        return std::make_tuple(tiles_per_gauss, isect_ids, flatten_ids);
+    }
+
+    const uint32_t n_tiles      = tile_width * tile_height;
+    const uint32_t image_n_bits = bits_for_count(I);
+    const uint32_t tile_n_bits  = bits_for_count(n_tiles);
+    assert(image_n_bits + tile_n_bits <= 32);
+
+    constexpr unsigned int threads = 256;
+    const int device_count         = static_cast<int>(c10::cuda::device_count());
+    TORCH_CHECK(device_count > 0, "PrivateUse1 intersect_tile requires at least one CUDA device");
+    const int64_t total_tile_keys = static_cast<int64_t>(I) * n_tiles;
+    const unsigned int blocks     = ::cuda::ceil_div(n_elements, threads);
+
+    std::vector<int32_t *> device_counts(device_count, nullptr);
+    std::vector<int64_t *> device_cumsum(device_count, nullptr);
+    std::vector<int64_t> device_intersection_offsets(device_count, 0);
+    std::vector<int64_t> device_intersection_counts(device_count, 0);
+
+    int64_t *device_totals = nullptr;
+    C10_CUDA_CHECK(cudaMallocHost(&device_totals, device_count * sizeof(int64_t)));
+
+    for(const auto device_id: c10::irange(device_count))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        C10_CUDA_CHECK(cudaMallocAsync(&device_counts[device_id], n_elements * sizeof(int32_t), stream));
+        C10_CUDA_CHECK(cudaMallocAsync(&device_cumsum[device_id], n_elements * sizeof(int64_t), stream));
+
+        size_t key_offset, key_count;
+        std::tie(key_offset, key_count) = chunk(total_tile_keys, device_id);
+        const int64_t key_start         = static_cast<int64_t>(key_offset);
+        const int64_t key_end           = static_cast<int64_t>(key_offset + key_count);
+
+        AT_DISPATCH_FLOATING_TYPES(
+            means2d.scalar_type(),
+            "intersect_tile_kernel_privateuseone_count",
+            [&]()
+            {
+                intersect_tile_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                    0,
+                    n_elements,
+                    packed,
+                    I,
+                    N,
+                    nnz,
+                    image_ids.has_value() ? image_ids.value().const_data_ptr<int64_t>() : nullptr,
+                    gaussian_ids.has_value() ? gaussian_ids.value().const_data_ptr<int64_t>() : nullptr,
+                    means2d.const_data_ptr<scalar_t>(),
+                    radii.const_data_ptr<int32_t>(),
+                    depths.const_data_ptr<scalar_t>(),
+                    conics.has_value() ? conics.value().const_data_ptr<float>() : nullptr,
+                    opacities.has_value() ? opacities.value().const_data_ptr<float>() : nullptr,
+                    nullptr,
+                    tile_size,
+                    tile_width,
+                    tile_height,
+                    tile_n_bits,
+                    image_n_bits,
+                    key_start,
+                    key_end,
+                    nullptr,
+                    device_counts[device_id],
+                    nullptr,
+                    nullptr
+                );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+        );
+
+        CUB_WRAPPER_ASYNC(
+            stream, cub::DeviceScan::InclusiveSum, device_counts[device_id], device_cumsum[device_id], n_elements
+        );
+
+        add_counts_kernel<<<blocks, threads, 0, stream>>>(
+            n_elements, device_counts[device_id], tiles_per_gauss.data_ptr<int32_t>()
+        );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        C10_CUDA_CHECK(cudaMemcpyAsync(
+            &device_totals[device_id],
+            device_cumsum[device_id] + n_elements - 1,
+            sizeof(int64_t),
+            cudaMemcpyDeviceToHost,
+            stream
+        ));
+    }
+
+    int64_t n_isects = 0;
+    for(const auto device_id: c10::irange(device_count))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+        C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+        device_intersection_offsets[device_id]  = n_isects;
+        device_intersection_counts[device_id]   = device_totals[device_id];
+        n_isects                               += device_totals[device_id];
+    }
+    C10_CUDA_CHECK(cudaFreeHost(device_totals));
+
+    isect_ids   = at::empty({n_isects}, opt.dtype(at::kLong));
+    flatten_ids = at::empty({n_isects}, opt.dtype(at::kInt));
+    if(n_isects == 0)
+    {
+        for(const auto device_id: c10::irange(device_count))
+        {
+            C10_CUDA_CHECK(cudaSetDevice(device_id));
+            auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+            C10_CUDA_CHECK(cudaFreeAsync(device_counts[device_id], stream));
+            C10_CUDA_CHECK(cudaFreeAsync(device_cumsum[device_id], stream));
+        }
+        merge_streams();
+        return std::make_tuple(tiles_per_gauss, isect_ids, flatten_ids);
+    }
+
+    for(const auto device_id: c10::irange(device_count))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        size_t key_offset, key_count;
+        std::tie(key_offset, key_count) = chunk(total_tile_keys, device_id);
+        const int64_t key_start         = static_cast<int64_t>(key_offset);
+        const int64_t key_end           = static_cast<int64_t>(key_offset + key_count);
+        const int64_t isect_offset      = device_intersection_offsets[device_id];
+        const int64_t isect_count       = device_intersection_counts[device_id];
+        if(isect_count == 0)
+        {
+            C10_CUDA_CHECK(cudaFreeAsync(device_counts[device_id], stream));
+            C10_CUDA_CHECK(cudaFreeAsync(device_cumsum[device_id], stream));
+            continue;
+        }
+
+        AT_DISPATCH_FLOATING_TYPES(
+            means2d.scalar_type(),
+            "intersect_tile_kernel_privateuseone_emit",
+            [&]()
+            {
+                intersect_tile_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                    0,
+                    n_elements,
+                    packed,
+                    I,
+                    N,
+                    nnz,
+                    image_ids.has_value() ? image_ids.value().const_data_ptr<int64_t>() : nullptr,
+                    gaussian_ids.has_value() ? gaussian_ids.value().const_data_ptr<int64_t>() : nullptr,
+                    means2d.const_data_ptr<scalar_t>(),
+                    radii.const_data_ptr<int32_t>(),
+                    depths.const_data_ptr<scalar_t>(),
+                    conics.has_value() ? conics.value().const_data_ptr<float>() : nullptr,
+                    opacities.has_value() ? opacities.value().const_data_ptr<float>() : nullptr,
+                    device_cumsum[device_id],
+                    tile_size,
+                    tile_width,
+                    tile_height,
+                    tile_n_bits,
+                    image_n_bits,
+                    key_start,
+                    key_end,
+                    nullptr,
+                    nullptr,
+                    isect_ids.data_ptr<int64_t>() + isect_offset,
+                    flatten_ids.data_ptr<int32_t>() + isect_offset
+                );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+        );
+
+        C10_CUDA_CHECK(cudaFreeAsync(device_counts[device_id], stream));
+        C10_CUDA_CHECK(cudaFreeAsync(device_cumsum[device_id], stream));
+    }
+
+    if(sort)
+    {
+        for(const auto device_id: c10::irange(device_count))
+        {
+            C10_CUDA_CHECK(cudaSetDevice(device_id));
+            auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+            const int64_t isect_offset = device_intersection_offsets[device_id];
+            const int64_t isect_count  = device_intersection_counts[device_id];
+            if(isect_count > 0)
+            {
+                CUB_WRAPPER_ASYNC(
+                    stream,
+                    cub::DeviceMergeSort::SortPairs,
+                    isect_ids.data_ptr<int64_t>() + isect_offset,
+                    flatten_ids.data_ptr<int32_t>() + isect_offset,
+                    isect_count,
+                    ::cuda::std::less<int64_t>{}
+                );
+            }
+        }
+    }
+    merge_streams();
+    return std::make_tuple(tiles_per_gauss, isect_ids, flatten_ids);
+}
+
 __global__ void intersect_offset_kernel(
+    const uint32_t offset,
+    const uint32_t count,
     const uint32_t n_isects,
     const int64_t *__restrict__ isect_ids,
     const uint32_t I,
@@ -504,10 +938,11 @@ __global__ void intersect_offset_kernel(
     // cumsum: [0, 3, 3, 5, 5, 5]
     // offsets: [0, 0, 3, 3, 5, 5]
     uint32_t idx = cg::this_grid().thread_rank();
-    if(idx >= n_isects)
+    if(idx >= count)
     {
         return;
     }
+    idx += offset;
 
     int64_t isect_id_curr = isect_ids[idx] >> 32;
     int64_t iid_curr      = isect_id_curr >> (tile_n_bits);
@@ -562,10 +997,9 @@ void launch_intersect_offset_kernel(
     at::Tensor offsets // [I, tile_height, tile_width]
 )
 {
-    int64_t n_elements = isect_ids.size(0); // total number of intersections
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    int64_t n_elements             = isect_ids.size(0); // total number of intersections
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -573,13 +1007,70 @@ void launch_intersect_offset_kernel(
         return;
     }
 
-    uint32_t n_tiles           = tile_width * tile_height;
+    const uint32_t n_tiles     = tile_width * tile_height;
     // Must match the packing in launch_intersect_tile_kernel so the (image,
     // tile) id unpacks with the same field width it was packed with.
     const uint32_t tile_n_bits = bits_for_count(n_tiles);
-    intersect_offset_kernel<<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-        n_elements, isect_ids.const_data_ptr<int64_t>(), I, n_tiles, tile_n_bits, offsets.data_ptr<int32_t>()
+    auto stream                = at::cuda::getCurrentCUDAStream();
+    intersect_offset_kernel<<<blocks, threads, 0, stream>>>(
+        0,
+        n_elements,
+        n_elements,
+        isect_ids.const_data_ptr<int64_t>(),
+        I,
+        n_tiles,
+        tile_n_bits,
+        offsets.data_ptr<int32_t>()
     );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void launch_intersect_offset_kernels(
+    // inputs
+    const at::Tensor isect_ids, // [n_isects]
+    const uint32_t I,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    // outputs
+    at::Tensor offsets // [I, tile_height, tile_width]
+)
+{
+    int64_t n_elements             = isect_ids.size(0);
+    constexpr unsigned int threads = 256;
+
+    if(n_elements == 0)
+    {
+        offsets.fill_(0);
+        return;
+    }
+
+    const uint32_t n_tiles     = tile_width * tile_height;
+    const uint32_t tile_n_bits = bits_for_count(n_tiles);
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t offset, count;
+        std::tie(offset, count) = chunk(n_elements, device_id);
+        unsigned int blocks     = ::cuda::ceil_div(count, threads);
+        if(blocks > 0)
+        {
+            intersect_offset_kernel<<<blocks, threads, 0, stream>>>(
+                offset,
+                count,
+                n_elements,
+                isect_ids.const_data_ptr<int64_t>(),
+                I,
+                n_tiles,
+                tile_n_bits,
+                offsets.data_ptr<int32_t>()
+            );
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+    }
+    merge_streams();
 }
 
 // https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceRadixSort.html

--- a/gsplat/cuda/csrc/MCMCPerturb.cpp
+++ b/gsplat/cuda/csrc/MCMCPerturb.cpp
@@ -26,7 +26,9 @@ void mcmc_perturb_positions(
     const at::Tensor &scales,    // [N, 3] log-scale
     const at::Tensor &opacities, // [N] logit
     const at::Tensor &noise,     // [N, 3] standard normal
-    double scaler
+    double noise_scale,
+    double t,
+    double k
 )
 {
     DEVICE_GUARD(positions);
@@ -49,7 +51,16 @@ void mcmc_perturb_positions(
     TORCH_CHECK(opacities.dim() == 1 && opacities.size(0) == N, "mcmc_perturb_positions: opacities must be [N]");
     TORCH_CHECK(noise.sizes() == at::IntArrayRef({N, 3}), "mcmc_perturb_positions: noise must be [N, 3]");
 
-    launch_mcmc_perturb_positions_kernel(positions, quats, scales, opacities, noise, static_cast<float>(scaler));
+    launch_mcmc_perturb_positions_kernel(
+        positions,
+        quats,
+        scales,
+        opacities,
+        noise,
+        static_cast<float>(noise_scale),
+        static_cast<float>(t),
+        static_cast<float>(k)
+    );
 }
 
 void register_mcmc_perturb_cuda_impl(torch::Library &m)

--- a/gsplat/cuda/csrc/MCMCPerturb.h
+++ b/gsplat/cuda/csrc/MCMCPerturb.h
@@ -18,6 +18,8 @@ void launch_mcmc_perturb_positions_kernel(
     const at::Tensor &scales,    // [N, 3] log-scale
     const at::Tensor &opacities, // [N] logit
     const at::Tensor &noise,     // [N, 3] standard normal
-    float scaler
+    float noise_scale,
+    float t,
+    float k
 );
 } // namespace gsplat

--- a/gsplat/cuda/csrc/MCMCPerturbCUDA.cu
+++ b/gsplat/cuda/csrc/MCMCPerturbCUDA.cu
@@ -24,11 +24,6 @@ inline __device__ float sigmoid_standard(float x)
     return 1.f / (1.f + expf(-x));
 }
 
-inline __device__ float sigmoid_steep(float x, float k, float x0)
-{
-    return 1.f / (1.f + expf(-k * (x - x0)));
-}
-
 __global__ void mcmc_perturb_positions_kernel(
     const uint32_t N,
     float *__restrict__ positions,
@@ -36,7 +31,9 @@ __global__ void mcmc_perturb_positions_kernel(
     const float *__restrict__ scales_log,
     const float *__restrict__ opacities_logit,
     const float *__restrict__ noise,
-    const float scaler
+    const float noise_scale,
+    const float t,
+    const float k
 )
 {
     const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -53,7 +50,7 @@ __global__ void mcmc_perturb_positions_kernel(
     quat_scale_to_covar_preci(quat, scale, &covar, nullptr);
 
     const float density = sigmoid_standard(opacities_logit[idx]);
-    const float w       = sigmoid_steep(1.f - density, 100.f, 0.995f) * scaler;
+    const float w       = sigmoid_standard(-k * (density - t)) * noise_scale;
 
     vec3 n           = glm::make_vec3(noise + idx * 3) * w;
     vec3 transformed = covar * n;
@@ -69,7 +66,9 @@ void launch_mcmc_perturb_positions_kernel(
     const at::Tensor &scales,
     const at::Tensor &opacities,
     const at::Tensor &noise,
-    float scaler
+    float noise_scale,
+    float t,
+    float k
 )
 {
     const int64_t N = positions.size(0);
@@ -90,7 +89,9 @@ void launch_mcmc_perturb_positions_kernel(
         scales.const_data_ptr<float>(),
         opacities.const_data_ptr<float>(),
         noise.const_data_ptr<float>(),
-        scaler
+        noise_scale,
+        t,
+        k
     );
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/gsplat/cuda/csrc/Projection.cpp
+++ b/gsplat/cuda/csrc/Projection.cpp
@@ -491,6 +491,87 @@ struct TorchArgDef<ProjectionEWA3DGSFusedGrad>
     }
 };
 
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::optional<at::Tensor>
+>
+    projection_ewa_3dgs_fused_fwd_privateuseone(
+        const at::Tensor &means,                   // [..., N, 3]
+        const at::optional<at::Tensor> &covars,    // [..., N, 6] optional
+        const at::optional<at::Tensor> &quats,     // [..., N, 4] optional
+        const at::optional<at::Tensor> &scales,    // [..., N, 3] optional
+        const at::optional<at::Tensor> &opacities, // [..., N] optional
+        const at::Tensor &viewmats,                // [..., C, 4, 4]
+        const at::Tensor &Ks,                      // [..., C, 3, 3]
+        int64_t image_width,
+        int64_t image_height,
+        double eps2d,
+        double near_plane,
+        double far_plane,
+        double radius_clip,
+        bool calc_compensations,
+        int64_t camera_model
+    )
+{
+    check_projection_ewa_3dgs_fused_inputs(
+        means, covars, quats, scales, opacities, viewmats, Ks, static_cast<CameraModelType>(camera_model)
+    );
+
+    DEVICE_GUARD(means);
+    auto opt = means.options();
+    at::DimVector batch_dims(means.sizes().slice(0, means.dim() - 2));
+    uint32_t N = means.size(-2);
+    uint32_t C = viewmats.size(-3);
+
+    at::DimVector radii_shape(batch_dims);
+    radii_shape.append({C, N, 2});
+    at::Tensor radii = at::empty(radii_shape, opt.dtype(at::kInt));
+    at::DimVector means2d_shape(batch_dims);
+    means2d_shape.append({C, N, 2});
+    at::Tensor means2d = at::empty(means2d_shape, opt);
+    at::DimVector depths_shape(batch_dims);
+    depths_shape.append({C, N});
+    at::Tensor depths = at::empty(depths_shape, opt);
+    at::DimVector conics_shape(batch_dims);
+    conics_shape.append({C, N, 3});
+    at::Tensor conics = at::empty(conics_shape, opt);
+    at::Tensor compensations;
+    if(calc_compensations)
+    {
+        at::DimVector compensations_shape(batch_dims);
+        compensations_shape.append({C, N});
+        compensations = at::zeros(compensations_shape, opt);
+    }
+
+    launch_projection_ewa_3dgs_fused_fwd_kernels(
+        means,
+        covars,
+        quats,
+        scales,
+        opacities,
+        viewmats,
+        Ks,
+        image_width,
+        image_height,
+        eps2d,
+        near_plane,
+        far_plane,
+        radius_clip,
+        static_cast<CameraModelType>(camera_model),
+        radii,
+        means2d,
+        depths,
+        conics,
+        calc_compensations ? at::optional<at::Tensor>(compensations) : c10::nullopt
+    );
+    return std::make_tuple(
+        radii, means2d, depths, conics, calc_compensations ? at::optional<at::Tensor>(compensations) : c10::nullopt
+    );
+}
+
 // Full backward for projection_ewa_3dgs_fused.
 // `viewmats_requires_grad` selects whether to compute the viewmats gradient. It
 // is an explicit argument rather than something inferred from a tensor's
@@ -644,6 +725,109 @@ ProjectionEWA3DGSFusedResult projection_ewa_3dgs_fused(
         radius_clip,
         calc_compensations,
         camera_model
+    );
+}
+
+std::tuple<
+    at::Tensor,
+    at::optional<at::Tensor>,
+    at::optional<at::Tensor>,
+    at::optional<at::Tensor>,
+    at::optional<at::Tensor>
+>
+    projection_ewa_3dgs_fused_bwd_privateuseone(
+        // fwd inputs
+        const at::Tensor &means,                // [..., N, 3]
+        const at::optional<at::Tensor> &covars, // [..., N, 6] optional
+        const at::optional<at::Tensor> &quats,  // [..., N, 4] optional
+        const at::optional<at::Tensor> &scales, // [..., N, 3] optional
+        const at::Tensor &viewmats,             // [..., C, 4, 4]
+        const at::Tensor &Ks,                   // [..., C, 3, 3]
+        int64_t image_width,
+        int64_t image_height,
+        double eps2d,
+        int64_t camera_model,
+        // fwd outputs
+        const at::Tensor &radii,                       // [..., C, N, 2]
+        const at::Tensor &conics,                      // [..., C, N, 3]
+        const at::optional<at::Tensor> &compensations, // [..., C, N] optional
+        // grad outputs
+        const at::Tensor &v_means2d,                     // [..., C, N, 2]
+        const at::Tensor &v_depths,                      // [..., C, N]
+        const at::Tensor &v_conics,                      // [..., C, N, 3]
+        const at::optional<at::Tensor> &v_compensations, // [..., C, N] optional
+        bool viewmats_requires_grad
+    )
+{
+    DEVICE_GUARD(means);
+    check_projection_ewa_3dgs_fused_inputs(
+        means, covars, quats, scales, c10::nullopt, viewmats, Ks, static_cast<CameraModelType>(camera_model)
+    );
+    CHECK_INPUT(radii);
+    CHECK_INPUT(conics);
+    CHECK_INPUT(v_means2d);
+    CHECK_INPUT(v_depths);
+    CHECK_INPUT(v_conics);
+    if(compensations.has_value())
+    {
+        CHECK_INPUT(compensations.value());
+    }
+    at::optional<at::Tensor> compensation_grad;
+    if(compensations.has_value() && v_compensations.has_value())
+    {
+        CHECK_INPUT(v_compensations.value());
+        compensation_grad = v_compensations;
+    }
+
+    at::Tensor v_means = at::zeros_like(means);
+    at::Tensor v_covars, v_quats, v_scales;
+    if(covars.has_value())
+    {
+        v_covars = at::zeros_like(covars.value());
+    }
+    else
+    {
+        v_quats  = at::zeros_like(quats.value());
+        v_scales = at::zeros_like(scales.value());
+    }
+    at::Tensor v_viewmats;
+    if(viewmats_requires_grad)
+    {
+        v_viewmats = at::zeros_like(viewmats);
+    }
+
+    launch_projection_ewa_3dgs_fused_bwd_kernels(
+        means,
+        covars,
+        quats,
+        scales,
+        viewmats,
+        Ks,
+        image_width,
+        image_height,
+        eps2d,
+        static_cast<CameraModelType>(camera_model),
+        radii,
+        conics,
+        compensations,
+        v_means2d,
+        v_depths,
+        v_conics,
+        compensation_grad,
+        viewmats_requires_grad,
+        v_means,
+        v_covars,
+        v_quats,
+        v_scales,
+        v_viewmats
+    );
+
+    return std::make_tuple(
+        v_means,
+        as_optional_tensor(v_covars),
+        as_optional_tensor(v_quats),
+        as_optional_tensor(v_scales),
+        as_optional_tensor(v_viewmats)
     );
 }
 
@@ -2007,5 +2191,13 @@ void register_projection_cuda_impl(torch::Library &m)
 #endif
 
     m.impl("projection_ut_3dgs_fused", to_torch_op<&projection_ut_3dgs_fused>);
+}
+
+void register_projection_privateuseone_impl(torch::Library &m)
+{
+#if GSPLAT_BUILD_3DGS
+    m.impl("projection_ewa_3dgs_fused", to_torch_op<&projection_ewa_3dgs_fused_fwd_privateuseone>);
+    m.impl("projection_ewa_3dgs_fused_bwd", to_torch_op<&projection_ewa_3dgs_fused_bwd_privateuseone>);
+#endif
 }
 } // namespace gsplat

--- a/gsplat/cuda/csrc/Projection.h
+++ b/gsplat/cuda/csrc/Projection.h
@@ -292,7 +292,63 @@ void launch_projection_ewa_3dgs_fused_fwd_kernel(
     at::Tensor conics,                     // [..., C, N, 3]
     at::optional<at::Tensor> compensations // [..., C, N] optional
 );
+
+void launch_projection_ewa_3dgs_fused_fwd_kernels(
+    // inputs
+    const at::Tensor means,                   // [..., N, 3]
+    const at::optional<at::Tensor> covars,    // [..., N, 6] optional
+    const at::optional<at::Tensor> quats,     // [..., N, 4] optional
+    const at::optional<at::Tensor> scales,    // [..., N, 3] optional
+    const at::optional<at::Tensor> opacities, // [..., N] optional
+    const at::Tensor viewmats,                // [..., C, 4, 4]
+    const at::Tensor Ks,                      // [..., C, 3, 3]
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const float eps2d,
+    const float near_plane,
+    const float far_plane,
+    const float radius_clip,
+    const CameraModelType camera_model,
+    // outputs
+    at::Tensor radii,                      // [..., C, N, 2]
+    at::Tensor means2d,                    // [..., C, N, 2]
+    at::Tensor depths,                     // [..., C, N]
+    at::Tensor conics,                     // [..., C, N, 3]
+    at::optional<at::Tensor> compensations // [..., C, N] optional
+);
+
 void launch_projection_ewa_3dgs_fused_bwd_kernel(
+    // inputs
+    // fwd inputs
+    const at::Tensor means,                // [..., N, 3]
+    const at::optional<at::Tensor> covars, // [..., N, 6] optional
+    const at::optional<at::Tensor> quats,  // [..., N, 4] optional
+    const at::optional<at::Tensor> scales, // [..., N, 3] optional
+    const at::Tensor viewmats,             // [..., C, 4, 4]
+    const at::Tensor Ks,                   // [..., C, 3, 3]
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const float eps2d,
+    const CameraModelType camera_model,
+    // fwd outputs
+    const at::Tensor radii,                       // [..., C, N, 2]
+    const at::Tensor conics,                      // [..., C, N, 3]
+    const at::optional<at::Tensor> compensations, // [..., C, N] optional
+    // grad outputs
+    const at::Tensor v_means2d,                     // [..., C, N, 2]
+    const at::Tensor v_depths,                      // [..., C, N]
+    const at::Tensor v_conics,                      // [..., C, N, 3]
+    const at::optional<at::Tensor> v_compensations, // [..., C, N] optional
+    const bool viewmats_requires_grad,
+    // outputs
+    at::Tensor v_means,   // [..., N, 3]
+    at::Tensor v_covars,  // [..., N, 3, 3]
+    at::Tensor v_quats,   // [..., N, 4]
+    at::Tensor v_scales,  // [..., N, 3]
+    at::Tensor v_viewmats // [..., C, 4, 4]
+);
+
+void launch_projection_ewa_3dgs_fused_bwd_kernels(
     // inputs
     // fwd inputs
     const at::Tensor means,                // [..., N, 3]

--- a/gsplat/cuda/csrc/ProjectionEWA3DGSFused.cu
+++ b/gsplat/cuda/csrc/ProjectionEWA3DGSFused.cu
@@ -36,6 +36,8 @@ namespace cg = cooperative_groups;
 
 template<typename scalar_t>
 __global__ void projection_ewa_3dgs_fused_fwd_kernel(
+    const int64_t gaussian_offset,
+    const int64_t gaussian_count,
     const uint32_t B,
     const uint32_t C,
     const uint32_t N,
@@ -61,15 +63,17 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
     scalar_t *__restrict__ compensations // [B, C, N] optional
 )
 {
-    // parallelize over B * C * N.
-    uint32_t idx = cg::this_grid().thread_rank();
-    if(idx >= B * C * N)
+    // parallelize over B * C * gaussian_count.
+    int64_t idx         = cg::this_grid().thread_rank();
+    const int64_t count = static_cast<int64_t>(B) * C * gaussian_count;
+    if(idx >= count)
     {
         return;
     }
-    const uint32_t bid = idx / (C * N); // batch id
-    const uint32_t cid = (idx / N) % C; // camera id
-    const uint32_t gid = idx % N;       // gaussian id
+    const uint32_t bid       = idx / (C * gaussian_count);             // batch id
+    const uint32_t cid       = (idx / gaussian_count) % C;             // camera id
+    const uint32_t gid       = idx % gaussian_count + gaussian_offset; // gaussian id
+    const int64_t global_idx = (static_cast<int64_t>(bid) * C + cid) * N + gid;
 
     // shift pointers to the current camera and gaussian
     means    += bid * N * 3 + gid * 3;
@@ -95,8 +99,8 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
     posW2C(R, t, glm::make_vec3(means), mean_c);
     if(mean_c.z < near_plane || mean_c.z > far_plane)
     {
-        radii[idx * 2]     = 0;
-        radii[idx * 2 + 1] = 0;
+        radii[global_idx * 2]     = 0;
+        radii[global_idx * 2 + 1] = 0;
         return;
     }
 
@@ -148,8 +152,8 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
     float det = add_blur(eps2d, covar2d, compensation);
     if(det <= 0.f)
     {
-        radii[idx * 2]     = 0;
-        radii[idx * 2 + 1] = 0;
+        radii[global_idx * 2]     = 0;
+        radii[global_idx * 2 + 1] = 0;
         return;
     }
 
@@ -167,8 +171,8 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
         }
         if(opacity < ALPHA_THRESHOLD)
         {
-            radii[idx * 2]     = 0;
-            radii[idx * 2 + 1] = 0;
+            radii[global_idx * 2]     = 0;
+            radii[global_idx * 2 + 1] = 0;
             return;
         }
         // Compute opacity-aware bounding box.
@@ -183,8 +187,8 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
 
     if(radius_x <= radius_clip && radius_y <= radius_clip)
     {
-        radii[idx * 2]     = 0;
-        radii[idx * 2 + 1] = 0;
+        radii[global_idx * 2]     = 0;
+        radii[global_idx * 2 + 1] = 0;
         return;
     }
 
@@ -194,23 +198,23 @@ __global__ void projection_ewa_3dgs_fused_fwd_kernel(
        || mean2d.y + radius_y <= 0
        || mean2d.y - radius_y >= image_height)
     {
-        radii[idx * 2]     = 0;
-        radii[idx * 2 + 1] = 0;
+        radii[global_idx * 2]     = 0;
+        radii[global_idx * 2 + 1] = 0;
         return;
     }
 
     // write to outputs
-    radii[idx * 2]       = (int32_t)radius_x;
-    radii[idx * 2 + 1]   = (int32_t)radius_y;
-    means2d[idx * 2]     = mean2d.x;
-    means2d[idx * 2 + 1] = mean2d.y;
-    depths[idx]          = mean_c.z;
-    conics[idx * 3]      = covar2d_inv[0][0];
-    conics[idx * 3 + 1]  = covar2d_inv[0][1];
-    conics[idx * 3 + 2]  = covar2d_inv[1][1];
+    radii[global_idx * 2]       = (int32_t)radius_x;
+    radii[global_idx * 2 + 1]   = (int32_t)radius_y;
+    means2d[global_idx * 2]     = mean2d.x;
+    means2d[global_idx * 2 + 1] = mean2d.y;
+    depths[global_idx]          = mean_c.z;
+    conics[global_idx * 3]      = covar2d_inv[0][0];
+    conics[global_idx * 3 + 1]  = covar2d_inv[0][1];
+    conics[global_idx * 3 + 2]  = covar2d_inv[1][1];
     if(compensations != nullptr)
     {
-        compensations[idx] = compensation;
+        compensations[global_idx] = compensation;
     }
 }
 
@@ -242,10 +246,9 @@ void launch_projection_ewa_3dgs_fused_fwd_kernel(
     uint32_t C = viewmats.size(-3);       // number of cameras
     uint32_t B = means.numel() / (N * 3); // number of batches
 
-    int64_t n_elements = B * C * N;
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    int64_t n_elements             = B * C * N;
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -253,42 +256,127 @@ void launch_projection_ewa_3dgs_fused_fwd_kernel(
         return;
     }
 
+    auto stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES(
         means.scalar_type(),
         "projection_ewa_3dgs_fused_fwd_kernel",
         [&]()
         {
-            projection_ewa_3dgs_fused_fwd_kernel<scalar_t>
-                <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                    B,
-                    C,
-                    N,
-                    means.const_data_ptr<scalar_t>(),
-                    covars.has_value() ? covars.value().const_data_ptr<scalar_t>() : nullptr,
-                    quats.has_value() ? quats.value().const_data_ptr<scalar_t>() : nullptr,
-                    scales.has_value() ? scales.value().const_data_ptr<scalar_t>() : nullptr,
-                    opacities.has_value() ? opacities.value().const_data_ptr<scalar_t>() : nullptr,
-                    viewmats.const_data_ptr<scalar_t>(),
-                    Ks.const_data_ptr<scalar_t>(),
-                    image_width,
-                    image_height,
-                    eps2d,
-                    near_plane,
-                    far_plane,
-                    radius_clip,
-                    camera_model,
-                    radii.data_ptr<int32_t>(),
-                    means2d.data_ptr<scalar_t>(),
-                    depths.data_ptr<scalar_t>(),
-                    conics.data_ptr<scalar_t>(),
-                    compensations.has_value() ? compensations.value().data_ptr<scalar_t>() : nullptr
-                );
+            projection_ewa_3dgs_fused_fwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                0,
+                N,
+                B,
+                C,
+                N,
+                means.const_data_ptr<scalar_t>(),
+                covars.has_value() ? covars.value().const_data_ptr<scalar_t>() : nullptr,
+                quats.has_value() ? quats.value().const_data_ptr<scalar_t>() : nullptr,
+                scales.has_value() ? scales.value().const_data_ptr<scalar_t>() : nullptr,
+                opacities.has_value() ? opacities.value().const_data_ptr<scalar_t>() : nullptr,
+                viewmats.const_data_ptr<scalar_t>(),
+                Ks.const_data_ptr<scalar_t>(),
+                image_width,
+                image_height,
+                eps2d,
+                near_plane,
+                far_plane,
+                radius_clip,
+                camera_model,
+                radii.data_ptr<int32_t>(),
+                means2d.data_ptr<scalar_t>(),
+                depths.data_ptr<scalar_t>(),
+                conics.data_ptr<scalar_t>(),
+                compensations.has_value() ? compensations.value().data_ptr<scalar_t>() : nullptr
+            );
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     );
 }
 
+void launch_projection_ewa_3dgs_fused_fwd_kernels(
+    // inputs
+    const at::Tensor means,                   // [..., N, 3]
+    const at::optional<at::Tensor> covars,    // [..., N, 6] optional
+    const at::optional<at::Tensor> quats,     // [..., N, 4] optional
+    const at::optional<at::Tensor> scales,    // [..., N, 3] optional
+    const at::optional<at::Tensor> opacities, // [..., N] optional
+    const at::Tensor viewmats,                // [..., C, 4, 4]
+    const at::Tensor Ks,                      // [..., C, 3, 3]
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const float eps2d,
+    const float near_plane,
+    const float far_plane,
+    const float radius_clip,
+    const CameraModelType camera_model,
+    // outputs
+    at::Tensor radii,                      // [..., C, N, 2]
+    at::Tensor means2d,                    // [..., C, N, 2]
+    at::Tensor depths,                     // [..., C, N]
+    at::Tensor conics,                     // [..., C, N, 3]
+    at::optional<at::Tensor> compensations // [..., C, N] optional
+)
+{
+    uint32_t N = means.size(-2);
+    uint32_t C = viewmats.size(-3);
+    uint32_t B = means.numel() / (N * 3);
+
+    constexpr unsigned int threads = 256;
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t gaussian_offset, gaussian_count;
+        std::tie(gaussian_offset, gaussian_count) = chunk(N, device_id);
+        int64_t n_elements                        = static_cast<int64_t>(B) * C * gaussian_count;
+        unsigned int blocks                       = ::cuda::ceil_div(n_elements, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_FLOATING_TYPES(
+                means.scalar_type(),
+                "projection_ewa_3dgs_fused_fwd_kernel",
+                [&]()
+                {
+                    projection_ewa_3dgs_fused_fwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                        gaussian_offset,
+                        gaussian_count,
+                        B,
+                        C,
+                        N,
+                        means.const_data_ptr<scalar_t>(),
+                        covars.has_value() ? covars.value().const_data_ptr<scalar_t>() : nullptr,
+                        quats.has_value() ? quats.value().const_data_ptr<scalar_t>() : nullptr,
+                        scales.has_value() ? scales.value().const_data_ptr<scalar_t>() : nullptr,
+                        opacities.has_value() ? opacities.value().const_data_ptr<scalar_t>() : nullptr,
+                        viewmats.const_data_ptr<scalar_t>(),
+                        Ks.const_data_ptr<scalar_t>(),
+                        image_width,
+                        image_height,
+                        eps2d,
+                        near_plane,
+                        far_plane,
+                        radius_clip,
+                        camera_model,
+                        radii.data_ptr<int32_t>(),
+                        means2d.data_ptr<scalar_t>(),
+                        depths.data_ptr<scalar_t>(),
+                        conics.data_ptr<scalar_t>(),
+                        compensations.has_value() ? compensations.value().data_ptr<scalar_t>() : nullptr
+                    );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            );
+        }
+    }
+    merge_streams();
+}
+
 template<typename scalar_t>
 __global__ void projection_ewa_3dgs_fused_bwd_kernel(
+    const int64_t gaussian_offset,
+    const int64_t gaussian_count,
     // fwd inputs
     const uint32_t B,
     const uint32_t C,
@@ -320,26 +408,32 @@ __global__ void projection_ewa_3dgs_fused_bwd_kernel(
     scalar_t *__restrict__ v_viewmats // [B, C, 4, 4] optional
 )
 {
-    // parallelize over B * C * N.
-    uint32_t idx = cg::this_grid().thread_rank();
-    if(idx >= B * C * N || radii[idx * 2] <= 0 || radii[idx * 2 + 1] <= 0)
+    // parallelize over B * C * gaussian_count.
+    int64_t idx         = cg::this_grid().thread_rank();
+    const int64_t count = static_cast<int64_t>(B) * C * gaussian_count;
+    if(idx >= count)
     {
         return;
     }
-    const uint32_t bid = idx / (C * N); // batch id
-    const uint32_t cid = (idx / N) % C; // camera id
-    const uint32_t gid = idx % N;       // gaussian id
+    const uint32_t bid       = idx / (C * gaussian_count);             // batch id
+    const uint32_t cid       = (idx / gaussian_count) % C;             // camera id
+    const uint32_t gid       = idx % gaussian_count + gaussian_offset; // gaussian id
+    const int64_t global_idx = (static_cast<int64_t>(bid) * C + cid) * N + gid;
+    if(radii[global_idx * 2] <= 0 || radii[global_idx * 2 + 1] <= 0)
+    {
+        return;
+    }
 
     // shift pointers to the current camera and gaussian
     means    += bid * N * 3 + gid * 3;
     viewmats += bid * C * 16 + cid * 16;
     Ks       += bid * C * 9 + cid * 9;
 
-    conics += idx * 3;
+    conics += global_idx * 3;
 
-    v_means2d += idx * 2;
-    v_depths  += idx;
-    v_conics  += idx * 3;
+    v_means2d += global_idx * 2;
+    v_depths  += global_idx;
+    v_conics  += global_idx * 3;
 
     // vjp: compute the inverse of the 2d covariance
     mat2 covar2d_inv   = mat2(conics[0], conics[1], conics[1], conics[2]);
@@ -350,8 +444,8 @@ __global__ void projection_ewa_3dgs_fused_bwd_kernel(
     if(v_compensations != nullptr)
     {
         // vjp: compensation term
-        const float compensation   = compensations[idx];
-        const float v_compensation = v_compensations[idx];
+        const float compensation   = compensations[global_idx];
+        const float v_compensation = v_compensations[global_idx];
         add_blur_vjp(eps2d, covar2d_inv, compensation, v_compensation, v_covar2d);
     }
 
@@ -535,9 +629,9 @@ __global__ void projection_ewa_3dgs_fused_bwd_kernel(
 #    pragma unroll
                 for(uint32_t j = 0; j < 3; j++)
                 { // cols
-                    gpuAtomicAdd(v_viewmats + i * 4 + j, v_R[j][i]);
+                    atomicAdd_system(v_viewmats + i * 4 + j, v_R[j][i]);
                 }
-                gpuAtomicAdd(v_viewmats + i * 4 + 3, v_t[i]);
+                atomicAdd_system(v_viewmats + i * 4 + 3, v_t[i]);
             }
         }
     }
@@ -578,10 +672,9 @@ void launch_projection_ewa_3dgs_fused_bwd_kernel(
     uint32_t C = viewmats.size(-3);       // number of cameras
     uint32_t B = means.numel() / (N * 3); // number of batches
 
-    int64_t n_elements = B * C * N;
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    int64_t n_elements             = B * C * N;
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -589,41 +682,139 @@ void launch_projection_ewa_3dgs_fused_bwd_kernel(
         return;
     }
 
+    auto stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES(
         means.scalar_type(),
         "projection_ewa_3dgs_fused_bwd_kernel",
         [&]()
         {
-            projection_ewa_3dgs_fused_bwd_kernel<scalar_t>
-                <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                    B,
-                    C,
-                    N,
-                    means.const_data_ptr<scalar_t>(),
-                    covars.has_value() ? covars.value().const_data_ptr<scalar_t>() : nullptr,
-                    covars.has_value() ? nullptr : quats.value().const_data_ptr<scalar_t>(),
-                    covars.has_value() ? nullptr : scales.value().const_data_ptr<scalar_t>(),
-                    viewmats.const_data_ptr<scalar_t>(),
-                    Ks.const_data_ptr<scalar_t>(),
-                    image_width,
-                    image_height,
-                    eps2d,
-                    camera_model,
-                    radii.const_data_ptr<int32_t>(),
-                    conics.const_data_ptr<scalar_t>(),
-                    compensations.has_value() ? compensations.value().const_data_ptr<scalar_t>() : nullptr,
-                    v_means2d.const_data_ptr<scalar_t>(),
-                    v_depths.const_data_ptr<scalar_t>(),
-                    v_conics.const_data_ptr<scalar_t>(),
-                    v_compensations.has_value() ? v_compensations.value().const_data_ptr<scalar_t>() : nullptr,
-                    v_means.data_ptr<scalar_t>(),
-                    covars.has_value() ? v_covars.data_ptr<scalar_t>() : nullptr,
-                    covars.has_value() ? nullptr : v_quats.data_ptr<scalar_t>(),
-                    covars.has_value() ? nullptr : v_scales.data_ptr<scalar_t>(),
-                    viewmats_requires_grad ? v_viewmats.data_ptr<scalar_t>() : nullptr
-                );
+            projection_ewa_3dgs_fused_bwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                0,
+                N,
+                B,
+                C,
+                N,
+                means.const_data_ptr<scalar_t>(),
+                covars.has_value() ? covars.value().const_data_ptr<scalar_t>() : nullptr,
+                covars.has_value() ? nullptr : quats.value().const_data_ptr<scalar_t>(),
+                covars.has_value() ? nullptr : scales.value().const_data_ptr<scalar_t>(),
+                viewmats.const_data_ptr<scalar_t>(),
+                Ks.const_data_ptr<scalar_t>(),
+                image_width,
+                image_height,
+                eps2d,
+                camera_model,
+                radii.const_data_ptr<int32_t>(),
+                conics.const_data_ptr<scalar_t>(),
+                compensations.has_value() ? compensations.value().const_data_ptr<scalar_t>() : nullptr,
+                v_means2d.const_data_ptr<scalar_t>(),
+                v_depths.const_data_ptr<scalar_t>(),
+                v_conics.const_data_ptr<scalar_t>(),
+                v_compensations.has_value() ? v_compensations.value().const_data_ptr<scalar_t>() : nullptr,
+                v_means.data_ptr<scalar_t>(),
+                covars.has_value() ? v_covars.data_ptr<scalar_t>() : nullptr,
+                covars.has_value() ? nullptr : v_quats.data_ptr<scalar_t>(),
+                covars.has_value() ? nullptr : v_scales.data_ptr<scalar_t>(),
+                viewmats_requires_grad ? v_viewmats.data_ptr<scalar_t>() : nullptr
+            );
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     );
+}
+
+void launch_projection_ewa_3dgs_fused_bwd_kernels(
+    // inputs
+    // fwd inputs
+    const at::Tensor means,                // [..., N, 3]
+    const at::optional<at::Tensor> covars, // [..., N, 6] optional
+    const at::optional<at::Tensor> quats,  // [..., N, 4] optional
+    const at::optional<at::Tensor> scales, // [..., N, 3] optional
+    const at::Tensor viewmats,             // [..., C, 4, 4]
+    const at::Tensor Ks,                   // [..., C, 3, 3]
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const float eps2d,
+    const CameraModelType camera_model,
+    // fwd outputs
+    const at::Tensor radii,                       // [..., C, N, 2]
+    const at::Tensor conics,                      // [..., C, N, 3]
+    const at::optional<at::Tensor> compensations, // [..., C, N] optional
+    // grad outputs
+    const at::Tensor v_means2d,                     // [..., C, N, 2]
+    const at::Tensor v_depths,                      // [..., C, N]
+    const at::Tensor v_conics,                      // [..., C, N, 3]
+    const at::optional<at::Tensor> v_compensations, // [..., C, N] optional
+    const bool viewmats_requires_grad,
+    // outputs
+    at::Tensor v_means,   // [..., N, 3]
+    at::Tensor v_covars,  // [..., N, 3, 3]
+    at::Tensor v_quats,   // [..., N, 4]
+    at::Tensor v_scales,  // [..., N, 3]
+    at::Tensor v_viewmats // [..., C, 4, 4]
+)
+{
+    uint32_t N = means.size(-2);
+    uint32_t C = viewmats.size(-3);
+    uint32_t B = means.numel() / (N * 3);
+
+    constexpr unsigned int threads = 256;
+
+    if(B == 0 || C == 0 || N == 0)
+    {
+        return;
+    }
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t gaussian_offset, gaussian_count;
+        std::tie(gaussian_offset, gaussian_count) = chunk(N, device_id);
+        int64_t n_elements                        = static_cast<int64_t>(B) * C * gaussian_count;
+        unsigned int blocks                       = ::cuda::ceil_div(n_elements, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_FLOATING_TYPES(
+                means.scalar_type(),
+                "projection_ewa_3dgs_fused_bwd_kernel",
+                [&]()
+                {
+                    projection_ewa_3dgs_fused_bwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                        gaussian_offset,
+                        gaussian_count,
+                        B,
+                        C,
+                        N,
+                        means.const_data_ptr<scalar_t>(),
+                        covars.has_value() ? covars.value().const_data_ptr<scalar_t>() : nullptr,
+                        covars.has_value() ? nullptr : quats.value().const_data_ptr<scalar_t>(),
+                        covars.has_value() ? nullptr : scales.value().const_data_ptr<scalar_t>(),
+                        viewmats.const_data_ptr<scalar_t>(),
+                        Ks.const_data_ptr<scalar_t>(),
+                        image_width,
+                        image_height,
+                        eps2d,
+                        camera_model,
+                        radii.const_data_ptr<int32_t>(),
+                        conics.const_data_ptr<scalar_t>(),
+                        compensations.has_value() ? compensations.value().const_data_ptr<scalar_t>() : nullptr,
+                        v_means2d.const_data_ptr<scalar_t>(),
+                        v_depths.const_data_ptr<scalar_t>(),
+                        v_conics.const_data_ptr<scalar_t>(),
+                        v_compensations.has_value() ? v_compensations.value().const_data_ptr<scalar_t>() : nullptr,
+                        v_means.data_ptr<scalar_t>(),
+                        covars.has_value() ? v_covars.data_ptr<scalar_t>() : nullptr,
+                        covars.has_value() ? nullptr : v_quats.data_ptr<scalar_t>(),
+                        covars.has_value() ? nullptr : v_scales.data_ptr<scalar_t>(),
+                        viewmats_requires_grad ? v_viewmats.data_ptr<scalar_t>() : nullptr
+                    );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            );
+        }
+    }
+    merge_streams();
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
+++ b/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
@@ -40,36 +40,40 @@ namespace gsplat
 {
 namespace cg = cooperative_groups;
 
+// Cap registers to 64 (>= 4 blocks/SM) only for paths where measurement shows it
+// wins. The default min-blocks policy is 1, which keeps camera codegen close to
+// baseline without needing a separate kernel wrapper.
 template<typename SensorModel, typename scalar_t>
-__global__ void projection_ut_3dgs_fused_kernel(
-    const uint32_t B,
-    const uint32_t C,
-    const uint32_t N,
-    const scalar_t *__restrict__ means,     // [B, N, 3]
-    const scalar_t *__restrict__ quats,     // [B, N, 4]
-    const scalar_t *__restrict__ scales,    // [B, N, 3]
-    const scalar_t *__restrict__ opacities, // [B, N] optional
-    const scalar_t *__restrict__ viewmats0, // [B, C, 4, 4]
-    const scalar_t *__restrict__ viewmats1, // [B, C, 4, 4] optional for rolling shutter
-    // Image width and height are redundant, they are in the sensor model parameters
-    const uint32_t image_width,
-    const uint32_t image_height,
-    const float eps2d,
-    const float near_plane,
-    const float far_plane,
-    const float radius_clip,
-    const bool global_z_order,
-    // uncented transform
-    const UnscentedTransformParameters ut_params,
-    // sensor model parameters
-    const __grid_constant__ typename SensorModel::KernelParameters sensor_model_params,
-    // outputs
-    int32_t *__restrict__ radii,         // [B, C, N, 2]
-    scalar_t *__restrict__ means2d,      // [B, C, N, 2]
-    scalar_t *__restrict__ depths,       // [B, C, N]
-    scalar_t *__restrict__ conics,       // [B, C, N, 3]
-    scalar_t *__restrict__ compensations // [B, C, N] optional
-)
+__global__ void
+    __launch_bounds__(256, ProjectionUTCodegenTraits<SensorModel>::kMinBlocks) projection_ut_3dgs_fused_kernel(
+        const uint32_t B,
+        const uint32_t C,
+        const uint32_t N,
+        const scalar_t *__restrict__ means,     // [B, N, 3]
+        const scalar_t *__restrict__ quats,     // [B, N, 4]
+        const scalar_t *__restrict__ scales,    // [B, N, 3]
+        const scalar_t *__restrict__ opacities, // [B, N] optional
+        const scalar_t *__restrict__ viewmats0, // [B, C, 4, 4]
+        const scalar_t *__restrict__ viewmats1, // [B, C, 4, 4] optional for rolling shutter
+        // Image width and height are redundant, they are in the sensor model parameters
+        const uint32_t image_width,
+        const uint32_t image_height,
+        const float eps2d,
+        const float near_plane,
+        const float far_plane,
+        const float radius_clip,
+        const bool global_z_order,
+        // uncented transform
+        const UnscentedTransformParameters ut_params,
+        // sensor model parameters
+        const __grid_constant__ typename SensorModel::KernelParameters sensor_model_params,
+        // outputs
+        int32_t *__restrict__ radii,         // [B, C, N, 2]
+        scalar_t *__restrict__ means2d,      // [B, C, N, 2]
+        scalar_t *__restrict__ depths,       // [B, C, N]
+        scalar_t *__restrict__ conics,       // [B, C, N, 3]
+        scalar_t *__restrict__ compensations // [B, C, N] optional
+    )
 {
     // parallelize over B * C * N.
     uint32_t idx = cg::this_grid().thread_rank();
@@ -212,7 +216,7 @@ __global__ void projection_ut_3dgs_fused_kernel(
         return;
     }
 
-    if constexpr(is_lidar<SensorModel>::value)
+    if constexpr(!ProjectionUTCodegenTraits<SensorModel>::kNeedsCulling)
     {
         // LIDAR culling is performed inside world_gaussian_to_image_gaussian_unscented_transform_shutter_pose,
         // so no additional 2D image-region masking is needed here.

--- a/gsplat/cuda/csrc/QuatScaleToCovar.cpp
+++ b/gsplat/cuda/csrc/QuatScaleToCovar.cpp
@@ -161,6 +161,52 @@ QuatScaleToCovarPreciFwdResult quat_scale_to_covar_preci_fwd(
     };
 }
 
+std::tuple<at::optional<at::Tensor>, at::optional<at::Tensor>> quat_scale_to_covar_preci_fwd_privateuseone(
+    const at::Tensor &quats,  // [..., 4]
+    const at::Tensor &scales, // [..., 3]
+    bool compute_covar,
+    bool compute_preci,
+    bool triu
+)
+{
+    DEVICE_GUARD(quats);
+    check_quat_scale_to_covar_preci_inputs(quats, scales);
+
+    auto opt = quats.options();
+    at::DimVector out_shape(quats.sizes().slice(0, quats.dim() - 1));
+    if(triu)
+    {
+        out_shape.append({6});
+    }
+    else
+    {
+        out_shape.append({3, 3});
+    }
+
+    at::Tensor covars, precis;
+    if(compute_covar)
+    {
+        covars = at::empty(out_shape, opt);
+    }
+    if(compute_preci)
+    {
+        precis = at::empty(out_shape, opt);
+    }
+
+    launch_quat_scale_to_covar_preci_fwd_kernels(
+        quats,
+        scales,
+        triu,
+        compute_covar ? at::optional<at::Tensor>(covars) : at::nullopt,
+        compute_preci ? at::optional<at::Tensor>(precis) : at::nullopt
+    );
+
+    return std::make_tuple(
+        compute_covar ? at::optional<at::Tensor>(covars) : at::nullopt,
+        compute_preci ? at::optional<at::Tensor>(precis) : at::nullopt
+    );
+}
+
 QuatScaleToCovarPreciBwdResult quat_scale_to_covar_preci_bwd(
     const at::Tensor &quats,  // [..., 4]
     const at::Tensor &scales, // [..., 3]
@@ -204,10 +250,52 @@ QuatScaleToCovarPreciBwdResult quat_scale_to_covar_preci_bwd(
     };
 }
 
+std::tuple<at::Tensor, at::Tensor> quat_scale_to_covar_preci_bwd_privateuseone(
+    const at::Tensor &quats,  // [..., 4]
+    const at::Tensor &scales, // [..., 3]
+    bool triu,
+    const at::optional<at::Tensor> &v_covars, // [..., 3, 3] or [..., 6]
+    const at::optional<at::Tensor> &v_precis  // [..., 3, 3] or [..., 6]
+)
+{
+    DEVICE_GUARD(quats);
+    CHECK_INPUT(quats);
+    CHECK_INPUT(scales);
+    if(v_covars.has_value())
+    {
+        CHECK_INPUT(v_covars.value());
+    }
+    if(v_precis.has_value())
+    {
+        CHECK_INPUT(v_precis.value());
+    }
+
+    at::Tensor v_scales = at::empty_like(scales);
+    at::Tensor v_quats  = at::empty_like(quats);
+
+    if(v_covars.has_value() || v_precis.has_value())
+    {
+        launch_quat_scale_to_covar_preci_bwd_kernels(quats, scales, triu, v_covars, v_precis, v_quats, v_scales);
+    }
+    else
+    {
+        v_scales.zero_();
+        v_quats.zero_();
+    }
+
+    return std::make_tuple(v_quats, v_scales);
+}
+
 void register_quat_scale_to_covar_cuda_impl(torch::Library &m)
 {
     m.impl("quat_scale_to_covar_preci", to_torch_op<&quat_scale_to_covar_preci_fwd>);
     m.impl("quat_scale_to_covar_preci_bwd", to_torch_op<&quat_scale_to_covar_preci_bwd>);
+}
+
+void register_quat_scale_to_covar_privateuseone_impl(torch::Library &m)
+{
+    m.impl("quat_scale_to_covar_preci", to_torch_op<&quat_scale_to_covar_preci_fwd_privateuseone>);
+    m.impl("quat_scale_to_covar_preci_bwd", to_torch_op<&quat_scale_to_covar_preci_bwd_privateuseone>);
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/QuatScaleToCovar.h
+++ b/gsplat/cuda/csrc/QuatScaleToCovar.h
@@ -36,7 +36,29 @@ void launch_quat_scale_to_covar_preci_fwd_kernel(
     at::optional<at::Tensor> precis  // [..., 3, 3] or [..., 6]
 );
 
+void launch_quat_scale_to_covar_preci_fwd_kernels(
+    // inputs
+    const at::Tensor quats,  // [..., 4]
+    const at::Tensor scales, // [..., 3]
+    const bool triu,
+    // outputs
+    at::optional<at::Tensor> covars, // [..., 3, 3] or [..., 6]
+    at::optional<at::Tensor> precis  // [..., 3, 3] or [..., 6]
+);
+
 void launch_quat_scale_to_covar_preci_bwd_kernel(
+    // inputs
+    const at::Tensor quats,  // [..., 4]
+    const at::Tensor scales, // [..., 3]
+    const bool triu,
+    const at::optional<at::Tensor> v_covars, // [..., 3, 3] or [..., 6]
+    const at::optional<at::Tensor> v_precis, // [..., 3, 3] or [..., 6]
+    // outputs
+    at::Tensor v_quats, // [..., 4]
+    at::Tensor v_scales // [..., 3]
+);
+
+void launch_quat_scale_to_covar_preci_bwd_kernels(
     // inputs
     const at::Tensor quats,  // [..., 4]
     const at::Tensor scales, // [..., 3]

--- a/gsplat/cuda/csrc/QuatScaleToCovarCUDA.cu
+++ b/gsplat/cuda/csrc/QuatScaleToCovarCUDA.cu
@@ -35,6 +35,7 @@ namespace cg = cooperative_groups;
 
 template<typename scalar_t>
 __global__ void quat_scale_to_covar_preci_fwd_kernel(
+    const uint32_t offset,
     const uint32_t N,
     const scalar_t *__restrict__ quats,  // [N, 4]
     const scalar_t *__restrict__ scales, // [N, 3]
@@ -50,6 +51,7 @@ __global__ void quat_scale_to_covar_preci_fwd_kernel(
     {
         return;
     }
+    idx += offset;
 
     // shift pointers to the current gaussian
     quats  += idx * 4;
@@ -129,10 +131,9 @@ void launch_quat_scale_to_covar_preci_fwd_kernel(
 
     uint32_t N = quats.numel() / 4;
 
-    int64_t n_elements = N;
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    int64_t n_elements             = N;
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -140,26 +141,75 @@ void launch_quat_scale_to_covar_preci_fwd_kernel(
         return;
     }
 
+    auto stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES(
         quats.scalar_type(),
         "quat_scale_to_covar_preci_fwd_kernel",
         [&]()
         {
-            quat_scale_to_covar_preci_fwd_kernel<scalar_t>
-                <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                    N,
-                    quats.const_data_ptr<scalar_t>(),
-                    scales.const_data_ptr<scalar_t>(),
-                    triu,
-                    covars.has_value() ? covars.value().data_ptr<scalar_t>() : nullptr,
-                    precis.has_value() ? precis.value().data_ptr<scalar_t>() : nullptr
-                );
+            quat_scale_to_covar_preci_fwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                0,
+                N,
+                quats.const_data_ptr<scalar_t>(),
+                scales.const_data_ptr<scalar_t>(),
+                triu,
+                covars.has_value() ? covars.value().data_ptr<scalar_t>() : nullptr,
+                precis.has_value() ? precis.value().data_ptr<scalar_t>() : nullptr
+            );
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     );
 }
 
+void launch_quat_scale_to_covar_preci_fwd_kernels(
+    // inputs
+    const at::Tensor quats,  // [..., 4]
+    const at::Tensor scales, // [..., 3]
+    const bool triu,
+    // outputs
+    at::optional<at::Tensor> covars, // [..., 3, 3] or [..., 6]
+    at::optional<at::Tensor> precis  // [..., 3, 3] or [..., 6]
+)
+{
+    uint32_t n_elements            = quats.numel() / 4;
+    constexpr unsigned int threads = 256;
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t offset, count;
+        std::tie(offset, count) = chunk(n_elements, device_id);
+        unsigned int blocks     = ::cuda::ceil_div(count, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_FLOATING_TYPES(
+                quats.scalar_type(),
+                "quat_scale_to_covar_preci_fwd_kernel",
+                [&]()
+                {
+                    quat_scale_to_covar_preci_fwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                        offset,
+                        count,
+                        quats.const_data_ptr<scalar_t>(),
+                        scales.const_data_ptr<scalar_t>(),
+                        triu,
+                        covars.has_value() ? covars.value().data_ptr<scalar_t>() : nullptr,
+                        precis.has_value() ? precis.value().data_ptr<scalar_t>() : nullptr
+                    );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            );
+        }
+    }
+
+    merge_streams();
+}
+
 template<typename scalar_t>
 __global__ void quat_scale_to_covar_preci_bwd_kernel(
+    const uint32_t offset,
     const uint32_t N,
     // fwd inputs
     const scalar_t *__restrict__ quats,  // [N, 4]
@@ -179,6 +229,7 @@ __global__ void quat_scale_to_covar_preci_bwd_kernel(
     {
         return;
     }
+    idx += offset;
 
     // shift pointers to the current gaussian
     v_scales += idx * 3;
@@ -272,10 +323,9 @@ void launch_quat_scale_to_covar_preci_bwd_kernel(
 {
     uint32_t N = quats.numel() / 4;
 
-    int64_t n_elements = N;
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    int64_t n_elements             = N;
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -288,24 +338,81 @@ void launch_quat_scale_to_covar_preci_bwd_kernel(
         return;
     }
 
+    auto stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES(
         quats.scalar_type(),
         "quat_scale_to_covar_preci_bwd_kernel",
         [&]()
         {
-            quat_scale_to_covar_preci_bwd_kernel<scalar_t>
-                <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                    N,
-                    quats.const_data_ptr<scalar_t>(),
-                    scales.const_data_ptr<scalar_t>(),
-                    triu,
-                    v_covars.has_value() ? v_covars.value().const_data_ptr<scalar_t>() : nullptr,
-                    v_precis.has_value() ? v_precis.value().const_data_ptr<scalar_t>() : nullptr,
-                    v_quats.data_ptr<scalar_t>(),
-                    v_scales.data_ptr<scalar_t>()
-                );
+            quat_scale_to_covar_preci_bwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                0,
+                N,
+                quats.const_data_ptr<scalar_t>(),
+                scales.const_data_ptr<scalar_t>(),
+                triu,
+                v_covars.has_value() ? v_covars.value().const_data_ptr<scalar_t>() : nullptr,
+                v_precis.has_value() ? v_precis.value().const_data_ptr<scalar_t>() : nullptr,
+                v_quats.data_ptr<scalar_t>(),
+                v_scales.data_ptr<scalar_t>()
+            );
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
     );
+}
+
+void launch_quat_scale_to_covar_preci_bwd_kernels(
+    // inputs
+    const at::Tensor quats,  // [..., 4]
+    const at::Tensor scales, // [..., 3]
+    const bool triu,
+    const at::optional<at::Tensor> v_covars, // [..., 3, 3] or [..., 6]
+    const at::optional<at::Tensor> v_precis, // [..., 3, 3] or [..., 6]
+    // outputs
+    at::Tensor v_quats, // [..., 4]
+    at::Tensor v_scales // [..., 3]
+)
+{
+    uint32_t n_elements            = quats.numel() / 4;
+    constexpr unsigned int threads = 256;
+
+    if(!v_covars.has_value() && !v_precis.has_value())
+    {
+        return;
+    }
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t offset, count;
+        std::tie(offset, count) = chunk(n_elements, device_id);
+        unsigned int blocks     = ::cuda::ceil_div(count, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_FLOATING_TYPES(
+                quats.scalar_type(),
+                "quat_scale_to_covar_preci_bwd_kernel",
+                [&]()
+                {
+                    quat_scale_to_covar_preci_bwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                        offset,
+                        count,
+                        quats.const_data_ptr<scalar_t>(),
+                        scales.const_data_ptr<scalar_t>(),
+                        triu,
+                        v_covars.has_value() ? v_covars.value().const_data_ptr<scalar_t>() : nullptr,
+                        v_precis.has_value() ? v_precis.value().const_data_ptr<scalar_t>() : nullptr,
+                        v_quats.data_ptr<scalar_t>(),
+                        v_scales.data_ptr<scalar_t>()
+                    );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            );
+        }
+    }
+
+    merge_streams();
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -351,6 +351,93 @@ RasterizeToPixels3DGSFwdResult rasterize_to_pixels_3dgs_fwd(
     };
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> rasterize_to_pixels_3dgs_fwd_privateuseone(
+    // Gaussian parameters
+    const at::Tensor &means2d,                   // [..., N, 2] or [nnz, 2]
+    const at::Tensor &conics,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor &colors,                    // [..., N, channels] or [nnz, channels]
+    const at::Tensor &opacities,                 // [..., N]  or [nnz]
+    const at::optional<at::Tensor> &backgrounds, // [..., channels]
+    const at::optional<at::Tensor> &masks,       // [..., tile_height, tile_width]
+    // image size
+    int64_t image_width,
+    int64_t image_height,
+    int64_t tile_size,
+    // intersections
+    const at::Tensor &isect_offsets, // [..., tile_height, tile_width]
+    const at::Tensor &flatten_ids,   // [n_isects]
+    bool packed,
+    bool absgrad
+)
+{
+    check_rasterize_to_pixels_3dgs_inputs(
+        means2d,
+        conics,
+        colors,
+        opacities,
+        backgrounds,
+        masks,
+        image_width,
+        image_height,
+        tile_size,
+        isect_offsets,
+        packed
+    );
+
+    DEVICE_GUARD(means2d);
+    CHECK_INPUT(means2d);
+    CHECK_INPUT(conics);
+    CHECK_INPUT(colors);
+    CHECK_INPUT(opacities);
+    CHECK_INPUT(isect_offsets);
+    CHECK_INPUT(flatten_ids);
+    if(backgrounds.has_value())
+    {
+        CHECK_INPUT(backgrounds.value());
+    }
+    if(masks.has_value())
+    {
+        CHECK_INPUT(masks.value());
+    }
+
+    auto opt = means2d.options();
+    at::DimVector image_dims(isect_offsets.sizes().slice(0, isect_offsets.dim() - 2));
+    uint32_t channels = colors.size(-1);
+
+    at::DimVector renders_dims(image_dims);
+    renders_dims.append({image_height, image_width, channels});
+    at::Tensor renders = at::empty(renders_dims, opt);
+
+    at::DimVector alphas_dims(image_dims);
+    alphas_dims.append({image_height, image_width, 1});
+    at::Tensor alphas = at::empty(alphas_dims, opt);
+
+    at::DimVector last_ids_dims(image_dims);
+    last_ids_dims.append({image_height, image_width});
+    at::Tensor last_ids = at::empty(last_ids_dims, opt.dtype(at::kInt));
+
+    launch_rasterize_to_pixels_3dgs_fwd_kernels(
+        means2d,
+        conics,
+        colors,
+        opacities,
+        backgrounds,
+        masks,
+        image_width,
+        image_height,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+        renders,
+        alphas,
+        last_ids
+    );
+
+    at::Tensor absgrad_holder = absgrad ? at::zeros_like(means2d) : at::empty({0}, means2d.options());
+
+    return std::make_tuple(renders, alphas.to(at::kFloat), absgrad_holder, last_ids);
+}
+
 // Gradients of the differentiable forward outputs.
 struct RasterizeToPixels3DGSGrad
 {
@@ -745,6 +832,98 @@ RasterizeToPixels3DGSBwdResult rasterize_to_pixels_sparse_bwd(
         .v_opacities   = v_opacities,
         .v_backgrounds = as_optional_tensor(v_backgrounds),
     };
+}
+
+std::tuple<at::optional<at::Tensor>, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::optional<at::Tensor>>
+    rasterize_to_pixels_3dgs_bwd_privateuseone(
+        // Gaussian parameters
+        const at::Tensor &means2d,                   // [..., N, 2] or [nnz, 2]
+        const at::Tensor &conics,                    // [..., N, 3] or [nnz, 3]
+        const at::Tensor &colors,                    // [..., N, channels] or [nnz, channels]
+        const at::Tensor &opacities,                 // [..., N] or [nnz]
+        const at::optional<at::Tensor> &backgrounds, // [..., channels]
+        const at::optional<at::Tensor> &masks,       // [..., tile_height, tile_width]
+        // intersections
+        const at::Tensor &tile_offsets, // [..., tile_height, tile_width]
+        const at::Tensor &flatten_ids,  // [n_isects]
+        // forward outputs
+        const at::Tensor &render_alphas, // [..., image_height, image_width, 1]
+        const at::Tensor &last_ids,      // [..., image_height, image_width]
+        // scalars
+        int64_t image_width,
+        int64_t image_height,
+        int64_t tile_size,
+        bool absgrad,
+        // gradients of outputs
+        const at::Tensor &v_render_colors, // [..., image_height, image_width, channels]
+        const at::Tensor &v_render_alphas, // [..., image_height, image_width, 1]
+        bool compute_v_backgrounds
+    )
+{
+    DEVICE_GUARD(means2d);
+    CHECK_INPUT(means2d);
+    CHECK_INPUT(conics);
+    CHECK_INPUT(colors);
+    CHECK_INPUT(opacities);
+    CHECK_INPUT(tile_offsets);
+    CHECK_INPUT(flatten_ids);
+    CHECK_INPUT(render_alphas);
+    CHECK_INPUT(last_ids);
+    CHECK_INPUT(v_render_colors);
+    CHECK_INPUT(v_render_alphas);
+    if(backgrounds.has_value())
+    {
+        CHECK_INPUT(backgrounds.value());
+    }
+    if(masks.has_value())
+    {
+        CHECK_INPUT(masks.value());
+    }
+
+    at::Tensor v_means2d   = at::zeros_like(means2d);
+    at::Tensor v_conics    = at::zeros_like(conics);
+    at::Tensor v_colors    = at::zeros_like(colors);
+    at::Tensor v_opacities = at::zeros_like(opacities);
+    at::Tensor v_means2d_abs;
+    if(absgrad)
+    {
+        v_means2d_abs = at::zeros_like(means2d);
+    }
+
+    launch_rasterize_to_pixels_3dgs_bwd_kernels(
+        means2d,
+        conics,
+        colors,
+        opacities,
+        backgrounds,
+        masks,
+        image_width,
+        image_height,
+        tile_size,
+        tile_offsets,
+        flatten_ids,
+        render_alphas,
+        last_ids,
+        v_render_colors,
+        v_render_alphas,
+        absgrad ? c10::optional<at::Tensor>(v_means2d_abs) : c10::nullopt,
+        v_means2d,
+        v_conics,
+        v_colors,
+        v_opacities
+    );
+
+    at::Tensor v_backgrounds;
+    if(compute_v_backgrounds)
+    {
+        const at::Tensor one_minus_alpha
+            = at::sub(at::ones_like(render_alphas).to(at::kFloat), render_alphas.to(at::kFloat));
+        v_backgrounds = at::mul(v_render_colors, one_minus_alpha).sum({-3, -2});
+    }
+
+    return std::make_tuple(
+        as_optional_tensor(v_means2d_abs), v_means2d, v_conics, v_colors, v_opacities, as_optional_tensor(v_backgrounds)
+    );
 }
 
 RasterizeToIndices3DGSResult rasterize_to_indices_3dgs(
@@ -3404,6 +3583,14 @@ void register_rasterization_cuda_impl(torch::Library &m)
 #endif
 
     m.impl("rasterize_to_pixels_from_world_3dgs", to_torch_op<&rasterize_to_pixels_from_world_3dgs>);
+}
+
+void register_rasterization_privateuseone_impl(torch::Library &m)
+{
+#if GSPLAT_BUILD_3DGS
+    m.impl("rasterize_to_pixels_3dgs", to_torch_op<&rasterize_to_pixels_3dgs_fwd_privateuseone>);
+    m.impl("rasterize_to_pixels_3dgs_bwd", to_torch_op<&rasterize_to_pixels_3dgs_bwd_privateuseone>);
+#endif
 }
 
 void register_rasterization_autograd_cuda_impl(torch::Library &m)

--- a/gsplat/cuda/csrc/Rasterization.h
+++ b/gsplat/cuda/csrc/Rasterization.h
@@ -120,7 +120,57 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
     at::Tensor last_ids // [..., image_height, image_width]
 );
 
+void launch_rasterize_to_pixels_3dgs_fwd_kernels(
+    // Gaussian parameters
+    const at::Tensor means2d,                   // [..., N, 2] or [nnz, 2]
+    const at::Tensor conics,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor colors,                    // [..., N, channels] or [nnz, channels]
+    const at::Tensor opacities,                 // [..., N]  or [nnz]
+    const at::optional<at::Tensor> backgrounds, // [..., channels]
+    const at::optional<at::Tensor> masks,       // [..., tile_height, tile_width]
+    // image size
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    // intersections
+    const at::Tensor isect_offsets, // [..., tile_height, tile_width]
+    const at::Tensor flatten_ids,   // [n_isects]
+    // outputs
+    at::Tensor renders, // [..., image_height, image_width, channels]
+    at::Tensor alphas,  // [..., image_height, image_width]
+    at::Tensor last_ids // [..., image_height, image_width]
+);
+
 void launch_rasterize_to_pixels_3dgs_bwd_kernel(
+    // Gaussian parameters
+    const at::Tensor means2d,                   // [..., N, 2] or [nnz, 2]
+    const at::Tensor conics,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor colors,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor opacities,                 // [..., N] or [nnz]
+    const at::optional<at::Tensor> backgrounds, // [..., 3]
+    const at::optional<at::Tensor> masks,       // [..., tile_height, tile_width]
+    // image size
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    // intersections
+    const at::Tensor tile_offsets, // [..., tile_height, tile_width]
+    const at::Tensor flatten_ids,  // [n_isects]
+    // forward outputs
+    const at::Tensor render_alphas, // [..., image_height, image_width, 1]
+    const at::Tensor last_ids,      // [..., image_height, image_width]
+    // gradients of outputs
+    const at::Tensor v_render_colors, // [..., image_height, image_width, 3]
+    const at::Tensor v_render_alphas, // [..., image_height, image_width, 1]
+    // outputs
+    at::optional<at::Tensor> v_means2d_abs, // [..., N, 2] or [nnz, 2]
+    at::Tensor v_means2d,                   // [..., N, 2] or [nnz, 2]
+    at::Tensor v_conics,                    // [..., N, 3] or [nnz, 3]
+    at::Tensor v_colors,                    // [..., N, 3] or [nnz, 3]
+    at::Tensor v_opacities                  // [..., N] or [nnz]
+);
+
+void launch_rasterize_to_pixels_3dgs_bwd_kernels(
     // Gaussian parameters
     const at::Tensor means2d,                   // [..., N, 2] or [nnz, 2]
     const at::Tensor conics,                    // [..., N, 3] or [nnz, 3]

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
@@ -55,6 +55,7 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
+    const uint32_t block_offset,
     const int32_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     // fwd outputs
@@ -72,11 +73,18 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     scalar_t *__restrict__ v_opacities // [..., N] or [nnz]
 )
 {
-    auto block        = cg::this_thread_block();
-    uint32_t image_id = block.group_index().x;
-    uint32_t tile_id  = block.group_index().y * tile_width + block.group_index().z;
-    uint32_t i        = block.group_index().y * tile_size + block.thread_index().y;
-    uint32_t j        = block.group_index().z * tile_size + block.thread_index().x;
+    auto block              = cg::this_thread_block();
+    auto linear_block_index = block.group_index().x + block_offset;
+    dim3 block_index(
+        linear_block_index / (tile_width * tile_height),
+        (linear_block_index / tile_width) % tile_height,
+        linear_block_index % tile_width
+    );
+
+    uint32_t image_id = block_index.x;
+    uint32_t tile_id  = block_index.y * tile_width + block_index.z;
+    uint32_t i        = block_index.y * tile_size + block.thread_index().y;
+    uint32_t j        = block_index.z * tile_size + block.thread_index().x;
 
     tile_offsets    += image_id * tile_height * tile_width;
     render_alphas   += image_id * image_height * image_width;
@@ -286,26 +294,26 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
 #    pragma unroll
                 for(uint32_t k = 0; k < CDIM; ++k)
                 {
-                    gpuAtomicAdd(v_rgb_ptr + k, v_rgb_local[k]);
+                    atomicAdd_system(v_rgb_ptr + k, v_rgb_local[k]);
                 }
 
                 float *v_conic_ptr = (float *)(v_conics) + 3 * g;
-                gpuAtomicAdd(v_conic_ptr, v_conic_local.x);
-                gpuAtomicAdd(v_conic_ptr + 1, v_conic_local.y);
-                gpuAtomicAdd(v_conic_ptr + 2, v_conic_local.z);
+                atomicAdd_system(v_conic_ptr, v_conic_local.x);
+                atomicAdd_system(v_conic_ptr + 1, v_conic_local.y);
+                atomicAdd_system(v_conic_ptr + 2, v_conic_local.z);
 
                 float *v_xy_ptr = (float *)(v_means2d) + 2 * g;
-                gpuAtomicAdd(v_xy_ptr, v_xy_local.x);
-                gpuAtomicAdd(v_xy_ptr + 1, v_xy_local.y);
+                atomicAdd_system(v_xy_ptr, v_xy_local.x);
+                atomicAdd_system(v_xy_ptr + 1, v_xy_local.y);
 
                 if(v_means2d_abs != nullptr)
                 {
                     float *v_xy_abs_ptr = (float *)(v_means2d_abs) + 2 * g;
-                    gpuAtomicAdd(v_xy_abs_ptr, v_xy_abs_local.x);
-                    gpuAtomicAdd(v_xy_abs_ptr + 1, v_xy_abs_local.y);
+                    atomicAdd_system(v_xy_abs_ptr, v_xy_abs_local.x);
+                    atomicAdd_system(v_xy_abs_ptr + 1, v_xy_abs_local.y);
                 }
 
-                gpuAtomicAdd(v_opacities + g, v_opacity_local);
+                atomicAdd_system(v_opacities + g, v_opacity_local);
             }
         }
     }
@@ -350,8 +358,9 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
 
     // Each block covers a tile on the image. In total there are
     // I * tile_height * tile_width blocks.
-    dim3 threads = {tile_size, tile_size, 1};
-    dim3 grid    = {I, tile_height, tile_width};
+    dim3 threads     = {tile_size, tile_size, 1};
+    uint32_t n_tiles = I * tile_height * tile_width;
+    dim3 grid        = {n_tiles, 1, 1};
 
     if(n_isects == 0)
     {
@@ -402,6 +411,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
                 tile_size,
                 tile_width,
                 tile_height,
+                0,
                 tile_offsets.const_data_ptr<int32_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 render_alphas.const_data_ptr<float>(),
@@ -414,9 +424,138 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
                 v_colors.data_ptr<float>(),
                 v_opacities.data_ptr<float>()
             );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
     };
     const bool dispatched = dispatch::dispatch(SupportedChannels{channels}, std::move(launch_kernel));
     TORCH_CHECK(dispatched, "dispatch failed: no matching compile-time instantiation for runtime parameters");
+}
+
+void launch_rasterize_to_pixels_3dgs_bwd_kernels(
+    // Gaussian parameters
+    const at::Tensor means2d,                   // [..., N, 2] or [nnz, 2]
+    const at::Tensor conics,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor colors,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor opacities,                 // [..., N] or [nnz]
+    const at::optional<at::Tensor> backgrounds, // [..., 3]
+    const at::optional<at::Tensor> masks,       // [..., tile_height, tile_width]
+    // image size
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    // intersections
+    const at::Tensor tile_offsets, // [..., tile_height, tile_width]
+    const at::Tensor flatten_ids,  // [n_isects]
+    // forward outputs
+    const at::Tensor render_alphas, // [..., image_height, image_width, 1]
+    const at::Tensor last_ids,      // [..., image_height, image_width]
+    // gradients of outputs
+    const at::Tensor v_render_colors, // [..., image_height, image_width, 3]
+    const at::Tensor v_render_alphas, // [..., image_height, image_width, 1]
+    // outputs
+    at::optional<at::Tensor> v_means2d_abs, // [..., N, 2] or [nnz, 2]
+    at::Tensor v_means2d,                   // [..., N, 2] or [nnz, 2]
+    at::Tensor v_conics,                    // [..., N, 3] or [nnz, 3]
+    at::Tensor v_colors,                    // [..., N, 3] or [nnz, 3]
+    at::Tensor v_opacities                  // [..., N] or [nnz]
+)
+{
+    bool packed = means2d.dim() == 2;
+
+    uint32_t N           = packed ? 0 : means2d.size(-2);
+    uint32_t I           = render_alphas.numel() / (image_height * image_width);
+    uint32_t tile_height = tile_offsets.size(-2);
+    uint32_t tile_width  = tile_offsets.size(-1);
+    uint32_t n_isects    = flatten_ids.size(0);
+    uint32_t n_tiles     = I * tile_height * tile_width;
+
+    dim3 threads = {tile_size, tile_size, 1};
+
+    if(n_isects == 0)
+    {
+        return;
+    }
+
+    const int32_t channels = colors.size(-1);
+    TORCH_CHECK_VALUE(
+        SupportedChannels::contains(channels),
+        "Unsupported number of color channels: ",
+        channels,
+        ". To add support, rebuild gsplat with this channel count included "
+        "in -DGSPLAT_NUM_CHANNELS=... (see gsplat/cuda/csrc/Config.h)."
+    );
+
+    auto launch_kernels = [&]<typename ChannelsT>()
+    {
+        constexpr uint32_t CDIM = ChannelsT::value;
+
+        int64_t shmem_size
+            = tile_size * tile_size * (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3) + sizeof(float) * CDIM);
+
+        for(const auto device_id: c10::irange(c10::cuda::device_count()))
+        {
+            C10_CUDA_CHECK(cudaSetDevice(device_id));
+            if(cudaFuncSetAttribute(
+                   rasterize_to_pixels_3dgs_bwd_kernel<CDIM, float>,
+                   cudaFuncAttributeMaxDynamicSharedMemorySize,
+                   shmem_size
+               )
+               != cudaSuccess)
+            {
+                AT_ERROR(
+                    "Failed to set maximum shared memory size (requested ",
+                    shmem_size,
+                    " bytes), try lowering tile_size."
+                );
+            }
+            auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+            int64_t block_offset, block_count;
+            std::tie(block_offset, block_count) = chunk(n_tiles, device_id);
+            if(block_count > 0)
+            {
+                dim3 grid = {static_cast<uint32_t>(block_count), 1, 1};
+                rasterize_to_pixels_3dgs_bwd_kernel<CDIM, float><<<grid, threads, shmem_size, stream>>>(
+                    I,
+                    N,
+                    n_isects,
+                    packed,
+                    reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
+                    reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
+                    colors.const_data_ptr<float>(),
+                    opacities.const_data_ptr<float>(),
+                    backgrounds.has_value() ? backgrounds.value().const_data_ptr<float>() : nullptr,
+                    masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr,
+                    image_width,
+                    image_height,
+                    tile_size,
+                    tile_width,
+                    tile_height,
+                    block_offset,
+                    tile_offsets.const_data_ptr<int32_t>(),
+                    flatten_ids.const_data_ptr<int32_t>(),
+                    render_alphas.const_data_ptr<float>(),
+                    last_ids.const_data_ptr<int32_t>(),
+                    v_render_colors.const_data_ptr<float>(),
+                    v_render_alphas.const_data_ptr<float>(),
+                    v_means2d_abs.has_value() ? reinterpret_cast<vec2 *>(v_means2d_abs.value().data_ptr<float>())
+                                              : nullptr,
+                    reinterpret_cast<vec2 *>(v_means2d.data_ptr<float>()),
+                    reinterpret_cast<vec3 *>(v_conics.data_ptr<float>()),
+                    v_colors.data_ptr<float>(),
+                    v_opacities.data_ptr<float>()
+                );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }
+        }
+    };
+    const bool dispatched = dispatch::dispatch(SupportedChannels{channels}, std::move(launch_kernels));
+    TORCH_CHECK(
+        dispatched,
+        "dispatch failed: no matching compile-time instantiation for runtime "
+        "parameters"
+    );
+
+    merge_streams();
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
@@ -25,8 +25,9 @@
 #    include <c10/cuda/CUDAStream.h>
 
 #    include "Common.h"
-#    include "Rasterization.h"
 #    include "Dispatch.h"
+#    include "Rasterization.h"
+#    include "Utils.cuh"
 
 namespace gsplat
 {
@@ -49,6 +50,10 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     const bool *__restrict__ masks,        // [I, tile_height, tile_width]
     const uint32_t image_width,
     const uint32_t image_height,
+    const uint32_t I,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const uint32_t block_offset,
     const int32_t *__restrict__ isect_offsets, // [I, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,   // [n_isects]
     float *__restrict__ render_colors,         // [I, image_height, image_width, CDIM]
@@ -68,13 +73,16 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     );
     static_assert(PIXELS_PER_THREAD > 0, "PIXELS_PER_THREAD == 0 - CTA_SIZE must not exceed TILE_SIZE * TILE_SIZE");
 
-    const int32_t image_id     = blockIdx.x;
-    const uint32_t grid_width  = gridDim.z;
-    const uint32_t grid_height = gridDim.y;
+    const uint32_t linear_block_index = blockIdx.x + block_offset;
+    const uint32_t tiles_per_image    = tile_width * tile_height;
+    const int32_t image_id            = linear_block_index / tiles_per_image;
+    const uint32_t tile_linear        = linear_block_index % tiles_per_image;
+    const uint32_t grid_width         = tile_width;
+    const uint32_t grid_height        = tile_height;
 
-    const uint32_t tile_x = blockIdx.z;
-    const uint32_t tile_y = blockIdx.y;
-    const int32_t tile_id = blockIdx.y * grid_width + blockIdx.z;
+    const uint32_t tile_x = tile_linear % grid_width;
+    const uint32_t tile_y = tile_linear / grid_width;
+    const int32_t tile_id = tile_y * grid_width + tile_x;
 
     const uint32_t tid      = threadIdx.x;
     const uint32_t thread_x = tid & TILE_MASK;   // X & 0xF(15) == X % 16
@@ -152,11 +160,10 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     // have all threads in tile process the same gaussians in batches
     // first collect gaussians between range.x and range.y in batches
     // which gaussians to look through in this tile
-    const int32_t range_start = isect_offsets[tile_id];
-    const int32_t range_end
-        = (image_id == (int32_t)gridDim.x - 1) && (tile_id == (int32_t)(grid_width * grid_height) - 1)
-            ? n_isects
-            : isect_offsets[tile_id + 1];
+    const int32_t range_start  = isect_offsets[tile_id];
+    const int32_t range_end    = (image_id == (int32_t)I - 1) && (tile_id == (int32_t)(grid_width * grid_height) - 1)
+                                   ? n_isects
+                                   : isect_offsets[tile_id + 1];
     const uint32_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
 
     extern __shared__ int s[];
@@ -316,8 +323,8 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
     const uint32_t grid_h   = isect_offsets.size(-2);
     const uint32_t grid_w   = isect_offsets.size(-1);
     const uint32_t n_isects = flatten_ids.size(0);
-
-    const dim3 grid = {I, grid_h, grid_w};
+    const uint32_t n_tiles  = I * grid_h * grid_w;
+    const dim3 grid         = {n_tiles, 1, 1};
 
     const int32_t channels = colors.size(-1);
     TORCH_CHECK_VALUE(
@@ -367,6 +374,10 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
                     masks_ptr,
                     image_width,
                     image_height,
+                    I,
+                    grid_w,
+                    grid_h,
+                    0,
                     isect_offsets.const_data_ptr<int32_t>(),
                     flatten_ids.const_data_ptr<int32_t>(),
                     renders.data_ptr<float>(),
@@ -396,6 +407,131 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
     };
     const bool dispatched = dispatch::dispatch(SupportedChannels{channels}, std::move(launch_kernel));
     TORCH_CHECK(dispatched, "dispatch failed: no matching compile-time instantiation for runtime parameters");
+}
+
+void launch_rasterize_to_pixels_3dgs_fwd_kernels(
+    // Gaussian parameters
+    const at::Tensor means2d,                   // [..., N, 2] or [nnz, 2]
+    const at::Tensor conics,                    // [..., N, 3] or [nnz, 3]
+    const at::Tensor colors,                    // [..., N, channels] or [nnz, channels]
+    const at::Tensor opacities,                 // [..., N]  or [nnz]
+    const at::optional<at::Tensor> backgrounds, // [..., channels]
+    const at::optional<at::Tensor> masks,       // [..., grid_h, grid_w]
+    // image size
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    // intersections
+    const at::Tensor isect_offsets, // [..., grid_h, grid_w]
+    const at::Tensor flatten_ids,   // [n_isects]
+    // outputs
+    at::Tensor renders, // [..., image_height, image_width, channels]
+    at::Tensor alphas,  // [..., image_height, image_width]
+    at::Tensor last_ids // [..., image_height, image_width]
+)
+{
+    const bool packed = means2d.dim() == 2;
+
+    const uint32_t N        = packed ? 0 : means2d.size(-2);
+    const uint32_t I        = alphas.numel() / (image_height * image_width);
+    const uint32_t grid_h   = isect_offsets.size(-2);
+    const uint32_t grid_w   = isect_offsets.size(-1);
+    const uint32_t n_isects = flatten_ids.size(0);
+    const uint32_t n_tiles  = I * grid_h * grid_w;
+
+    const int32_t channels = colors.size(-1);
+    TORCH_CHECK_VALUE(
+        SupportedChannels::contains(channels),
+        "Unsupported number of color channels: ",
+        channels,
+        ". To add support, rebuild gsplat with this channel count included "
+        "in -DGSPLAT_NUM_CHANNELS=... (see gsplat/cuda/csrc/Config.h)."
+    );
+
+    auto launch_kernels = [&]<typename ChannelsT>()
+    {
+        constexpr uint32_t CDIM = ChannelsT::value;
+
+        auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
+        {
+            const dim3 threads       = dim3{CTA_SIZE, 1, 1};
+            const int64_t shmem_size = CTA_SIZE * (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3));
+
+            const float *bg_ptr   = backgrounds.has_value() ? backgrounds.value().const_data_ptr<float>() : nullptr;
+            const bool *masks_ptr = masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr;
+
+            for(const auto device_id: c10::irange(c10::cuda::device_count()))
+            {
+                C10_CUDA_CHECK(cudaSetDevice(device_id));
+                if(cudaFuncSetAttribute(
+                       rasterize_to_pixels_3dgs_fwd_kernel<CDIM, TILE_SIZE, CTA_SIZE>,
+                       cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       shmem_size
+                   )
+                   != cudaSuccess)
+                {
+                    AT_ERROR(
+                        "Failed to set maximum shared memory size (requested ",
+                        shmem_size,
+                        " bytes), try lowering tile_size."
+                    );
+                }
+                auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+                int64_t block_offset, block_count;
+                std::tie(block_offset, block_count) = chunk(n_tiles, device_id);
+                if(block_count > 0)
+                {
+                    const dim3 grid = {static_cast<uint32_t>(block_count), 1, 1};
+                    rasterize_to_pixels_3dgs_fwd_kernel<CDIM, TILE_SIZE, CTA_SIZE>
+                        <<<grid, threads, shmem_size, stream>>>(
+                            N,
+                            n_isects,
+                            packed,
+                            reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
+                            reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
+                            colors.const_data_ptr<float>(),
+                            opacities.const_data_ptr<float>(),
+                            bg_ptr,
+                            masks_ptr,
+                            image_width,
+                            image_height,
+                            I,
+                            grid_w,
+                            grid_h,
+                            block_offset,
+                            isect_offsets.const_data_ptr<int32_t>(),
+                            flatten_ids.const_data_ptr<int32_t>(),
+                            renders.data_ptr<float>(),
+                            alphas.data_ptr<float>(),
+                            last_ids.data_ptr<int32_t>()
+                        );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                }
+            }
+        };
+
+        if(tile_size == 16)
+        {
+            launch_variant.template operator()<16, 64>();
+        }
+        else if(tile_size == 4)
+        {
+            launch_variant.template operator()<4, 16>();
+        }
+        else
+        {
+            AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
+        }
+    };
+    const bool dispatched = dispatch::dispatch(SupportedChannels{channels}, std::move(launch_kernels));
+    TORCH_CHECK(
+        dispatched,
+        "dispatch failed: no matching compile-time instantiation for runtime "
+        "parameters"
+    );
+
+    merge_streams();
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/Relocation.cpp
+++ b/gsplat/cuda/csrc/Relocation.cpp
@@ -55,7 +55,8 @@ RelocationResult relocation(
     const at::Tensor &scales,    // [N, 3]
     const at::Tensor &ratios,    // [N]
     const at::Tensor &binoms,    // [n_max, n_max]
-    int64_t n_max
+    int64_t n_max,
+    double min_opacity
 )
 {
     DEVICE_GUARD(opacities);
@@ -66,7 +67,9 @@ RelocationResult relocation(
     at::Tensor new_opacities = at::empty_like(opacities);
     at::Tensor new_scales    = at::empty_like(scales);
 
-    launch_relocation_kernel(opacities, scales, ratios, binoms, n_max, new_opacities, new_scales);
+    launch_relocation_kernel(
+        opacities, scales, ratios, binoms, n_max, static_cast<float>(min_opacity), new_opacities, new_scales
+    );
     return {.new_opacities = new_opacities, .new_scales = new_scales};
 }
 

--- a/gsplat/cuda/csrc/Relocation.h
+++ b/gsplat/cuda/csrc/Relocation.h
@@ -33,6 +33,7 @@ void launch_relocation_kernel(
     at::Tensor ratios,    // [N]
     at::Tensor binoms,    // [n_max, n_max]
     const int n_max,
+    float min_opacity,
     // outputs
     at::Tensor new_opacities, // [N]
     at::Tensor new_scales     // [N, 3]

--- a/gsplat/cuda/csrc/RelocationCUDA.cu
+++ b/gsplat/cuda/csrc/RelocationCUDA.cu
@@ -20,6 +20,8 @@
 
 #if GSPLAT_BUILD_RELOC
 
+#    include <cfloat>
+
 #    include <ATen/Dispatch.h>
 #    include <ATen/core/Tensor.h>
 #    include <c10/cuda/CUDAStream.h>
@@ -38,6 +40,7 @@ __global__ void relocation_kernel(
     const int *ratios,
     const scalar_t *binoms,
     int n_max,
+    float min_opacity,
     scalar_t *new_opacities,
     scalar_t *new_scales
 )
@@ -51,8 +54,12 @@ __global__ void relocation_kernel(
     int n_idx       = ratios[idx];
     float denom_sum = 0.0f;
 
-    // compute new opacity
-    new_opacities[idx] = 1.0f - powf(1.0f - opacities[idx], 1.0f / n_idx);
+    // Clamp before the scale computation; intentionally deviates from the Eq. 9
+    // transparency invariant for near-zero-opacity Gaussians for numerical
+    // stability purposes.
+    float new_opacity  = 1.0f - powf(1.0f - opacities[idx], 1.0f / n_idx);
+    new_opacity        = fminf(fmaxf(new_opacity, min_opacity), 1.0f - FLT_EPSILON);
+    new_opacities[idx] = new_opacity;
 
     // compute new scale
     for(int i = 1; i <= n_idx; ++i)
@@ -60,7 +67,7 @@ __global__ void relocation_kernel(
         for(int k = 0; k <= (i - 1); ++k)
         {
             float bin_coeff  = binoms[(i - 1) * n_max + k];
-            float term       = (pow(-1.0f, k) / sqrt(static_cast<float>(k + 1))) * pow(new_opacities[idx], k + 1);
+            float term       = (pow(-1.0f, k) / sqrt(static_cast<float>(k + 1))) * pow(new_opacity, k + 1);
             denom_sum       += (bin_coeff * term);
         }
     }
@@ -78,6 +85,7 @@ void launch_relocation_kernel(
     at::Tensor ratios,    // [N]
     at::Tensor binoms,    // [n_max, n_max]
     const int n_max,
+    float min_opacity,
     // outputs
     at::Tensor new_opacities, // [N]
     at::Tensor new_scales     // [N, 3]
@@ -108,6 +116,7 @@ void launch_relocation_kernel(
                 ratios.const_data_ptr<int>(),
                 binoms.const_data_ptr<scalar_t>(),
                 n_max,
+                min_opacity,
                 new_opacities.data_ptr<scalar_t>(),
                 new_scales.data_ptr<scalar_t>()
             );

--- a/gsplat/cuda/csrc/Rendering.cpp
+++ b/gsplat/cuda/csrc/Rendering.cpp
@@ -2056,4 +2056,18 @@ void register_rendering_autograd_cuda_impl(torch::Library &m)
     m.impl("rasterization_2dgs", to_torch_op<&rasterization_2dgs>);
 #endif
 }
+
+void register_rendering_privateuseone_impl(torch::Library &m)
+{
+#if GSPLAT_BUILD_3DGS || GSPLAT_BUILD_3DGUT
+    m.impl("rasterization_3dgs", to_torch_op<&rasterization_3dgs>);
+#endif
+}
+
+void register_rendering_autograd_privateuseone_impl(torch::Library &m)
+{
+#if GSPLAT_BUILD_3DGS || GSPLAT_BUILD_3DGUT
+    m.impl("rasterization_3dgs", to_torch_op<&rasterization_3dgs>);
+#endif
+}
 } // namespace gsplat

--- a/gsplat/cuda/csrc/SphericalHarmonics.cpp
+++ b/gsplat/cuda/csrc/SphericalHarmonics.cpp
@@ -151,6 +151,24 @@ SphericalHarmonicsFwdResult spherical_harmonics_fwd(
     };
 }
 
+at::Tensor spherical_harmonics_fwd_privateuseone(
+    int64_t degrees_to_use,
+    const at::Tensor &dirs,               // [..., N, 3]
+    const at::Tensor &coeffs,             // [N, K, D]
+    const at::optional<at::Tensor> &masks // [..., N]
+)
+{
+    DEVICE_GUARD(dirs);
+    check_spherical_harmonics_inputs(degrees_to_use, dirs, coeffs, masks);
+
+    auto out_shape    = dirs.sizes().vec();
+    out_shape.back()  = coeffs.size(-1);
+    at::Tensor colors = at::empty(out_shape, dirs.options()); // [..., N, D]
+
+    launch_spherical_harmonics_fwd_kernels(degrees_to_use, dirs, coeffs, masks, colors);
+    return colors; // [..., N, D]
+}
+
 // Full backward for spherical_harmonics.
 // `compute_v_dirs` selects whether to compute the direction gradient. It is an
 // explicit argument rather than something inferred from a tensor's
@@ -241,7 +259,7 @@ void assemble_proj_features_unpacked_fwd(
     CHECK_INPUT(means);
     CHECK_INPUT(campos);
     CHECK_INPUT(coeffs);
-    CHECK_CUDA(out);
+    CHECK_DEVICE(out);
     TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
     TORCH_CHECK(means.scalar_type() == at::kFloat, "means must be float32");
     TORCH_CHECK(campos.scalar_type() == at::kFloat, "campos must be float32");
@@ -282,7 +300,7 @@ void assemble_proj_features_unpacked_fwd(
     }
     if(relu_mask.has_value())
     {
-        CHECK_CUDA(relu_mask.value());
+        CHECK_DEVICE(relu_mask.value());
         TORCH_CHECK(relu_mask.value().is_contiguous(), "relu_mask must be contiguous");
         TORCH_CHECK(relu_mask.value().scalar_type() == at::kBool, "relu_mask must be bool");
         TORCH_CHECK(relu_mask.value().numel() == lead * Dc, "relu_mask numel mismatch");
@@ -567,10 +585,59 @@ at::Tensor assemble_proj_features(
     );
 }
 
+std::tuple<at::Tensor, at::optional<at::Tensor>> spherical_harmonics_bwd_privateuseone(
+    int64_t degrees_to_use,
+    const at::Tensor &dirs,                // [..., N, 3]
+    const at::Tensor &coeffs,              // [N, K, D]
+    const at::optional<at::Tensor> &masks, // [..., N]
+    const at::Tensor &v_colors,            // [..., N, D]
+    bool compute_v_dirs
+)
+{
+    DEVICE_GUARD(dirs);
+    check_spherical_harmonics_inputs(degrees_to_use, dirs, coeffs, masks);
+    CHECK_INPUT(v_colors);
+    TORCH_CHECK(
+        v_colors.size(-1) == coeffs.size(-1),
+        "v_colors last dim (",
+        v_colors.size(-1),
+        ") must match coeffs last dim (",
+        coeffs.size(-1),
+        ")"
+    );
+
+    at::Tensor v_coeffs_accum = at::zeros(coeffs.sizes(), coeffs.options().dtype(at::kFloat));
+    at::Tensor v_dirs;
+    if(compute_v_dirs)
+    {
+        v_dirs = at::zeros_like(dirs);
+    }
+
+    launch_spherical_harmonics_bwd_kernels(
+        degrees_to_use,
+        dirs,
+        coeffs,
+        masks,
+        v_colors,
+        v_coeffs_accum,
+        v_dirs.defined() ? at::optional<at::Tensor>(v_dirs) : c10::nullopt
+    );
+
+    at::Tensor v_coeffs
+        = (coeffs.scalar_type() == at::kFloat) ? v_coeffs_accum : v_coeffs_accum.to(coeffs.scalar_type());
+    return std::make_tuple(v_coeffs, as_optional_tensor(v_dirs));
+}
+
 void register_spherical_harmonics_cuda_impl(torch::Library &m)
 {
     m.impl("spherical_harmonics", to_torch_op<&spherical_harmonics_fwd>);
     m.impl("spherical_harmonics_bwd", to_torch_op<&spherical_harmonics_bwd>);
     m.impl("assemble_proj_features_unpacked_fwd", &assemble_proj_features_unpacked_fwd);
+}
+
+void register_spherical_harmonics_privateuseone_impl(torch::Library &m)
+{
+    m.impl("spherical_harmonics", to_torch_op<&spherical_harmonics_fwd_privateuseone>);
+    m.impl("spherical_harmonics_bwd", to_torch_op<&spherical_harmonics_bwd_privateuseone>);
 }
 } // namespace gsplat

--- a/gsplat/cuda/csrc/SphericalHarmonics.h
+++ b/gsplat/cuda/csrc/SphericalHarmonics.h
@@ -45,6 +45,16 @@ void launch_spherical_harmonics_fwd_kernel(
     at::Tensor colors // [..., N, D]
 );
 
+void launch_spherical_harmonics_fwd_kernels(
+    // inputs
+    const uint32_t degrees_to_use,
+    const at::Tensor dirs,                // [..., N, 3]
+    const at::Tensor coeffs,              // [N, K, D]
+    const at::optional<at::Tensor> masks, // [..., N]
+    // outputs
+    at::Tensor colors // [..., N, D]
+);
+
 void launch_spherical_harmonics_bwd_kernel(
     // inputs
     const uint32_t degrees_to_use,
@@ -130,5 +140,17 @@ void assemble_proj_features_unpacked_fwd(
     const at::optional<at::Tensor> &masks,
     at::Tensor &out,
     const at::optional<at::Tensor> &relu_mask
+);
+
+void launch_spherical_harmonics_bwd_kernels(
+    // inputs
+    const uint32_t degrees_to_use,
+    const at::Tensor dirs,                // [..., N, 3]
+    const at::Tensor coeffs,              // [N, K, D]
+    const at::optional<at::Tensor> masks, // [..., N]
+    const at::Tensor v_colors,            // [..., N, D]
+    // outputs
+    at::Tensor v_coeffs,            // [N, K, D]
+    at::optional<at::Tensor> v_dirs // [..., N, 3]
 );
 } // namespace gsplat

--- a/gsplat/cuda/csrc/SphericalHarmonicsCUDA.cu
+++ b/gsplat/cuda/csrc/SphericalHarmonicsCUDA.cu
@@ -433,6 +433,8 @@ __device__ void sh_coeffs_to_color_fast_vjp(
 // scalar_t is fp16 or fp32; reads are upcast to opmath_t (fp32) inside the helper.
 template<typename scalar_t, typename opmath_t>
 __global__ void spherical_harmonics_fwd_kernel(
+    const int64_t gaussian_offset,
+    const int64_t gaussian_count,
     const uint32_t B,
     const uint32_t N,
     const uint32_t K,
@@ -444,15 +446,18 @@ __global__ void spherical_harmonics_fwd_kernel(
     opmath_t *__restrict__ colors        // [..., N, D]
 )
 {
-    // parallelize over B * N * D
-    uint32_t idx = cg::this_grid().thread_rank();
-    if(idx >= B * N * D)
+    // parallelize over B * gaussian_count * D
+    auto idx            = cg::this_grid().thread_rank();
+    const int64_t count = static_cast<int64_t>(B) * gaussian_count * D;
+    if(idx >= count)
     {
         return;
     }
-    uint32_t elem_id     = idx / D;
-    uint32_t gaussian_id = elem_id % N;
-    uint32_t c           = idx % D; // output channel
+    const int64_t local_elem_id = idx / D;
+    const int64_t batch_id      = local_elem_id / gaussian_count;
+    const int64_t gaussian_id   = local_elem_id % gaussian_count + gaussian_offset;
+    const int64_t elem_id       = batch_id * N + gaussian_id;
+    const uint32_t c            = idx % D; // output channel
     if(masks != nullptr && !masks[elem_id])
     {
         return;
@@ -559,9 +564,9 @@ void launch_spherical_harmonics_fwd_kernel(
 
     if(K == 16 && D == 3 && wide_load_aligned)
     {
-        int64_t n_threads = B * N;
-        dim3 threads(256);
-        dim3 grid((n_threads + threads.x - 1) / threads.x);
+        int64_t n_elements             = B * N;
+        constexpr unsigned int threads = 256;
+        unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
         auto *masks_ptr = masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr;
 
@@ -589,9 +594,10 @@ void launch_spherical_harmonics_fwd_kernel(
                 constexpr int DEGREE = DegConst::value;
                 auto *dirs_ptr       = reinterpret_cast<const vec3 *>(dirs.const_data_ptr<opmath_t>());
                 auto *colors_ptr     = colors.data_ptr<opmath_t>();
-                spherical_harmonics_fwd_kernel_k16_3channel<CoeffT, opmath_t, DEGREE><<<grid, threads, 0, stream>>>(
+                spherical_harmonics_fwd_kernel_k16_3channel<CoeffT, opmath_t, DEGREE><<<blocks, threads, 0, stream>>>(
                     B, N, dirs_ptr, coeffs.const_data_ptr<CoeffT>(), masks_ptr, colors_ptr
                 );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
         );
         TORCH_CHECK(
@@ -600,10 +606,9 @@ void launch_spherical_harmonics_fwd_kernel(
     }
     else
     {
-        int64_t n_elements = static_cast<int64_t>(B) * N * D;
-        dim3 threads(256);
-        dim3 grid((n_elements + threads.x - 1) / threads.x);
-        int64_t shmem_size = 0; // No shared memory used in this kernel
+        int64_t n_elements             = static_cast<int64_t>(B) * N * D;
+        constexpr unsigned int threads = 256;
+        unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
         // Dispatch on the coeff dtype (fp16/fp32); dirs/colors read as opmath_t (float).
         AT_DISPATCH_V2(
@@ -617,9 +622,20 @@ void launch_spherical_harmonics_fwd_kernel(
                     auto *masks_ptr  = masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr;
                     auto *colors_ptr = colors.data_ptr<opmath_t>();
 
-                    spherical_harmonics_fwd_kernel<scalar_t, opmath_t><<<grid, threads, shmem_size, stream>>>(
-                        B, N, K, D, degrees_to_use, dirs_ptr, coeffs.const_data_ptr<scalar_t>(), masks_ptr, colors_ptr
+                    spherical_harmonics_fwd_kernel<scalar_t, opmath_t><<<blocks, threads, 0, stream>>>(
+                        0,
+                        N,
+                        B,
+                        N,
+                        K,
+                        D,
+                        degrees_to_use,
+                        dirs_ptr,
+                        coeffs.const_data_ptr<scalar_t>(),
+                        masks_ptr,
+                        colors_ptr
                     );
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
                 }
             ),
             at::kFloat,
@@ -628,8 +644,73 @@ void launch_spherical_harmonics_fwd_kernel(
     }
 }
 
+void launch_spherical_harmonics_fwd_kernels(
+    // inputs
+    const uint32_t degrees_to_use,
+    const at::Tensor dirs,                // [..., N, 3]
+    const at::Tensor coeffs,              // [N, K, D]
+    const at::optional<at::Tensor> masks, // [..., N]
+    // outputs
+    at::Tensor colors // [..., N, D]
+)
+{
+    const uint32_t D = coeffs.size(-1);
+    const uint32_t K = coeffs.size(-2);
+    const uint32_t N = coeffs.size(-3);
+    const uint32_t B = c10::multiply_integers(dirs.sizes().slice(0, dirs.dim() - 2));
+
+    constexpr unsigned int threads = 256;
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t gaussian_offset, gaussian_count;
+        std::tie(gaussian_offset, gaussian_count) = chunk(N, device_id);
+        int64_t n_elements                        = static_cast<int64_t>(B) * gaussian_count * D;
+        unsigned int blocks                       = ::cuda::ceil_div(n_elements, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_V2(
+                coeffs.scalar_type(),
+                "spherical_harmonics_fwd_kernel",
+                AT_WRAP(
+                    [&]()
+                    {
+                        using opmath_t   = at::opmath_type<scalar_t>;
+                        auto *dirs_ptr   = reinterpret_cast<const vec3 *>(dirs.const_data_ptr<opmath_t>());
+                        auto *masks_ptr  = masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr;
+                        auto *colors_ptr = colors.data_ptr<opmath_t>();
+
+                        spherical_harmonics_fwd_kernel<scalar_t, opmath_t><<<blocks, threads, 0, stream>>>(
+                            gaussian_offset,
+                            gaussian_count,
+                            B,
+                            N,
+                            K,
+                            D,
+                            degrees_to_use,
+                            dirs_ptr,
+                            coeffs.const_data_ptr<scalar_t>(),
+                            masks_ptr,
+                            colors_ptr
+                        );
+                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    }
+                ),
+                at::kFloat,
+                at::kHalf
+            );
+        }
+    }
+    merge_streams();
+}
+
 template<typename scalar_t, typename opmath_t>
 __global__ void spherical_harmonics_bwd_kernel(
+    const int64_t gaussian_offset,
+    const int64_t gaussian_count,
     const uint32_t B,
     const uint32_t N,
     const uint32_t K,
@@ -643,15 +724,18 @@ __global__ void spherical_harmonics_bwd_kernel(
     opmath_t *__restrict__ v_dirs          // [..., N, 3] optional
 )
 {
-    // parallelize over B * N * D
-    uint32_t idx = cg::this_grid().thread_rank();
-    if(idx >= B * N * D)
+    // parallelize over B * gaussian_count * D
+    auto idx            = cg::this_grid().thread_rank();
+    const int64_t count = static_cast<int64_t>(B) * gaussian_count * D;
+    if(idx >= count)
     {
         return;
     }
-    uint32_t elem_id     = idx / D;
-    uint32_t gaussian_id = elem_id % N;
-    uint32_t c           = idx % D; // output channel
+    const int64_t local_elem_id = idx / D;
+    const int64_t batch_id      = local_elem_id / gaussian_count;
+    const int64_t gaussian_id   = local_elem_id % gaussian_count + gaussian_offset;
+    const int64_t elem_id       = batch_id * N + gaussian_id;
+    const uint32_t c            = idx % D; // output channel
     if(masks != nullptr && !masks[elem_id])
     {
         return;
@@ -697,10 +781,9 @@ void launch_spherical_harmonics_bwd_kernel(
     auto stream = at::cuda::getCurrentCUDAStream();
 
     // parallelize over B * N * D
-    int64_t n_elements = static_cast<int64_t>(B) * N * D;
-    dim3 threads(256);
-    dim3 grid((n_elements + threads.x - 1) / threads.x);
-    int64_t shmem_size = 0; // No shared memory used in this kernel
+    int64_t n_elements             = static_cast<int64_t>(B) * N * D;
+    constexpr unsigned int threads = 256;
+    unsigned int blocks            = ::cuda::ceil_div(n_elements, threads);
 
     if(n_elements == 0)
     {
@@ -722,7 +805,9 @@ void launch_spherical_harmonics_bwd_kernel(
                 auto *v_colors_ptr = v_colors.const_data_ptr<opmath_t>();
                 auto *v_dirs_ptr   = v_dirs.has_value() ? v_dirs.value().data_ptr<opmath_t>() : nullptr;
 
-                spherical_harmonics_bwd_kernel<scalar_t, opmath_t><<<grid, threads, shmem_size, stream>>>(
+                spherical_harmonics_bwd_kernel<scalar_t, opmath_t><<<blocks, threads, 0, stream>>>(
+                    0,
+                    N,
                     B,
                     N,
                     K,
@@ -735,6 +820,7 @@ void launch_spherical_harmonics_bwd_kernel(
                     v_coeffs.data_ptr<float>(),
                     v_dirs_ptr
                 );
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
             }
         ),
         at::kFloat,
@@ -1236,5 +1322,73 @@ void launch_assemble_proj_features_unpacked_fwd_kernel(
         );
         TORCH_CHECK(dispatched, "assemble_proj_features: dispatch failed for sh_degree=", degrees_to_use);
     }
+}
+
+void launch_spherical_harmonics_bwd_kernels(
+    // inputs
+    const uint32_t degrees_to_use,
+    const at::Tensor dirs,                // [..., N, 3]
+    const at::Tensor coeffs,              // [N, K, D]
+    const at::optional<at::Tensor> masks, // [..., N]
+    const at::Tensor v_colors,            // [..., N, D]
+    // outputs
+    at::Tensor v_coeffs,            // [N, K, D]
+    at::optional<at::Tensor> v_dirs // [..., N, 3]
+)
+{
+    const uint32_t D = coeffs.size(-1);
+    const uint32_t K = coeffs.size(-2);
+    const uint32_t N = coeffs.size(-3);
+    const uint32_t B = c10::multiply_integers(dirs.sizes().slice(0, dirs.dim() - 2));
+
+    constexpr unsigned int threads = 256;
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+
+        int64_t gaussian_offset, gaussian_count;
+        std::tie(gaussian_offset, gaussian_count) = chunk(N, device_id);
+        int64_t n_elements                        = static_cast<int64_t>(B) * gaussian_count * D;
+        unsigned int blocks                       = ::cuda::ceil_div(n_elements, threads);
+        if(blocks > 0)
+        {
+            AT_DISPATCH_V2(
+                coeffs.scalar_type(),
+                "spherical_harmonics_bwd_kernel",
+                AT_WRAP(
+                    [&]()
+                    {
+                        using opmath_t     = at::opmath_type<scalar_t>;
+                        auto *dirs_ptr     = reinterpret_cast<const vec3 *>(dirs.const_data_ptr<opmath_t>());
+                        auto *masks_ptr    = masks.has_value() ? masks.value().const_data_ptr<bool>() : nullptr;
+                        auto *v_colors_ptr = v_colors.const_data_ptr<opmath_t>();
+                        auto *v_dirs_ptr   = v_dirs.has_value() ? v_dirs.value().data_ptr<opmath_t>() : nullptr;
+
+                        spherical_harmonics_bwd_kernel<scalar_t, opmath_t><<<blocks, threads, 0, stream>>>(
+                            gaussian_offset,
+                            gaussian_count,
+                            B,
+                            N,
+                            K,
+                            D,
+                            degrees_to_use,
+                            dirs_ptr,
+                            coeffs.const_data_ptr<scalar_t>(),
+                            masks_ptr,
+                            v_colors_ptr,
+                            v_coeffs.data_ptr<float>(),
+                            v_dirs_ptr
+                        );
+                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    }
+                ),
+                at::kFloat,
+                at::kHalf
+            );
+        }
+    }
+    merge_streams();
 }
 } // namespace gsplat

--- a/gsplat/cuda/csrc/Utils.cpp
+++ b/gsplat/cuda/csrc/Utils.cpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Utils.h"
+
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAStream.h>
+#include <c10/util/irange.h>
+#include <cuda_runtime_api.h>
+
+#include <vector>
+
+namespace gsplat
+{
+void merge_streams()
+{
+    constexpr int merge_device_id = 0;
+    cudaEvent_t merge_event       = 0;
+    std::vector<cudaEvent_t> events(c10::cuda::device_count());
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+        C10_CUDA_CHECK(cudaEventCreate(&events[device_id], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventRecord(events[device_id], stream));
+    }
+
+    C10_CUDA_CHECK(cudaSetDevice(merge_device_id));
+    C10_CUDA_CHECK(cudaEventCreate(&merge_event, cudaEventDisableTiming));
+    auto merge_stream = c10::cuda::getCurrentCUDAStream(merge_device_id);
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaStreamWaitEvent(merge_stream, events[device_id]));
+    }
+    C10_CUDA_CHECK(cudaEventRecord(merge_event, merge_stream));
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaSetDevice(device_id));
+        auto stream = c10::cuda::getCurrentCUDAStream(device_id);
+        C10_CUDA_CHECK(cudaStreamWaitEvent(stream, merge_event));
+    }
+
+    for(const auto device_id: c10::irange(c10::cuda::device_count()))
+    {
+        C10_CUDA_CHECK(cudaEventDestroy(events[device_id]));
+    }
+    C10_CUDA_CHECK(cudaEventDestroy(merge_event));
+}
+} // namespace gsplat

--- a/gsplat/cuda/ext.cpp
+++ b/gsplat/cuda/ext.cpp
@@ -18,6 +18,8 @@
 
 #include <torch/extension.h>
 
+#include <cmath>
+
 #include "Cameras.h"
 #include "ExternalDistortion.h"
 #include "csrc/Config.h"
@@ -160,9 +162,9 @@ TORCH_LIBRARY(gsplat, m)
         .def_property(
             "alpha",
             [](const c10::intrusive_ptr<UnscentedTransformParameters> &self)
-            { return static_cast<double>(self->alpha); },
+            { return static_cast<double>(std::sqrt(self->alpha2)); },
             [](const c10::intrusive_ptr<UnscentedTransformParameters> &self, double alpha)
-            { self->alpha = static_cast<float>(alpha); }
+            { self->alpha2 = static_cast<float>(alpha * alpha); }
         )
         .def_property(
             "beta",
@@ -193,7 +195,7 @@ TORCH_LIBRARY(gsplat, m)
                 return c10::IValue(
                     c10::ivalue::Tuple::create(
                         {c10::IValue(static_cast<int64_t>(1)),
-                         c10::IValue(static_cast<double>(self->alpha)),
+                         c10::IValue(static_cast<double>(std::sqrt(self->alpha2))),
                          c10::IValue(static_cast<double>(self->beta)),
                          c10::IValue(static_cast<double>(self->kappa)),
                          c10::IValue(static_cast<double>(self->in_image_margin_factor)),

--- a/gsplat/cuda/ext.cpp
+++ b/gsplat/cuda/ext.cpp
@@ -37,15 +37,22 @@ void register_adam_cuda_impl(torch::Library &m);
 void register_external_distortion_wrappers_cuda_impl(torch::Library &m);
 void register_gaussian_losses_cuda_impl(torch::Library &m);
 void register_intersect_cuda_impl(torch::Library &m);
+void register_intersect_privateuseone_impl(torch::Library &m);
 void register_mcmc_perturb_cuda_impl(torch::Library &m);
 void register_projection_cuda_impl(torch::Library &m);
+void register_projection_privateuseone_impl(torch::Library &m);
 void register_quat_scale_to_covar_cuda_impl(torch::Library &m);
+void register_quat_scale_to_covar_privateuseone_impl(torch::Library &m);
 void register_rasterization_cuda_impl(torch::Library &m);
 void register_rasterization_autograd_cuda_impl(torch::Library &m);
 void register_rendering_cuda_impl(torch::Library &m);
 void register_rendering_autograd_cuda_impl(torch::Library &m);
+void register_rendering_privateuseone_impl(torch::Library &m);
+void register_rendering_autograd_privateuseone_impl(torch::Library &m);
+void register_rasterization_privateuseone_impl(torch::Library &m);
 void register_relocation_cuda_impl(torch::Library &m);
 void register_spherical_harmonics_cuda_impl(torch::Library &m);
+void register_spherical_harmonics_privateuseone_impl(torch::Library &m);
 } // namespace gsplat
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
@@ -1290,8 +1297,30 @@ TORCH_LIBRARY_IMPL(gsplat, CUDA, m)
 #endif
 }
 
+TORCH_LIBRARY_IMPL(gsplat, PrivateUse1, m)
+{
+#if GSPLAT_BUILD_3DGS
+    gsplat::register_quat_scale_to_covar_privateuseone_impl(m);
+#endif
+
+    gsplat::register_intersect_privateuseone_impl(m);
+    gsplat::register_spherical_harmonics_privateuseone_impl(m);
+
+#if GSPLAT_BUILD_3DGS
+    gsplat::register_projection_privateuseone_impl(m);
+    gsplat::register_rasterization_privateuseone_impl(m);
+#endif
+
+    gsplat::register_rendering_privateuseone_impl(m);
+}
+
 TORCH_LIBRARY_IMPL(gsplat, AutogradCUDA, m)
 {
     gsplat::register_rasterization_autograd_cuda_impl(m);
     gsplat::register_rendering_autograd_cuda_impl(m);
+}
+
+TORCH_LIBRARY_IMPL(gsplat, AutogradPrivateUse1, m)
+{
+    gsplat::register_rendering_autograd_privateuseone_impl(m);
 }

--- a/gsplat/cuda/ext.cpp
+++ b/gsplat/cuda/ext.cpp
@@ -1194,7 +1194,10 @@ TORCH_LIBRARY(gsplat, m)
 #endif
 
 #if GSPLAT_BUILD_RELOC
-    m.def("relocation(Tensor opacities, Tensor scales, Tensor ratios, Tensor binoms, int n_max) -> (Tensor, Tensor)");
+    m.def(
+        "relocation(Tensor opacities, Tensor scales, Tensor ratios, Tensor binoms, int n_max, float min_opacity=0.0) "
+        "-> (Tensor, Tensor)"
+    );
 #endif
 
     m.def(
@@ -1225,7 +1228,7 @@ TORCH_LIBRARY(gsplat, m)
 #if GSPLAT_BUILD_3DGS
     m.def(
         "mcmc_perturb_positions(Tensor(a!) positions, Tensor quats, Tensor scales, Tensor opacities, Tensor noise, "
-        "float scaler) -> ()"
+        "float noise_scale, float t=0.005, float k=100.0) -> ()"
     );
 #endif
 

--- a/gsplat/cuda/include/Cameras.cuh
+++ b/gsplat/cuda/include/Cameras.cuh
@@ -23,6 +23,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <type_traits>
 #include <cuda_runtime.h>
 
 // Silence warnings / errors of the form
@@ -39,6 +40,7 @@
 
 #include "Cameras.h"
 #include "ExternalDistortion.cuh"
+#include "Utils.cuh"
 
 template<typename T, std::size_t N>
 __device__ std::array<T, N> make_array(const T *ptr)
@@ -51,6 +53,24 @@ __device__ std::array<T, N> make_array(const T *ptr)
     }
     return arr;
 }
+
+// Per-sensor codegen knobs for the UT projection kernel. The default keeps
+// camera models close to the baseline path; specializations opt into measured
+// faster codegen/solver policies.
+template<typename SensorModel>
+struct ProjectionUTCodegenTraits
+{
+    static constexpr int kMinBlocks                = 1;
+    static constexpr unsigned kUTUnroll            = 2u * 3u + 1u;
+    static constexpr bool kNeedsCulling            = true;
+    static constexpr bool kUseGaussianScopeSlerper = false;
+
+    template<size_t N_ROLLING_SHUTTER_ITERATIONS>
+    static constexpr auto rolling_shutter_unroll() -> unsigned
+    {
+        return N_ROLLING_SHUTTER_ITERATIONS == 0u ? 1u : N_ROLLING_SHUTTER_ITERATIONS;
+    }
+};
 
 struct RollingShutterParameters
 {
@@ -330,6 +350,69 @@ inline __device__ auto precise_normalize(const glm::fquat &q) -> glm::fquat
 #endif
 }
 
+// Precomputes the loop-invariant part of a quaternion slerp between two fixed
+// endpoints so the rolling-shutter solver can re-interpolate at successive
+// relative frame times without recomputing the inter-quaternion angle on every
+// iteration. operator()(a) reproduces glm::slerp(q_start, q_end, a) bit-for-bit:
+// the only quantities cached are those that are identical across calls (the
+// sign-corrected endpoint, the angle and its sine), so dividing by the cached
+// sin(angle) is equivalent to glm recomputing it each call.
+template<bool kEnabled = true>
+struct QuaternionSlerper
+{
+    glm::fquat x    = glm::fquat{0.f, 0.f, 0.f, 0.f}; // start endpoint
+    glm::fquat z    = glm::fquat{0.f, 0.f, 0.f, 0.f}; // end endpoint, sign-flipped onto the short arc
+    float angle     = 0.f;                            // angle between x and z
+    float sin_angle = 0.f;
+    bool linear     = false; // near-parallel endpoints -> component-wise mix
+
+    QuaternionSlerper() = default;
+
+    inline __device__ QuaternionSlerper(const glm::fquat &q_start, const glm::fquat &q_end)
+        : x(q_start)
+        , z(q_end)
+    {
+        float cos_theta = glm::dot(q_start, q_end);
+        if(cos_theta < 0.f)
+        {
+            z         = -q_end;
+            cos_theta = -cos_theta;
+        }
+        if(cos_theta > 1.f - glm::epsilon<float>())
+        {
+            linear = true;
+        }
+        else
+        {
+            angle     = glm::acos(cos_theta);
+            sin_angle = glm::sin(angle);
+        }
+    }
+
+    inline __device__ auto operator()(float a) const -> glm::fquat
+    {
+        if(linear)
+        {
+            // Component-wise lerp, matching glm::slerp's near-parallel branch.
+            // Open-coded rather than glm::lerp(x, z, a) because glm::lerp
+            // asserts 0 <= a <= 1, which fails in debug builds when the
+            // rolling-shutter frame time lands slightly outside [0, 1].
+            return glm::fquat(
+                glm::mix(x.w, z.w, a), glm::mix(x.x, z.x, a), glm::mix(x.y, z.y, a), glm::mix(x.z, z.z, a)
+            );
+        }
+        return (glm::sin((1.f - a) * angle) * x + glm::sin(a * angle) * z) / sin_angle;
+    }
+};
+
+template<>
+struct QuaternionSlerper<false>
+{
+    QuaternionSlerper() = default;
+
+    inline __device__ QuaternionSlerper(const glm::fquat &, const glm::fquat &) { }
+};
+
 inline __device__ auto interpolate_shutter_pose(
     float relative_frame_time, const RollingShutterParameters &rolling_shutter_parameters
 ) -> ShutterPose
@@ -462,9 +545,12 @@ struct BaseCameraModel
             .camera_ray_to_world_ray(camera_ray.ray_dir);
     }
 
-    template<size_t N_ROLLING_SHUTTER_ITERATIONS = 10>
+    template<size_t N_ROLLING_SHUTTER_ITERATIONS = 10, bool UsePrecomputedSlerper = false>
     inline __device__ auto world_point_to_image_point_shutter_pose(
-        const glm::fvec3 &world_point, const RollingShutterParameters &rolling_shutter_parameters, float margin_factor
+        const glm::fvec3 &world_point,
+        const RollingShutterParameters &rolling_shutter_parameters,
+        float margin_factor,
+        QuaternionSlerper<UsePrecomputedSlerper> precomputed_slerper = {}
     ) const -> ImagePointReturn
     {
         // Perform rolling-shutter-based world point to image point projection /
@@ -519,19 +605,38 @@ struct BaseCameraModel
 
         // Compute the new timestamp and project again
         auto image_points_rs_prev = init_image_point;
-        auto relative_frame_time  = float{};
         auto t_rs                 = glm::fvec3{};
         auto q_rs                 = glm::fquat{};
         bool valid                = true;
-#pragma unroll
+
+        constexpr unsigned kRollingShutterUnroll = ProjectionUTCodegenTraits<DerivedCameraModel>::
+            template rolling_shutter_unroll<N_ROLLING_SHUTTER_ITERATIONS>();
+        auto prev_relative_frame_time = -std::numeric_limits<float>::max();
+#pragma unroll kRollingShutterUnroll
         for(auto j = 0; j < N_ROLLING_SHUTTER_ITERATIONS; ++j)
         {
-            relative_frame_time = derived->shutter_relative_frame_time(image_points_rs_prev);
+            const auto relative_frame_time = derived->shutter_relative_frame_time(image_points_rs_prev);
+
+            if(relative_frame_time == prev_relative_frame_time)
+            {
+                // Same frame time means the same pose and reprojection for
+                // all remaining iterations, so this is bit-identical to
+                // continuing.
+                break;
+            }
+            prev_relative_frame_time = relative_frame_time;
 
             t_rs = (1.f - relative_frame_time) * t_start + relative_frame_time * t_end;
-            // The rolling-shutter optimization loop is sensitive to small pose
-            // updates, so use the precise normalization here.
-            q_rs = precise_normalize(glm::slerp(q_start, q_end, relative_frame_time));
+            // LiDAR reuses a Gaussian-level slerper across sigma points. Other
+            // sensors pass an empty slerper and construct the local one here.
+            decltype(auto) slerper
+                = gsplat::select_provided_or_construct<UsePrecomputedSlerper, QuaternionSlerper<true>>(
+                    precomputed_slerper, q_start, q_end
+                );
+
+            // The rolling-shutter optimization loop is sensitive to small
+            // pose updates, so use the precise normalization here.
+            q_rs = precise_normalize(slerper(relative_frame_time));
 
             const auto [image_point_rs, valid_rs]
                 = derived->camera_ray_to_image_point(glm::rotate(q_rs, world_point) + t_rs, margin_factor);
@@ -1509,23 +1614,39 @@ public:
 
 struct SigmaPoints
 {
-    std::array<glm::fvec3, 2 * 3 + 1> points;
-    std::array<float, 2 * 3 + 1> weights_mean;
-    std::array<float, 2 * 3 + 1> weights_covariance;
+    std::array<glm::fvec3, 2 * UnscentedTransformParameters::D + 1> points;
 };
+
+inline __device__ auto ut_lambda(const UnscentedTransformParameters &unscented_transform_parameters) -> float
+{
+    const auto &alpha2 = unscented_transform_parameters.alpha2;
+    const auto &kappa  = unscented_transform_parameters.kappa;
+    return alpha2 * (UnscentedTransformParameters::D + kappa) - UnscentedTransformParameters::D;
+}
+
+inline __device__ auto ut_weights(const UnscentedTransformParameters &unscented_transform_parameters, float lambda)
+    -> std::tuple<float, float, float>
+{
+    const auto &alpha2       = unscented_transform_parameters.alpha2;
+    const auto &beta         = unscented_transform_parameters.beta;
+    const auto lambda_plus_D = UnscentedTransformParameters::D + lambda;
+
+    const auto mean0       = lambda / lambda_plus_D;
+    const auto covariance0 = mean0 + (1 - alpha2 + beta);
+    const auto rest        = 1 / (2 * lambda_plus_D);
+
+    return {mean0, covariance0, rest};
+}
 
 inline __device__ auto world_gaussian_sigma_points(
     const UnscentedTransformParameters &unscented_transform_parameters,
     const glm::fvec3 &gaussian_world_mean,
     const glm::fvec3 &gaussian_world_scale,
     const glm::fquat &gaussian_world_rot
-) -> SigmaPoints
+) -> std::tuple<float, SigmaPoints>
 {
-    static constexpr size_t D = 3;
-    const auto &alpha         = unscented_transform_parameters.alpha;
-    const auto &beta          = unscented_transform_parameters.beta;
-    const auto &kappa         = unscented_transform_parameters.kappa;
-    const auto lambda         = alpha * alpha * (D + kappa) - D;
+    static constexpr auto D = UnscentedTransformParameters::D;
+    const auto lambda       = ut_lambda(unscented_transform_parameters);
 
     // Compute rotation matrix R from quaternion (scaling matrix S is diag(s_i))
     glm::fmat3 R = glm::mat3_cast(gaussian_world_rot);
@@ -1534,11 +1655,7 @@ inline __device__ auto world_gaussian_sigma_points(
     // R) provides a closed form of it's SVD C = U * Σ * U^T with U = R^T and Σ
     // = S^T*S = diag((s_i)^2).
 
-    // Use this closed form SVD to compute sigma points and weights from a (D +
-    // lambda)-scaled covariance C (cf. "On Unscented Kalman Filtering for State
-    // Estimation of Continuous-Time Nonlinear Systems" - Särkkä 2007). In
-    // particular, this means that the singular values are given by σ_i = s_i
-    // and the singular vectors u_i are the columns of R
+    // Use this closed form SVD to compute sigma points.
     auto ret = SigmaPoints{};
 
     ret.points[0] = gaussian_world_mean;
@@ -1553,18 +1670,7 @@ inline __device__ auto world_gaussian_sigma_points(
         ret.points[i + 1 + D] = gaussian_world_mean - delta;
     }
 
-    // Compute weights
-    ret.weights_mean[0]       = lambda / (D + lambda);
-    ret.weights_covariance[0] = lambda / (D + lambda) + (1 - alpha * alpha + beta);
-
-#pragma unroll
-    for(auto i = 0u; i < 2 * D; ++i)
-    {
-        ret.weights_mean[i + 1]       = 1 / (2 * (D + lambda));
-        ret.weights_covariance[i + 1] = 1 / (2 * (D + lambda));
-    }
-
-    return ret;
+    return {lambda, ret};
 }
 
 struct ImageGaussianReturn
@@ -1585,27 +1691,52 @@ inline __device__ auto world_gaussian_to_image_gaussian_unscented_transform_shut
 ) -> ImageGaussianReturn
 {
     // Compute sigma points for input distribution
-    const auto sigma_points = world_gaussian_sigma_points(
+    const auto [lambda, sigma_points] = world_gaussian_sigma_points(
         unscented_transform_parameters, gaussian_world_mean, gaussian_world_scale, gaussian_world_rot
     );
 
     // Transform sigma points / compute approximation of output distribution via
     // sample mean / covariance
     bool valid            = unscented_transform_parameters.require_all_sigma_points_valid;
-    auto image_points     = std::array<glm::fvec2, 2 * 3 + 1>{};
+    auto image_points     = std::array<glm::fvec2, 2 * UnscentedTransformParameters::D + 1>{};
     auto image_mean       = glm::fvec2{0};
     auto image_covariance = glm::fmat2{0};
-#pragma unroll
+
+    auto [mean, covariance, rest] = ut_weights(unscented_transform_parameters, lambda);
+
+    // De-unroll the two 7-point loops only for measured wins. The fixed 7-trip
+    // camera loops are cheap enough that the LiDAR register/codegen policy is
+    // not a universal improvement.
+    constexpr unsigned kUTUnroll = ProjectionUTCodegenTraits<CameraModel>::kUTUnroll;
+
+    // The rolling-shutter slerp endpoints are identical for every sigma point of
+    // this Gaussian, so compute the inter-quaternion angle once here and share it
+    // across all 7 sigma-point projections when rolling shutter is active.
+    using GaussianSlerper = std::conditional_t<
+        ProjectionUTCodegenTraits<CameraModel>::kUseGaussianScopeSlerper,
+        QuaternionSlerper<true>,
+        QuaternionSlerper<false>
+    >;
+    GaussianSlerper rs_slerper{};
+    if constexpr(ProjectionUTCodegenTraits<CameraModel>::kUseGaussianScopeSlerper)
+    {
+        if(camera_model.parameters.shutter_type != ShutterType::GLOBAL)
+        {
+            rs_slerper = QuaternionSlerper<>(rolling_shutter_parameters.q_start, rolling_shutter_parameters.q_end);
+        }
+    }
+#pragma unroll kUTUnroll
     for(auto i = 0u; i < std::size(image_points); ++i)
     {
-        const auto [image_point, point_valid] =
-            // annotate with 'template' to avoid warnings: #174-D: expression
-            // has no effect
-            camera_model.template world_point_to_image_point_shutter_pose<>(
-                sigma_points.points[i],
-                rolling_shutter_parameters,
-                unscented_transform_parameters.in_image_margin_factor
-            );
+        typename CameraModel::ImagePointReturn image_point_return{};
+        image_point_return = camera_model.template world_point_to_image_point_shutter_pose<>(
+            sigma_points.points[i],
+            rolling_shutter_parameters,
+            unscented_transform_parameters.in_image_margin_factor,
+            rs_slerper
+        );
+
+        const auto [image_point, point_valid] = image_point_return;
 
         if(unscented_transform_parameters.require_all_sigma_points_valid)
         {
@@ -1620,9 +1751,9 @@ inline __device__ auto world_gaussian_to_image_gaussian_unscented_transform_shut
         {
             valid |= point_valid; // any valid is sufficient
         }
-        image_points[i] = {image_point.x, image_point.y};
-
-        image_mean += sigma_points.weights_mean[i] * image_points[i];
+        image_points[i]  = {image_point.x, image_point.y};
+        image_mean      += mean * image_points[i];
+        mean             = rest;
     }
 
     if(!valid)
@@ -1631,11 +1762,12 @@ inline __device__ auto world_gaussian_to_image_gaussian_unscented_transform_shut
         return {image_mean, image_covariance, false};
     }
 
-#pragma unroll
+#pragma unroll kUTUnroll
     for(auto i = 0u; i < std::size(image_points); ++i)
     {
-        const auto image_mean_vec = image_points[i] - image_mean;
-        image_covariance += sigma_points.weights_covariance[i] * glm::outerProduct(image_mean_vec, image_mean_vec);
+        const auto image_mean_vec  = image_points[i] - image_mean;
+        image_covariance          += covariance * glm::outerProduct(image_mean_vec, image_mean_vec);
+        covariance                 = rest;
     }
 
     return {image_mean, image_covariance, valid};

--- a/gsplat/cuda/include/Cameras.h
+++ b/gsplat/cuda/include/Cameras.h
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
@@ -27,6 +28,8 @@
 #include <variant>
 
 #include <ATen/core/ivalue.h>
+
+#include "Common.h"
 
 // ---------------------------------------------------------------------------------------------
 
@@ -46,6 +49,8 @@ enum class ShutterType
 // Gaussian-specific types
 struct UnscentedTransformParameters : public torch::CustomClassHolder
 {
+    static constexpr size_t D = 3;
+
     // See Gustafsson and Hendeby 2012 for sigma point parameterization - this
     // default parameter choice is based on
     //
@@ -58,7 +63,7 @@ struct UnscentedTransformParameters : public torch::CustomClassHolder
         float in_image_margin_factor        = 0.1f,
         bool require_all_sigma_points_valid = false
     )
-        : alpha(alpha)
+        : alpha2(alpha * alpha)
         , beta(beta)
         , kappa(kappa)
         , in_image_margin_factor(in_image_margin_factor)
@@ -67,19 +72,18 @@ struct UnscentedTransformParameters : public torch::CustomClassHolder
         // The UT requires D + lambda = alpha^2 * (D + kappa) > 0 to produce
         // meaningful sigma point spread.  A non-positive value would make
         // sqrt(D + lambda) produce NaN and the weight denominators diverge.
-        constexpr float D = 3.0f;
         TORCH_CHECK(
-            alpha * alpha * (D + kappa) > 0.0f,
+            alpha2 * (D + kappa) > 0.0f,
             "UT parameters invalid: alpha^2 * (D + kappa) must be > 0 "
-            "(got alpha=",
-            alpha,
+            "(got alpha^2=",
+            alpha2,
             ", kappa=",
             kappa,
             ")"
         );
     }
 
-    float alpha;
+    float alpha2;
     float beta;
     float kappa;
 

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <ATen/DeviceGuard.h>
 #include <algorithm>
 #include <cstdint>
 #include <glm/gtc/type_ptr.hpp>
@@ -28,14 +29,14 @@ namespace gsplat
 //
 // Some Macros.
 //
-#define CHECK_CUDA(x)       TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_DEVICE(x)     TORCH_CHECK(x.is_cuda() || x.is_privateuseone(), #x " must be a CUDA or PrivateUse1 tensor")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) \
-    CHECK_CUDA(x);     \
+    CHECK_DEVICE(x);   \
     CHECK_CONTIGUOUS(x)
 // Kernels index raw dense storage; a strided (non-sparse) layout is required.
 #define CHECK_DENSE(x)     TORCH_CHECK(x.layout() == c10::kStrided, #x " must be a dense tensor")
-#define DEVICE_GUARD(_ten) const at::cuda::OptionalCUDAGuard device_guard(device_of(_ten));
+#define DEVICE_GUARD(_ten) const at::OptionalDeviceGuard device_guard(device_of(_ten));
 
 // Host/device qualifier for helpers shared between host (tests, host-side
 // setup) and device code. Expands to nothing under a non-CUDA compiler.

--- a/gsplat/cuda/include/Lidars.cuh
+++ b/gsplat/cuda/include/Lidars.cuh
@@ -312,15 +312,19 @@ public:
     }
 };
 
-// Type trait to detect LIDAR model
-template<typename T>
-struct is_lidar : std::false_type
-{
-};
-
 template<>
-struct is_lidar<RowOffsetStructuredSpinningLidarModel> : std::true_type
+struct ProjectionUTCodegenTraits<RowOffsetStructuredSpinningLidarModel>
 {
+    static constexpr int kMinBlocks                = 4;
+    static constexpr unsigned kUTUnroll            = 1u;
+    static constexpr bool kNeedsCulling            = false;
+    static constexpr bool kUseGaussianScopeSlerper = true;
+
+    template<size_t N_ROLLING_SHUTTER_ITERATIONS>
+    static constexpr auto rolling_shutter_unroll() -> unsigned
+    {
+        return 1u;
+    }
 };
 
 // Type list of all lidar model types

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -19,7 +19,11 @@
 #pragma once
 
 #include "Common.h"
+#include "Utils.h"
 
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAStream.h>
+#include <c10/util/irange.h>
 #ifdef __CUDACC__
 #    include <cooperative_groups.h>
 #    include <cooperative_groups/reduce.h>
@@ -27,6 +31,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cmath>
+#include <tuple>
 #include <type_traits>
 
 namespace gsplat

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -20,14 +20,29 @@
 
 #include "Common.h"
 
-#include <cooperative_groups.h>
-#include <cooperative_groups/reduce.h>
+#ifdef __CUDACC__
+#    include <cooperative_groups.h>
+#    include <cooperative_groups/reduce.h>
+#endif
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <cmath>
+#include <type_traits>
 
 namespace gsplat
 {
+#ifdef __CUDACC__
 namespace cg = cooperative_groups;
+#endif
+
+inline __device__ float rsqrt_parse_safe(float x)
+{
+#ifdef __CUDA_ARCH__
+    return rsqrt(x);
+#else
+    return 1.f / std::sqrt(x);
+#endif
+}
 
 // Check whether a floating-point value is effectively zero, using the
 // machine epsilon for the given type.
@@ -36,6 +51,20 @@ constexpr __host__ __device__ bool is_near_zero(T x)
 {
     static_assert(cuda::std::is_floating_point_v<T>, "is_near_zero requires a floating-point type");
     return abs(x) < cuda::std::numeric_limits<T>::epsilon();
+}
+
+template<bool kUseProvided, typename ConstructedT, typename ProvidedT, typename... Args>
+inline __device__ auto select_provided_or_construct(const ProvidedT &provided, Args &&...args)
+    -> std::conditional_t<kUseProvided, const ProvidedT &, ConstructedT>
+{
+    if constexpr(kUseProvided)
+    {
+        return provided;
+    }
+    else
+    {
+        return ConstructedT(args...);
+    }
 }
 
 ///////////////////////////////
@@ -115,10 +144,11 @@ inline __device__ void covarW2C_VJP(
 // Reduce
 ///////////////////////////////
 
+#ifdef __CUDACC__
 template<uint32_t DIM, class WarpT>
 inline __device__ void warpSum(float *val, WarpT &warp)
 {
-#pragma unroll
+#    pragma unroll
     for(uint32_t i = 0; i < DIM; i++)
     {
         val[i] = cg::reduce(warp, val[i], cg::plus<float>());
@@ -184,6 +214,7 @@ inline __device__ void warpMax(float &val, WarpT &warp)
 {
     val = cg::reduce(warp, val, cg::greater<float>());
 }
+#endif
 
 ///////////////////////////////
 // Quaternion
@@ -193,7 +224,7 @@ inline __device__ mat3 quat_to_rotmat(const vec4 quat)
 {
     float w = quat[0], x = quat[1], y = quat[2], z = quat[3];
     // normalize
-    float inv_norm  = rsqrt(x * x + y * y + z * z + w * w);
+    float inv_norm  = rsqrt_parse_safe(x * x + y * y + z * z + w * w);
     x              *= inv_norm;
     y              *= inv_norm;
     z              *= inv_norm;
@@ -218,7 +249,7 @@ inline __device__ void quat_to_rotmat_vjp(const vec4 quat, const mat3 v_R, vec4 
 {
     float w = quat[0], x = quat[1], y = quat[2], z = quat[3];
     // normalize
-    float inv_norm  = rsqrt(x * x + y * y + z * z + w * w);
+    float inv_norm  = rsqrt_parse_safe(x * x + y * y + z * z + w * w);
     x              *= inv_norm;
     y              *= inv_norm;
     z              *= inv_norm;
@@ -287,7 +318,6 @@ inline __device__ void quat_scale_to_covar_vjp(
     vec3 &v_scale
 )
 {
-    float w = quat[0], x = quat[1], y = quat[2], z = quat[3];
     float sx = scale[0], sy = scale[1], sz = scale[2];
 
     // M = R * S
@@ -327,7 +357,6 @@ inline __device__ void quat_scale_to_preci_vjp(
     // Scale must be non-zero; the projection kernel culls degenerate
     // Gaussians (scale < epsilon) so they never reach this path.
     assert(scale[0] != 0.f && scale[1] != 0.f && scale[2] != 0.f);
-    float w = quat[0], x = quat[1], y = quat[2], z = quat[3];
     float sx = 1.0f / scale[0], sy = 1.0f / scale[1], sz = 1.0f / scale[2];
 
     // M = R * S
@@ -393,7 +422,6 @@ inline __device__ void quat_scale_to_preci_half_vjp(
     // Scale must be non-zero; the projection kernel culls degenerate
     // Gaussians (scale < epsilon) so they never reach this path.
     assert(scale[0] != 0.f && scale[1] != 0.f && scale[2] != 0.f);
-    float w = quat[0], x = quat[1], y = quat[2], z = quat[3];
     float sx = 1.0f / scale[0], sy = 1.0f / scale[1], sz = 1.0f / scale[2];
 
     // M = R * S
@@ -425,7 +453,7 @@ inline __device__ float add_blur(const float eps2d, mat2 &covar, float &compensa
     covar[0][0]    += eps2d;
     covar[1][1]    += eps2d;
     float det_blur  = covar[0][0] * covar[1][1] - covar[0][1] * covar[1][0];
-    compensation    = sqrt(max(MIN_COMPENSATION * MIN_COMPENSATION, det_orig / det_blur));
+    compensation    = sqrtf(glm::max(MIN_COMPENSATION * MIN_COMPENSATION, det_orig / det_blur));
     return det_blur;
 }
 
@@ -477,7 +505,7 @@ inline __device__ void ortho_proj(
     vec2 &mean2d
 )
 {
-    float x = mean3d[0], y = mean3d[1], z = mean3d[2];
+    float x = mean3d[0], y = mean3d[1];
 
     // mat3x2 is 3 columns x 2 rows.
     mat3x2 J = mat3x2(
@@ -510,8 +538,6 @@ inline __device__ void ortho_proj_vjp(
     mat3 &v_cov3d
 )
 {
-    float x = mean3d[0], y = mean3d[1], z = mean3d[2];
-
     // mat3x2 is 3 columns x 2 rows.
     mat3x2 J = mat3x2(
         fx,
@@ -559,8 +585,8 @@ inline __device__ void persp_proj(
 
     float rz  = 1.f / z;
     float rz2 = rz * rz;
-    float tx  = z * min(lim_x_pos, max(-lim_x_neg, x * rz));
-    float ty  = z * min(lim_y_pos, max(-lim_y_neg, y * rz));
+    float tx  = z * glm::min(lim_x_pos, glm::max(-lim_x_neg, x * rz));
+    float ty  = z * glm::min(lim_y_pos, glm::max(-lim_y_neg, y * rz));
 
     // mat3x2 is 3 columns x 2 rows.
     mat3x2 J = mat3x2(
@@ -604,8 +630,8 @@ inline __device__ void persp_proj_vjp(
 
     float rz  = 1.f / z;
     float rz2 = rz * rz;
-    float tx  = z * min(lim_x_pos, max(-lim_x_neg, x * rz));
-    float ty  = z * min(lim_y_pos, max(-lim_y_neg, y * rz));
+    float tx  = z * glm::min(lim_x_pos, glm::max(-lim_x_neg, x * rz));
+    float ty  = z * glm::min(lim_y_pos, glm::max(-lim_y_neg, y * rz));
 
     // mat3x2 is 3 columns x 2 rows.
     mat3x2 J = mat3x2(
@@ -825,6 +851,7 @@ inline __device__ void fisheye_proj_vjp(
 // FFMA + MUFU.RSQ + FMUL sequence regardless of context.
 inline __device__ vec3 safe_normalize(vec3 v)
 {
+#ifdef __CUDA_ARCH__
     float l = __fmul_rn(v.x, v.x);
     l       = __fmaf_rn(v.y, v.y, l);
     l       = __fmaf_rn(v.z, v.z, l);
@@ -834,6 +861,15 @@ inline __device__ vec3 safe_normalize(vec3 v)
         return vec3(__fmul_rn(v.x, inv), __fmul_rn(v.y, inv), __fmul_rn(v.z, inv));
     }
     return v;
+#else
+    const float l = v.x * v.x + v.y * v.y + v.z * v.z;
+    if(l > 0.0f)
+    {
+        const float inv = 1.0f / std::sqrt(l);
+        return vec3(v.x * inv, v.y * inv, v.z * inv);
+    }
+    return v;
+#endif
 }
 
 inline __device__ vec3 safe_normalize_bw(const vec3 &v, const vec3 &d_out)
@@ -841,7 +877,11 @@ inline __device__ vec3 safe_normalize_bw(const vec3 &v, const vec3 &d_out)
     const float l = v.x * v.x + v.y * v.y + v.z * v.z;
     if(l > 0.0f)
     {
-        const float il  = rsqrtf(l);
+#ifdef __CUDA_ARCH__
+        const float il = rsqrtf(l);
+#else
+        const float il = 1.0f / std::sqrt(l);
+#endif
         const float il3 = (il * il * il);
         return il * d_out - il3 * glm::dot(d_out, v) * v;
     }

--- a/gsplat/cuda/include/Utils.h
+++ b/gsplat/cuda/include/Utils.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <c10/cuda/CUDAFunctions.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+
+namespace gsplat
+{
+inline std::tuple<size_t, size_t> aligned_chunk(size_t alignment, size_t size, c10::DeviceIndex device)
+{
+    size_t chunk_size
+        = alignment * ((size + alignment * c10::cuda::device_count() - 1) / (c10::cuda::device_count() * alignment));
+    auto chunk_offset = chunk_size * device;
+    if(chunk_offset + chunk_size > size)
+    {
+        chunk_offset = std::min(chunk_offset, size);
+        chunk_size   = std::min(chunk_size, size - chunk_offset);
+    }
+    return std::make_tuple(chunk_offset, chunk_size);
+}
+
+inline std::tuple<size_t, size_t> chunk(size_t size, c10::DeviceIndex device)
+{
+    return aligned_chunk(1u, size, device);
+}
+
+void merge_streams();
+} // namespace gsplat

--- a/gsplat/distributed.py
+++ b/gsplat/distributed.py
@@ -344,7 +344,7 @@ def cli(fn: Callable, args: Any, verbose: bool = False) -> bool:
         )
 
     world_size = torch.cuda.device_count()
-    distributed = world_size > 1
+    distributed = world_size > 1 and not getattr(args, "backend", None) == "dgx"
 
     if distributed:
         os.environ["MASTER_ADDR"] = "localhost"

--- a/gsplat/geometry/functional/__init__.py
+++ b/gsplat/geometry/functional/__init__.py
@@ -17,6 +17,8 @@
 
 from gsplat.geometry.functional.pose import (
     frame_transform_poses_tquat,
+    se3_interpolate_tracks,
+    se3pose_compose,
     se3pose_from_matrix,
     se3pose_inverse_transform_direction,
     se3pose_inverse_transform_point,
@@ -45,6 +47,8 @@ from gsplat.geometry.functional.quaternion import (
 
 __all__ = [
     "frame_transform_poses_tquat",
+    "se3_interpolate_tracks",
+    "se3pose_compose",
     "se3pose_from_matrix",
     "se3pose_inverse_transform_direction",
     "se3pose_inverse_transform_point",

--- a/gsplat/geometry/functional/pose.py
+++ b/gsplat/geometry/functional/pose.py
@@ -17,6 +17,8 @@
 
 from ..kernels.pose_ops import (
     frame_transform_poses_tquat,
+    se3_interpolate_tracks,
+    se3pose_compose,
     se3pose_from_matrix,
     se3pose_inverse_transform_direction,
     se3pose_inverse_transform_point,
@@ -31,6 +33,8 @@ from ..kernels.pose_ops import (
 
 __all__ = [
     "frame_transform_poses_tquat",
+    "se3_interpolate_tracks",
+    "se3pose_compose",
     "se3pose_from_matrix",
     "se3pose_inverse_transform_direction",
     "se3pose_inverse_transform_point",

--- a/gsplat/geometry/kernels/cuda/csrc/pose.cu
+++ b/gsplat/geometry/kernels/cuda/csrc/pose.cu
@@ -59,6 +59,65 @@ __global__ void se3pose_transform_direction_fwd_kernel(
     se3pose_transform_direction_fwd_device(i, n, rotation, direction, out);
 }
 
+// Grid-stride: row-wise SE(3) pose composition parent * child.
+template<typename scalar_t>
+__global__ void se3pose_compose_fwd_kernel(
+    int64_t n,
+    const scalar_t *__restrict__ parent_translation,
+    const scalar_t *__restrict__ parent_rotation,
+    const scalar_t *__restrict__ child_translation,
+    const scalar_t *__restrict__ child_rotation,
+    scalar_t *__restrict__ out_translation,
+    scalar_t *__restrict__ out_rotation
+)
+{
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if(i >= n)
+    {
+        return;
+    }
+    se3pose_compose_fwd_device(
+        i, n, parent_translation, parent_rotation, child_translation, child_rotation, out_translation, out_rotation
+    );
+}
+
+// Grid-stride: VJP for row-wise SE(3) pose composition.
+template<typename scalar_t>
+__global__ void se3pose_compose_bwd_kernel(
+    int64_t n,
+    const scalar_t *__restrict__ parent_translation,
+    const scalar_t *__restrict__ parent_rotation,
+    const scalar_t *__restrict__ child_translation,
+    const scalar_t *__restrict__ child_rotation,
+    const scalar_t *__restrict__ grad_out_translation,
+    const scalar_t *__restrict__ grad_out_rotation,
+    scalar_t *__restrict__ grad_parent_translation,
+    scalar_t *__restrict__ grad_parent_rotation,
+    scalar_t *__restrict__ grad_child_translation,
+    scalar_t *__restrict__ grad_child_rotation
+)
+{
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if(i >= n)
+    {
+        return;
+    }
+    se3pose_compose_bwd_device(
+        i,
+        n,
+        parent_translation,
+        parent_rotation,
+        child_translation,
+        child_rotation,
+        grad_out_translation,
+        grad_out_rotation,
+        grad_parent_translation,
+        grad_parent_rotation,
+        grad_child_translation,
+        grad_child_rotation
+    );
+}
+
 // Grid-stride: inverse point R^T(p−t); q stored xyzw (device uses conjugate for inverse rotation).
 template<typename scalar_t>
 __global__ void se3pose_inverse_transform_point_fwd_kernel(
@@ -137,6 +196,76 @@ void launch_se3pose_transform_direction_fwd(const at::Tensor &rotation, const at
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+// Launch row-wise SE(3) pose composition on the current CUDA stream.
+template<typename scalar_t>
+void launch_se3pose_compose_fwd(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation,
+    at::Tensor &out_translation,
+    at::Tensor &out_rotation
+)
+{
+    const int64_t n = parent_translation.size(0);
+    if(n == 0)
+    {
+        return;
+    }
+    const int threads         = kThreadsPerBlock;
+    const int blocks          = static_cast<int>((n + threads - 1) / threads);
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream(parent_translation.device().index());
+    se3pose_compose_fwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        n,
+        parent_translation.data_ptr<scalar_t>(),
+        parent_rotation.data_ptr<scalar_t>(),
+        child_translation.data_ptr<scalar_t>(),
+        child_rotation.data_ptr<scalar_t>(),
+        out_translation.data_ptr<scalar_t>(),
+        out_rotation.data_ptr<scalar_t>()
+    );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+// Launch VJP for row-wise SE(3) pose composition on the current CUDA stream.
+template<typename scalar_t>
+void launch_se3pose_compose_bwd(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation,
+    const at::Tensor &grad_out_translation,
+    const at::Tensor &grad_out_rotation,
+    at::Tensor &grad_parent_translation,
+    at::Tensor &grad_parent_rotation,
+    at::Tensor &grad_child_translation,
+    at::Tensor &grad_child_rotation
+)
+{
+    const int64_t n = parent_translation.size(0);
+    if(n == 0)
+    {
+        return;
+    }
+    const int threads         = kThreadsPerBlock;
+    const int blocks          = static_cast<int>((n + threads - 1) / threads);
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream(parent_translation.device().index());
+    se3pose_compose_bwd_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        n,
+        parent_translation.data_ptr<scalar_t>(),
+        parent_rotation.data_ptr<scalar_t>(),
+        child_translation.data_ptr<scalar_t>(),
+        child_rotation.data_ptr<scalar_t>(),
+        grad_out_translation.data_ptr<scalar_t>(),
+        grad_out_rotation.data_ptr<scalar_t>(),
+        grad_parent_translation.data_ptr<scalar_t>(),
+        grad_parent_rotation.data_ptr<scalar_t>(),
+        grad_child_translation.data_ptr<scalar_t>(),
+        grad_child_rotation.data_ptr<scalar_t>()
+    );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 // Launch the inverse SE(3) point transform kernel on the current CUDA stream.
 // Inputs: translation (N,3), rotation (N,4) in xyzw order, point (N,3).
 // Output: out (N,3) with row i = R(q_i)^T * (point_i - translation_i).
@@ -209,6 +338,64 @@ void se3pose_transform_direction_cuda(const at::Tensor &rotation, const at::Tens
         direction.scalar_type(),
         "se3pose_transform_direction_cuda",
         [&] { launch_se3pose_transform_direction_fwd<scalar_t>(rotation, direction, out); }
+    );
+}
+
+// Public CUDA entrypoint for row-wise SE(3) pose composition.
+// Output pose is parent * child with xyzw rotations.
+void se3pose_compose_cuda(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation,
+    at::Tensor &out_translation,
+    at::Tensor &out_rotation
+)
+{
+    AT_DISPATCH_FLOATING_TYPES(
+        parent_translation.scalar_type(),
+        "se3pose_compose_cuda",
+        [&]
+        {
+            launch_se3pose_compose_fwd<scalar_t>(
+                parent_translation, parent_rotation, child_translation, child_rotation, out_translation, out_rotation
+            );
+        }
+    );
+}
+
+// Public CUDA entrypoint for row-wise SE(3) pose composition VJP.
+void se3pose_compose_bwd_cuda(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation,
+    const at::Tensor &grad_out_translation,
+    const at::Tensor &grad_out_rotation,
+    at::Tensor &grad_parent_translation,
+    at::Tensor &grad_parent_rotation,
+    at::Tensor &grad_child_translation,
+    at::Tensor &grad_child_rotation
+)
+{
+    AT_DISPATCH_FLOATING_TYPES(
+        parent_translation.scalar_type(),
+        "se3pose_compose_bwd_cuda",
+        [&]
+        {
+            launch_se3pose_compose_bwd<scalar_t>(
+                parent_translation,
+                parent_rotation,
+                child_translation,
+                child_rotation,
+                grad_out_translation,
+                grad_out_rotation,
+                grad_parent_translation,
+                grad_parent_rotation,
+                grad_child_translation,
+                grad_child_rotation
+            );
+        }
     );
 }
 
@@ -1013,6 +1200,451 @@ void launch_trajectory_get_rotation_2poses_bwd(
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 } // namespace trajectory_cuda
+
+namespace packed_track_cuda
+{
+template<typename scalar_t, typename time_t>
+__global__ void se3_interpolate_tracks_fwd_kernel(
+    int64_t n_tracks,
+    int64_t n_poses,
+    const scalar_t *__restrict__ pose_translations,
+    const scalar_t *__restrict__ pose_rotations,
+    const time_t *__restrict__ pose_times,
+    const int64_t *__restrict__ pose_offsets,
+    const int64_t *__restrict__ pose_counts,
+    const time_t *__restrict__ query_times,
+    scalar_t *__restrict__ out_translations,
+    scalar_t *__restrict__ out_rotations
+)
+{
+    const int64_t track = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if(track >= n_tracks)
+    {
+        return;
+    }
+
+    const int64_t start = pose_offsets[track];
+    const int64_t count = pose_counts[track];
+    const int64_t out3  = track * 3;
+    const int64_t out4  = track * 4;
+    if(!valid_track_range(start, count, n_poses))
+    {
+        out_translations[out3 + 0] = scalar_t(0);
+        out_translations[out3 + 1] = scalar_t(0);
+        out_translations[out3 + 2] = scalar_t(0);
+        out_rotations[out4 + 0]    = scalar_t(0);
+        out_rotations[out4 + 1]    = scalar_t(0);
+        out_rotations[out4 + 2]    = scalar_t(0);
+        out_rotations[out4 + 3]    = scalar_t(1);
+        return;
+    }
+    int64_t left = 0, right = 0;
+    bool same = false, valid = false;
+    time_t clamped_query, left_time, right_time;
+    track_interval(
+        pose_times,
+        start,
+        count,
+        query_times[track],
+        &left,
+        &right,
+        &same,
+        &valid,
+        &clamped_query,
+        &left_time,
+        &right_time
+    );
+    const scalar_t alpha = interpolation_alpha<scalar_t>(left_time, right_time, clamped_query, valid);
+
+    const int64_t l3 = left * 3;
+    const int64_t r3 = right * 3;
+    out_translations[out3 + 0]
+        = pose_translations[l3 + 0] + alpha * (pose_translations[r3 + 0] - pose_translations[l3 + 0]);
+    out_translations[out3 + 1]
+        = pose_translations[l3 + 1] + alpha * (pose_translations[r3 + 1] - pose_translations[l3 + 1]);
+    out_translations[out3 + 2]
+        = pose_translations[l3 + 2] + alpha * (pose_translations[r3 + 2] - pose_translations[l3 + 2]);
+
+    const int64_t l4 = left * 4;
+    if(same)
+    {
+        out_rotations[out4 + 0] = pose_rotations[l4 + 0];
+        out_rotations[out4 + 1] = pose_rotations[l4 + 1];
+        out_rotations[out4 + 2] = pose_rotations[l4 + 2];
+        out_rotations[out4 + 3] = pose_rotations[l4 + 3];
+        return;
+    }
+
+    const int64_t r4 = right * 4;
+    quat_slerp_pair_fwd(
+        pose_rotations[l4 + 0],
+        pose_rotations[l4 + 1],
+        pose_rotations[l4 + 2],
+        pose_rotations[l4 + 3],
+        pose_rotations[r4 + 0],
+        pose_rotations[r4 + 1],
+        pose_rotations[r4 + 2],
+        pose_rotations[r4 + 3],
+        alpha,
+        out_rotations + out4 + 0,
+        out_rotations + out4 + 1,
+        out_rotations + out4 + 2,
+        out_rotations + out4 + 3
+    );
+}
+
+template<typename scalar_t, typename time_t>
+__global__ void se3_interpolate_tracks_bwd_kernel(
+    int64_t n_tracks,
+    int64_t n_poses,
+    const scalar_t *__restrict__ pose_translations,
+    const scalar_t *__restrict__ pose_rotations,
+    const time_t *__restrict__ pose_times,
+    const int64_t *__restrict__ pose_offsets,
+    const int64_t *__restrict__ pose_counts,
+    const time_t *__restrict__ query_times,
+    const scalar_t *__restrict__ out_rotations,
+    const scalar_t *__restrict__ grad_out_translations,
+    const scalar_t *__restrict__ grad_out_rotations,
+    scalar_t *__restrict__ grad_pose_translations,
+    scalar_t *__restrict__ grad_pose_rotations,
+    time_t *__restrict__ grad_pose_times,
+    time_t *__restrict__ grad_query_times
+)
+{
+    const int64_t track = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if(track >= n_tracks)
+    {
+        return;
+    }
+
+    const int64_t start = pose_offsets[track];
+    const int64_t count = pose_counts[track];
+    if(!valid_track_range(start, count, n_poses))
+    {
+        return;
+    }
+    int64_t left = 0, right = 0;
+    bool same = false, valid = false;
+    time_t clamped_query, left_time, right_time;
+    track_interval(
+        pose_times,
+        start,
+        count,
+        query_times[track],
+        &left,
+        &right,
+        &same,
+        &valid,
+        &clamped_query,
+        &left_time,
+        &right_time
+    );
+    const scalar_t alpha           = interpolation_alpha<scalar_t>(left_time, right_time, clamped_query, valid);
+    const scalar_t one_minus_alpha = scalar_t(1) - alpha;
+
+    const int64_t out3 = track * 3;
+    const int64_t l3   = left * 3;
+    const int64_t r3   = right * 3;
+    const scalar_t gtx = grad_out_translations[out3 + 0];
+    const scalar_t gty = grad_out_translations[out3 + 1];
+    const scalar_t gtz = grad_out_translations[out3 + 2];
+    atomic_add(grad_pose_translations + l3 + 0, one_minus_alpha * gtx);
+    atomic_add(grad_pose_translations + l3 + 1, one_minus_alpha * gty);
+    atomic_add(grad_pose_translations + l3 + 2, one_minus_alpha * gtz);
+    if(!same)
+    {
+        atomic_add(grad_pose_translations + r3 + 0, alpha * gtx);
+        atomic_add(grad_pose_translations + r3 + 1, alpha * gty);
+        atomic_add(grad_pose_translations + r3 + 2, alpha * gtz);
+    }
+
+    scalar_t grad_alpha = gtx * (pose_translations[r3 + 0] - pose_translations[l3 + 0])
+                        + gty * (pose_translations[r3 + 1] - pose_translations[l3 + 1])
+                        + gtz * (pose_translations[r3 + 2] - pose_translations[l3 + 2]);
+
+    const int64_t out4 = track * 4;
+    const int64_t l4   = left * 4;
+    if(same)
+    {
+        atomic_add(grad_pose_rotations + l4 + 0, grad_out_rotations[out4 + 0]);
+        atomic_add(grad_pose_rotations + l4 + 1, grad_out_rotations[out4 + 1]);
+        atomic_add(grad_pose_rotations + l4 + 2, grad_out_rotations[out4 + 2]);
+        atomic_add(grad_pose_rotations + l4 + 3, grad_out_rotations[out4 + 3]);
+        return;
+    }
+
+    const int64_t r4 = right * 4;
+    scalar_t glqx, glqy, glqz, glqw, grqx, grqy, grqz, grqw, grad_alpha_q;
+    quat_slerp_pair_bwd(
+        pose_rotations[l4 + 0],
+        pose_rotations[l4 + 1],
+        pose_rotations[l4 + 2],
+        pose_rotations[l4 + 3],
+        pose_rotations[r4 + 0],
+        pose_rotations[r4 + 1],
+        pose_rotations[r4 + 2],
+        pose_rotations[r4 + 3],
+        alpha,
+        out_rotations[out4 + 0],
+        out_rotations[out4 + 1],
+        out_rotations[out4 + 2],
+        out_rotations[out4 + 3],
+        grad_out_rotations[out4 + 0],
+        grad_out_rotations[out4 + 1],
+        grad_out_rotations[out4 + 2],
+        grad_out_rotations[out4 + 3],
+        &glqx,
+        &glqy,
+        &glqz,
+        &glqw,
+        &grqx,
+        &grqy,
+        &grqz,
+        &grqw,
+        &grad_alpha_q
+    );
+    atomic_add(grad_pose_rotations + l4 + 0, glqx);
+    atomic_add(grad_pose_rotations + l4 + 1, glqy);
+    atomic_add(grad_pose_rotations + l4 + 2, glqz);
+    atomic_add(grad_pose_rotations + l4 + 3, glqw);
+    atomic_add(grad_pose_rotations + r4 + 0, grqx);
+    atomic_add(grad_pose_rotations + r4 + 1, grqy);
+    atomic_add(grad_pose_rotations + r4 + 2, grqz);
+    atomic_add(grad_pose_rotations + r4 + 3, grqw);
+    grad_alpha += grad_alpha_q;
+
+    accumulate_interpolation_time_grads<scalar_t>(
+        left_time, right_time, clamped_query, valid, left, right, track, grad_alpha, grad_pose_times, grad_query_times
+    );
+}
+
+template<typename scalar_t, typename time_t>
+void launch_se3_interpolate_tracks_fwd(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times,
+    at::Tensor &out_translations,
+    at::Tensor &out_rotations
+)
+{
+    const int64_t n_tracks = pose_offsets.size(0);
+    if(n_tracks == 0)
+    {
+        return;
+    }
+    const int threads         = kThreadsPerBlock;
+    const int blocks          = static_cast<int>((n_tracks + threads - 1) / threads);
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream(pose_translations.device().index());
+    se3_interpolate_tracks_fwd_kernel<scalar_t, time_t><<<blocks, threads, 0, stream>>>(
+        n_tracks,
+        pose_times.size(0),
+        pose_translations.data_ptr<scalar_t>(),
+        pose_rotations.data_ptr<scalar_t>(),
+        pose_times.data_ptr<time_t>(),
+        pose_offsets.data_ptr<int64_t>(),
+        pose_counts.data_ptr<int64_t>(),
+        query_times.data_ptr<time_t>(),
+        out_translations.data_ptr<scalar_t>(),
+        out_rotations.data_ptr<scalar_t>()
+    );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template<typename scalar_t, typename time_t>
+void launch_se3_interpolate_tracks_bwd(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times,
+    const at::Tensor &out_rotations,
+    const at::Tensor &grad_out_translations,
+    const at::Tensor &grad_out_rotations,
+    at::Tensor &grad_pose_translations,
+    at::Tensor &grad_pose_rotations,
+    at::Tensor &grad_pose_times,
+    at::Tensor &grad_query_times
+)
+{
+    const int64_t n_tracks = pose_offsets.size(0);
+    if(n_tracks == 0)
+    {
+        return;
+    }
+    const int threads         = kThreadsPerBlock;
+    const int blocks          = static_cast<int>((n_tracks + threads - 1) / threads);
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream(pose_translations.device().index());
+    se3_interpolate_tracks_bwd_kernel<scalar_t, time_t><<<blocks, threads, 0, stream>>>(
+        n_tracks,
+        pose_times.size(0),
+        pose_translations.data_ptr<scalar_t>(),
+        pose_rotations.data_ptr<scalar_t>(),
+        pose_times.data_ptr<time_t>(),
+        pose_offsets.data_ptr<int64_t>(),
+        pose_counts.data_ptr<int64_t>(),
+        query_times.data_ptr<time_t>(),
+        out_rotations.data_ptr<scalar_t>(),
+        grad_out_translations.data_ptr<scalar_t>(),
+        grad_out_rotations.data_ptr<scalar_t>(),
+        grad_pose_translations.data_ptr<scalar_t>(),
+        grad_pose_rotations.data_ptr<scalar_t>(),
+        grad_pose_times.data_ptr<time_t>(),
+        grad_query_times.data_ptr<time_t>()
+    );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+} // namespace packed_track_cuda
+
+void se3_interpolate_tracks_cuda(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times,
+    at::Tensor &out_translations,
+    at::Tensor &out_rotations
+)
+{
+    AT_DISPATCH_FLOATING_TYPES(
+        pose_translations.scalar_type(),
+        "se3_interpolate_tracks_cuda",
+        [&]
+        {
+            if(pose_times.scalar_type() == at::kLong)
+            {
+                packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, int64_t>(
+                    pose_translations,
+                    pose_rotations,
+                    pose_times,
+                    pose_offsets,
+                    pose_counts,
+                    query_times,
+                    out_translations,
+                    out_rotations
+                );
+            }
+            else if(pose_times.scalar_type() == at::kFloat)
+            {
+                packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, float>(
+                    pose_translations,
+                    pose_rotations,
+                    pose_times,
+                    pose_offsets,
+                    pose_counts,
+                    query_times,
+                    out_translations,
+                    out_rotations
+                );
+            }
+            else if(pose_times.scalar_type() == at::kDouble)
+            {
+                packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, double>(
+                    pose_translations,
+                    pose_rotations,
+                    pose_times,
+                    pose_offsets,
+                    pose_counts,
+                    query_times,
+                    out_translations,
+                    out_rotations
+                );
+            }
+            else
+            {
+                TORCH_CHECK(false, "se3_interpolate_tracks_cuda: unsupported pose_times dtype");
+            }
+        }
+    );
+}
+
+void se3_interpolate_tracks_bwd_cuda(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times,
+    const at::Tensor &out_rotations,
+    const at::Tensor &grad_out_translations,
+    const at::Tensor &grad_out_rotations,
+    at::Tensor &grad_pose_translations,
+    at::Tensor &grad_pose_rotations,
+    at::Tensor &grad_pose_times,
+    at::Tensor &grad_query_times
+)
+{
+    AT_DISPATCH_FLOATING_TYPES(
+        pose_translations.scalar_type(),
+        "se3_interpolate_tracks_bwd_cuda",
+        [&]
+        {
+            if(pose_times.scalar_type() == at::kLong)
+            {
+                packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, int64_t>(
+                    pose_translations,
+                    pose_rotations,
+                    pose_times,
+                    pose_offsets,
+                    pose_counts,
+                    query_times,
+                    out_rotations,
+                    grad_out_translations,
+                    grad_out_rotations,
+                    grad_pose_translations,
+                    grad_pose_rotations,
+                    grad_pose_times,
+                    grad_query_times
+                );
+            }
+            else if(pose_times.scalar_type() == at::kFloat)
+            {
+                packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, float>(
+                    pose_translations,
+                    pose_rotations,
+                    pose_times,
+                    pose_offsets,
+                    pose_counts,
+                    query_times,
+                    out_rotations,
+                    grad_out_translations,
+                    grad_out_rotations,
+                    grad_pose_translations,
+                    grad_pose_rotations,
+                    grad_pose_times,
+                    grad_query_times
+                );
+            }
+            else if(pose_times.scalar_type() == at::kDouble)
+            {
+                packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, double>(
+                    pose_translations,
+                    pose_rotations,
+                    pose_times,
+                    pose_offsets,
+                    pose_counts,
+                    query_times,
+                    out_rotations,
+                    grad_out_translations,
+                    grad_out_rotations,
+                    grad_pose_translations,
+                    grad_pose_rotations,
+                    grad_pose_times,
+                    grad_query_times
+                );
+            }
+            else
+            {
+                TORCH_CHECK(false, "se3_interpolate_tracks_bwd_cuda: unsupported pose_times dtype");
+            }
+        }
+    );
+}
 
 // Public CUDA entrypoint for 2-keyframe trajectory point interpolation.
 // Inputs: keyframe translations/rotations/times, point (N,3), and query_time.

--- a/gsplat/geometry/kernels/cuda/csrc/pose.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/pose.cuh
@@ -250,37 +250,7 @@ __forceinline__ __device__ void quat_slerp_pair_fwd_f(
     float *ow
 )
 {
-    const float dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const float s   = dot < 0.0f ? -1.0f : 1.0f;
-    const float sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const float c_raw    = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const float c        = quat_slerp_clamp_dot<float>(c_raw);
-    const float small_th = quat_slerp_small_angle_dot_threshold<float>();
-
-    if(c > small_th)
-    {
-        const float om      = 1.0f - ti;
-        const float rx      = om * x1 + ti * sx;
-        const float ry      = om * y1 + ti * sy;
-        const float rz      = om * z1 + ti * sz;
-        const float rw      = om * w1 + ti * sw;
-        const float norm_sq = rx * rx + ry * ry + rz * rz + rw * rw;
-        const float inv_n   = 1.0f / sqrtf(norm_sq);
-        *ox                 = rx * inv_n;
-        *oy                 = ry * inv_n;
-        *oz                 = rz * inv_n;
-        *ow                 = rw * inv_n;
-        return;
-    }
-
-    const float theta     = acosf(c);
-    const float sin_theta = sinf(theta);
-    const float w1s       = sinf((1.0f - ti) * theta) / sin_theta;
-    const float w2s       = sinf(ti * theta) / sin_theta;
-    *ox                   = w1s * x1 + w2s * sx;
-    *oy                   = w1s * y1 + w2s * sy;
-    *oz                   = w1s * z1 + w2s * sz;
-    *ow                   = w1s * w1 + w2s * sw;
+    quat_slerp_pair_fwd<float>(x1, y1, z1, w1, x2, y2, z2, w2, ti, ox, oy, oz, ow);
 }
 
 // VJP for quat_slerp_pair_fwd_f: forward outputs (rx,ry,rz,rw) and upstream (gx..gw) → *gq1*, *gq2*, *grad_t.
@@ -313,72 +283,34 @@ __forceinline__ __device__ void quat_slerp_pair_bwd_f(
     float *grad_t
 )
 {
-    const float dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const float s   = dot < 0.0f ? -1.0f : 1.0f;
-    const float sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const float c_raw     = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const float c         = quat_slerp_clamp_dot<float>(c_raw);
-    const bool interior_c = (c_raw > -1.0f) && (c_raw < 1.0f);
-    const float c_mask    = interior_c ? 1.0f : 0.0f;
-    const float small_th  = quat_slerp_small_angle_dot_threshold<float>();
-
-    if(c > small_th)
-    {
-        const float om      = 1.0f - ti;
-        const float rrx     = om * x1 + ti * sx;
-        const float rry     = om * y1 + ti * sy;
-        const float rrz     = om * z1 + ti * sz;
-        const float rrw     = om * w1 + ti * sw;
-        const float norm_sq = rrx * rrx + rry * rry + rrz * rrz + rrw * rrw;
-        const float r_norm  = sqrtf(norm_sq);
-        const float yx = rx, yy = ry, yz = rz, yw = rw;
-        const float ydotg     = yx * gx + yy * gy + yz * gz + yw * gw;
-        const float scale     = 1.0f / r_norm;
-        const float grx       = (gx - yx * ydotg) * scale;
-        const float gry       = (gy - yy * ydotg) * scale;
-        const float grz       = (gz - yz * ydotg) * scale;
-        const float grw       = (gw - yw * ydotg) * scale;
-        *gq1x                 = om * grx;
-        *gq1y                 = om * gry;
-        *gq1z                 = om * grz;
-        *gq1w                 = om * grw;
-        *gq2x                 = s * ti * grx;
-        *gq2y                 = s * ti * gry;
-        *gq2z                 = s * ti * grz;
-        *gq2w                 = s * ti * grw;
-        const float dq2m_dq1x = sx - x1, dq2m_dq1y = sy - y1, dq2m_dq1z = sz - z1, dq2m_dq1w = sw - w1;
-        *grad_t = grx * dq2m_dq1x + gry * dq2m_dq1y + grz * dq2m_dq1z + grw * dq2m_dq1w;
-        return;
-    }
-
-    const float theta     = acosf(c);
-    const float sin_theta = sinf(theta);
-    const float w1s       = sinf((1.0f - ti) * theta) / sin_theta;
-    const float w2s       = sinf(ti * theta) / sin_theta;
-    const float G1        = gx * x1 + gy * y1 + gz * z1 + gw * w1;
-    const float G2        = gx * sx + gy * sy + gz * sz + gw * sw;
-    const float den       = sin_theta * sin_theta;
-    const float dw1_dtheta
-        = ((1.0f - ti) * cosf((1.0f - ti) * theta) * sin_theta - sinf((1.0f - ti) * theta) * c) / den;
-    const float dw2_dtheta = (ti * cosf(ti * theta) * sin_theta - sinf(ti * theta) * c) / den;
-    const float dw1_dc     = sin_theta > 1e-20f ? (-dw1_dtheta / sin_theta) * c_mask : 0.0f;
-    const float dw2_dc     = sin_theta > 1e-20f ? (-dw2_dtheta / sin_theta) * c_mask : 0.0f;
-    const float K          = G1 * dw1_dc + G2 * dw2_dc;
-    *gq1x                  = w1s * gx + K * sx;
-    *gq1y                  = w1s * gy + K * sy;
-    *gq1z                  = w1s * gz + K * sz;
-    *gq1w                  = w1s * gw + K * sw;
-    const float gq2ex      = w2s * gx + K * x1;
-    const float gq2ey      = w2s * gy + K * y1;
-    const float gq2ez      = w2s * gz + K * z1;
-    const float gq2ew      = w2s * gw + K * w1;
-    *gq2x                  = s * gq2ex;
-    *gq2y                  = s * gq2ey;
-    *gq2z                  = s * gq2ez;
-    *gq2w                  = s * gq2ew;
-    const float dw1_dt     = -theta * cosf((1.0f - ti) * theta) / sin_theta;
-    const float dw2_dt     = theta * cosf(ti * theta) / sin_theta;
-    *grad_t                = G1 * dw1_dt + G2 * dw2_dt;
+    quat_slerp_pair_bwd<float>(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        ti,
+        rx,
+        ry,
+        rz,
+        rw,
+        gx,
+        gy,
+        gz,
+        gw,
+        gq1x,
+        gq1y,
+        gq1z,
+        gq1w,
+        gq2x,
+        gq2y,
+        gq2z,
+        gq2w,
+        grad_t
+    );
 }
 
 // Time-interpolation chain rule: grad_alpha = ∂L/∂α with α=(qt-t_min)/(t_max-t_min), d=t_max-t_min.
@@ -946,6 +878,154 @@ __forceinline__ __device__ void frame_transform_poses_tquat_fwd_device(
 }
 } // namespace trajectory_cuda
 
+namespace packed_track_cuda
+{
+template<typename scalar_t>
+__forceinline__ __device__ void atomic_add(scalar_t *__restrict__ address, scalar_t value)
+{
+    atomicAdd(address, value);
+}
+
+template<typename time_t>
+__forceinline__ __device__ time_t clamp_time(time_t value, time_t first, time_t last)
+{
+    return value < first ? first : (value > last ? last : value);
+}
+
+template<typename time_t>
+__forceinline__ __device__ int64_t
+    lower_bound_local(const time_t *__restrict__ times, int64_t start, int64_t count, time_t query)
+{
+    int64_t lo = 0;
+    int64_t hi = count;
+    while(lo < hi)
+    {
+        const int64_t mid = lo + ((hi - lo) >> 1);
+        if(times[start + mid] < query)
+        {
+            lo = mid + 1;
+        }
+        else
+        {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+template<typename scalar_t, typename time_t>
+__forceinline__ __device__ scalar_t interpolation_alpha(time_t left, time_t right, time_t query, bool valid)
+{
+    if(!valid)
+    {
+        return scalar_t(0);
+    }
+    return static_cast<scalar_t>((query - left) / (right - left));
+}
+
+template<typename scalar_t>
+__forceinline__ __device__ scalar_t interpolation_alpha(int64_t left, int64_t right, int64_t query, bool valid)
+{
+    if(!valid)
+    {
+        return scalar_t(0);
+    }
+    const bool numerator_fits   = !((left > 0 && query < INT64_MIN + left) || (left < 0 && query > INT64_MAX + left));
+    const bool denominator_fits = !((left > 0 && right < INT64_MIN + left) || (left < 0 && right > INT64_MAX + left));
+    const double numerator
+        = numerator_fits ? static_cast<double>(query - left) : static_cast<double>(query) - static_cast<double>(left);
+    const double denominator
+        = denominator_fits ? static_cast<double>(right - left) : static_cast<double>(right) - static_cast<double>(left);
+    return denominator != 0.0 ? static_cast<scalar_t>(numerator / denominator) : scalar_t(0);
+}
+
+__forceinline__ __device__ bool valid_track_range(int64_t start, int64_t count, int64_t n_poses)
+{
+    return start >= 0 && count > 0 && start <= n_poses && count <= n_poses - start;
+}
+
+template<typename scalar_t, typename time_t>
+__forceinline__ __device__ void accumulate_interpolation_time_grads(
+    time_t left_time,
+    time_t right_time,
+    time_t clamped_query,
+    bool valid,
+    int64_t left,
+    int64_t right,
+    int64_t track,
+    scalar_t grad_alpha,
+    time_t *__restrict__ grad_pose_times,
+    time_t *__restrict__ grad_query_times
+)
+{
+    const time_t d = right_time - left_time;
+    if(valid && d != time_t(0))
+    {
+        const time_t grad_alpha_t = static_cast<time_t>(grad_alpha);
+        const time_t d2           = d * d;
+        atomic_add(grad_pose_times + left, grad_alpha_t * (clamped_query - right_time) / d2);
+        atomic_add(grad_pose_times + right, -grad_alpha_t * (clamped_query - left_time) / d2);
+        grad_query_times[track] = grad_alpha_t / d;
+    }
+}
+
+template<typename scalar_t>
+__forceinline__ __device__ void accumulate_interpolation_time_grads(
+    int64_t, int64_t, int64_t, bool, int64_t, int64_t, int64_t, scalar_t, int64_t *__restrict__, int64_t *__restrict__
+)
+{
+}
+
+template<typename time_t>
+__forceinline__ __device__ void track_interval(
+    const time_t *__restrict__ times,
+    int64_t start,
+    int64_t count,
+    time_t query,
+    int64_t *left_index,
+    int64_t *right_index,
+    bool *same_pose,
+    bool *valid_interval,
+    time_t *clamped_query,
+    time_t *left_time,
+    time_t *right_time
+)
+{
+    const time_t first_time  = times[start];
+    const time_t last_time   = times[start + count - 1];
+    const time_t clamped     = clamp_time(query, first_time, last_time);
+    int64_t right_local      = lower_bound_local(times, start, count, clamped);
+    const int64_t last_local = count - 1;
+    if(query <= first_time)
+    {
+        right_local = 0;
+    }
+    else if(query > last_time)
+    {
+        right_local = last_local;
+    }
+    else if(right_local > last_local)
+    {
+        right_local = last_local;
+    }
+
+    const int64_t right       = start + right_local;
+    const time_t rt           = times[right];
+    const bool exact_or_first = right_local == 0 || rt == clamped;
+    const int64_t left_local  = exact_or_first ? right_local : right_local - 1;
+    const int64_t left        = start + left_local;
+    const time_t lt           = times[left];
+    const bool same           = left == right;
+    *left_index               = left;
+    *right_index              = right;
+    *same_pose                = same;
+    *valid_interval           = !same && rt != lt;
+    *clamped_query            = clamped;
+    *left_time                = lt;
+    *right_time               = rt;
+}
+} // namespace packed_track_cuda
+
 // Batch row i: out = R(q_i) p_i + t_i. translation/point (N,3), rotation (N,4) xyzw, contiguous row-major.
 template<typename scalar_t>
 __device__ void se3pose_transform_point_fwd_device(
@@ -967,6 +1047,143 @@ __device__ void se3pose_transform_point_fwd_device(
     out[ot + 0] = rx + tx;
     out[ot + 1] = ry + ty;
     out[ot + 2] = rz + tz;
+}
+
+// Batch row i: out = parent * child for SE(3) poses. Translation is
+// R(parent_q) child_t + parent_t; rotation is parent_q ⊗ child_q.
+template<typename scalar_t>
+__device__ void se3pose_compose_fwd_device(
+    int64_t i,
+    int64_t n,
+    const scalar_t *__restrict__ parent_translation,
+    const scalar_t *__restrict__ parent_rotation,
+    const scalar_t *__restrict__ child_translation,
+    const scalar_t *__restrict__ child_rotation,
+    scalar_t *__restrict__ out_translation,
+    scalar_t *__restrict__ out_rotation
+)
+{
+    const int64_t ot = i * 3;
+    const int64_t oq = i * 4;
+
+    const scalar_t pqx = parent_rotation[oq + 0];
+    const scalar_t pqy = parent_rotation[oq + 1];
+    const scalar_t pqz = parent_rotation[oq + 2];
+    const scalar_t pqw = parent_rotation[oq + 3];
+    const scalar_t ctx = child_translation[ot + 0];
+    const scalar_t cty = child_translation[ot + 1];
+    const scalar_t ctz = child_translation[ot + 2];
+
+    scalar_t rtx = 0, rty = 0, rtz = 0;
+    quat_rotate_vector_fwd_impl(pqx, pqy, pqz, pqw, ctx, cty, ctz, &rtx, &rty, &rtz);
+    out_translation[ot + 0] = rtx + parent_translation[ot + 0];
+    out_translation[ot + 1] = rty + parent_translation[ot + 1];
+    out_translation[ot + 2] = rtz + parent_translation[ot + 2];
+
+    quat_multiply_impl(
+        pqx,
+        pqy,
+        pqz,
+        pqw,
+        child_rotation[oq + 0],
+        child_rotation[oq + 1],
+        child_rotation[oq + 2],
+        child_rotation[oq + 3],
+        out_rotation + oq + 0,
+        out_rotation + oq + 1,
+        out_rotation + oq + 2,
+        out_rotation + oq + 3
+    );
+}
+
+// VJP for se3pose_compose_fwd_device.
+template<typename scalar_t>
+__device__ void se3pose_compose_bwd_device(
+    int64_t i,
+    int64_t n,
+    const scalar_t *__restrict__ parent_translation,
+    const scalar_t *__restrict__ parent_rotation,
+    const scalar_t *__restrict__ child_translation,
+    const scalar_t *__restrict__ child_rotation,
+    const scalar_t *__restrict__ grad_out_translation,
+    const scalar_t *__restrict__ grad_out_rotation,
+    scalar_t *__restrict__ grad_parent_translation,
+    scalar_t *__restrict__ grad_parent_rotation,
+    scalar_t *__restrict__ grad_child_translation,
+    scalar_t *__restrict__ grad_child_rotation
+)
+{
+    const int64_t ot = i * 3;
+    const int64_t oq = i * 4;
+
+    const scalar_t pqx = parent_rotation[oq + 0];
+    const scalar_t pqy = parent_rotation[oq + 1];
+    const scalar_t pqz = parent_rotation[oq + 2];
+    const scalar_t pqw = parent_rotation[oq + 3];
+    const scalar_t ctx = child_translation[ot + 0];
+    const scalar_t cty = child_translation[ot + 1];
+    const scalar_t ctz = child_translation[ot + 2];
+    const scalar_t gtx = grad_out_translation[ot + 0];
+    const scalar_t gty = grad_out_translation[ot + 1];
+    const scalar_t gtz = grad_out_translation[ot + 2];
+
+    scalar_t g_parent_q_tx = 0, g_parent_q_ty = 0, g_parent_q_tz = 0, g_parent_q_tw = 0;
+    scalar_t g_child_tx = 0, g_child_ty = 0, g_child_tz = 0;
+    quat_rotate_vector_bwd_impl(
+        pqx,
+        pqy,
+        pqz,
+        pqw,
+        ctx,
+        cty,
+        ctz,
+        gtx,
+        gty,
+        gtz,
+        &g_parent_q_tx,
+        &g_parent_q_ty,
+        &g_parent_q_tz,
+        &g_parent_q_tw,
+        &g_child_tx,
+        &g_child_ty,
+        &g_child_tz
+    );
+
+    grad_parent_translation[ot + 0] = gtx;
+    grad_parent_translation[ot + 1] = gty;
+    grad_parent_translation[ot + 2] = gtz;
+    grad_child_translation[ot + 0]  = g_child_tx;
+    grad_child_translation[ot + 1]  = g_child_ty;
+    grad_child_translation[ot + 2]  = g_child_tz;
+
+    scalar_t g_parent_q_rx = 0, g_parent_q_ry = 0, g_parent_q_rz = 0, g_parent_q_rw = 0;
+    quat_multiply_bwd_impl(
+        pqx,
+        pqy,
+        pqz,
+        pqw,
+        child_rotation[oq + 0],
+        child_rotation[oq + 1],
+        child_rotation[oq + 2],
+        child_rotation[oq + 3],
+        grad_out_rotation[oq + 0],
+        grad_out_rotation[oq + 1],
+        grad_out_rotation[oq + 2],
+        grad_out_rotation[oq + 3],
+        &g_parent_q_rx,
+        &g_parent_q_ry,
+        &g_parent_q_rz,
+        &g_parent_q_rw,
+        grad_child_rotation + oq + 0,
+        grad_child_rotation + oq + 1,
+        grad_child_rotation + oq + 2,
+        grad_child_rotation + oq + 3
+    );
+
+    grad_parent_rotation[oq + 0] = g_parent_q_tx + g_parent_q_rx;
+    grad_parent_rotation[oq + 1] = g_parent_q_ty + g_parent_q_ry;
+    grad_parent_rotation[oq + 2] = g_parent_q_tz + g_parent_q_rz;
+    grad_parent_rotation[oq + 3] = g_parent_q_tw + g_parent_q_rw;
 }
 
 // Batch row i: out = R(q_i) d_i (3-vector); rotation xyzw (N,4), direction/out (N,3).

--- a/gsplat/geometry/kernels/cuda/csrc/quaternion.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/quaternion.cuh
@@ -148,6 +148,42 @@ __forceinline__ __device__ void quat_multiply_impl(
     *ow               = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2;
 }
 
+// VJP for Hamilton product q_out = q1 ⊗ q2, all quaternions in xyzw order.
+template<typename scalar_t>
+__forceinline__ __device__ void quat_multiply_bwd_impl(
+    scalar_t x1,
+    scalar_t y1,
+    scalar_t z1,
+    scalar_t w1,
+    scalar_t x2,
+    scalar_t y2,
+    scalar_t z2,
+    scalar_t w2,
+    scalar_t gx,
+    scalar_t gy,
+    scalar_t gz,
+    scalar_t gw,
+    scalar_t *gq1x,
+    scalar_t *gq1y,
+    scalar_t *gq1z,
+    scalar_t *gq1w,
+    scalar_t *gq2x,
+    scalar_t *gq2y,
+    scalar_t *gq2z,
+    scalar_t *gq2w
+)
+{
+    *gq1x = w2 * gx - z2 * gy + y2 * gz - x2 * gw;
+    *gq1y = z2 * gx + w2 * gy - x2 * gz - y2 * gw;
+    *gq1z = -y2 * gx + x2 * gy + w2 * gz - z2 * gw;
+    *gq1w = x2 * gx + y2 * gy + z2 * gz + w2 * gw;
+
+    *gq2x = w1 * gx + z1 * gy - y1 * gz - x1 * gw;
+    *gq2y = -z1 * gx + w1 * gy + x1 * gz - y1 * gw;
+    *gq2z = y1 * gx - x1 * gy + w1 * gz - z1 * gw;
+    *gq2w = x1 * gx + y1 * gy + z1 * gz + w1 * gw;
+}
+
 // -----------------------------------------------------------------------------
 // quat_to_matrix using the native CUDA normalize-and-convert path.
 // -----------------------------------------------------------------------------
@@ -302,6 +338,161 @@ template<typename scalar_t>
 __forceinline__ __device__ scalar_t quat_slerp_small_angle_dot_threshold()
 {
     return scalar_t(0.9995);
+}
+
+// Scalar SLERP(q1, q2, t) in xyzw order. Used by batched quaternion, trajectory,
+// and packed pose-track kernels so the hemisphere, clamp, and small-angle paths
+// stay identical.
+template<typename scalar_t>
+__forceinline__ __device__ void quat_slerp_pair_fwd(
+    scalar_t x1,
+    scalar_t y1,
+    scalar_t z1,
+    scalar_t w1,
+    scalar_t x2,
+    scalar_t y2,
+    scalar_t z2,
+    scalar_t w2,
+    scalar_t ti,
+    scalar_t *ox,
+    scalar_t *oy,
+    scalar_t *oz,
+    scalar_t *ow
+)
+{
+    const scalar_t dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
+    const scalar_t s   = dot < scalar_t(0) ? scalar_t(-1) : scalar_t(1);
+    const scalar_t sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
+    const scalar_t c_raw = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
+    const scalar_t c     = quat_slerp_clamp_dot(c_raw);
+
+    if(c > quat_slerp_small_angle_dot_threshold<scalar_t>())
+    {
+        const scalar_t om      = scalar_t(1) - ti;
+        const scalar_t rx      = om * x1 + ti * sx;
+        const scalar_t ry      = om * y1 + ti * sy;
+        const scalar_t rz      = om * z1 + ti * sz;
+        const scalar_t rw      = om * w1 + ti * sw;
+        const scalar_t norm_sq = rx * rx + ry * ry + rz * rz + rw * rw;
+        const scalar_t inv_n   = scalar_t(1) / sqrt(norm_sq);
+        *ox                    = rx * inv_n;
+        *oy                    = ry * inv_n;
+        *oz                    = rz * inv_n;
+        *ow                    = rw * inv_n;
+        return;
+    }
+
+    const scalar_t theta     = acos(c);
+    const scalar_t sin_theta = sin(theta);
+    const scalar_t w1s       = sin((scalar_t(1) - ti) * theta) / sin_theta;
+    const scalar_t w2s       = sin(ti * theta) / sin_theta;
+    *ox                      = w1s * x1 + w2s * sx;
+    *oy                      = w1s * y1 + w2s * sy;
+    *oz                      = w1s * z1 + w2s * sz;
+    *ow                      = w1s * w1 + w2s * sw;
+}
+
+// VJP for quat_slerp_pair_fwd. `rx..rw` are the forward outputs and
+// `gx..gw` is upstream dL/dout.
+template<typename scalar_t>
+__forceinline__ __device__ void quat_slerp_pair_bwd(
+    scalar_t x1,
+    scalar_t y1,
+    scalar_t z1,
+    scalar_t w1,
+    scalar_t x2,
+    scalar_t y2,
+    scalar_t z2,
+    scalar_t w2,
+    scalar_t ti,
+    scalar_t rx,
+    scalar_t ry,
+    scalar_t rz,
+    scalar_t rw,
+    scalar_t gx,
+    scalar_t gy,
+    scalar_t gz,
+    scalar_t gw,
+    scalar_t *gq1x,
+    scalar_t *gq1y,
+    scalar_t *gq1z,
+    scalar_t *gq1w,
+    scalar_t *gq2x,
+    scalar_t *gq2y,
+    scalar_t *gq2z,
+    scalar_t *gq2w,
+    scalar_t *grad_t
+)
+{
+    const scalar_t dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
+    const scalar_t s   = dot < scalar_t(0) ? scalar_t(-1) : scalar_t(1);
+    const scalar_t sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
+    const scalar_t c_raw  = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
+    const scalar_t c      = quat_slerp_clamp_dot(c_raw);
+    const bool interior_c = (c_raw > scalar_t(-1)) && (c_raw < scalar_t(1));
+    const scalar_t c_mask = interior_c ? scalar_t(1) : scalar_t(0);
+
+    if(c > quat_slerp_small_angle_dot_threshold<scalar_t>())
+    {
+        const scalar_t om      = scalar_t(1) - ti;
+        const scalar_t rrx     = om * x1 + ti * sx;
+        const scalar_t rry     = om * y1 + ti * sy;
+        const scalar_t rrz     = om * z1 + ti * sz;
+        const scalar_t rrw     = om * w1 + ti * sw;
+        const scalar_t norm_sq = rrx * rrx + rry * rry + rrz * rrz + rrw * rrw;
+        const scalar_t r_norm  = sqrt(norm_sq);
+        const scalar_t ydotg   = rx * gx + ry * gy + rz * gz + rw * gw;
+        const scalar_t scale   = scalar_t(1) / r_norm;
+        const scalar_t grx     = (gx - rx * ydotg) * scale;
+        const scalar_t gry     = (gy - ry * ydotg) * scale;
+        const scalar_t grz     = (gz - rz * ydotg) * scale;
+        const scalar_t grw     = (gw - rw * ydotg) * scale;
+
+        *gq1x = om * grx;
+        *gq1y = om * gry;
+        *gq1z = om * grz;
+        *gq1w = om * grw;
+        *gq2x = s * ti * grx;
+        *gq2y = s * ti * gry;
+        *gq2z = s * ti * grz;
+        *gq2w = s * ti * grw;
+
+        *grad_t = grx * (sx - x1) + gry * (sy - y1) + grz * (sz - z1) + grw * (sw - w1);
+        return;
+    }
+
+    const scalar_t theta     = acos(c);
+    const scalar_t sin_theta = sin(theta);
+    const scalar_t w1s       = sin((scalar_t(1) - ti) * theta) / sin_theta;
+    const scalar_t w2s       = sin(ti * theta) / sin_theta;
+    const scalar_t G1        = gx * x1 + gy * y1 + gz * z1 + gw * w1;
+    const scalar_t G2        = gx * sx + gy * sy + gz * sz + gw * sw;
+    const scalar_t den       = sin_theta * sin_theta;
+    const scalar_t dw1_dtheta
+        = ((scalar_t(1) - ti) * cos((scalar_t(1) - ti) * theta) * sin_theta - sin((scalar_t(1) - ti) * theta) * c)
+        / den;
+    const scalar_t dw2_dtheta = (ti * cos(ti * theta) * sin_theta - sin(ti * theta) * c) / den;
+    const scalar_t dw1_dc     = sin_theta > scalar_t(1e-20) ? (-dw1_dtheta / sin_theta) * c_mask : scalar_t(0);
+    const scalar_t dw2_dc     = sin_theta > scalar_t(1e-20) ? (-dw2_dtheta / sin_theta) * c_mask : scalar_t(0);
+    const scalar_t K          = G1 * dw1_dc + G2 * dw2_dc;
+
+    *gq1x = w1s * gx + K * sx;
+    *gq1y = w1s * gy + K * sy;
+    *gq1z = w1s * gz + K * sz;
+    *gq1w = w1s * gw + K * sw;
+
+    const scalar_t gq2ex = w2s * gx + K * x1;
+    const scalar_t gq2ey = w2s * gy + K * y1;
+    const scalar_t gq2ez = w2s * gz + K * z1;
+    const scalar_t gq2ew = w2s * gw + K * w1;
+    *gq2x                = s * gq2ex;
+    *gq2y                = s * gq2ey;
+    *gq2z                = s * gq2ez;
+    *gq2w                = s * gq2ew;
+
+    const scalar_t dw1_dt = -theta * cos((scalar_t(1) - ti) * theta) / sin_theta;
+    const scalar_t dw2_dt = theta * cos(ti * theta) / sin_theta;
+    *grad_t               = G1 * dw1_dt + G2 * dw2_dt;
 }
 
 // -----------------------------------------------------------------------------
@@ -650,17 +841,28 @@ __device__ void quat_multiply_bwd_device(
     const scalar_t x2 = q2[o + 0], y2 = q2[o + 1], z2 = q2[o + 2], w2 = q2[o + 3];
     const scalar_t gx = grad_out[o + 0], gy = grad_out[o + 1], gz = grad_out[o + 2], gw = grad_out[o + 3];
 
-    // grad_q1 = J1^T * grad_out (q2 fixed)
-    grad_q1[o + 0] = w2 * gx - z2 * gy + y2 * gz - x2 * gw;
-    grad_q1[o + 1] = z2 * gx + w2 * gy - x2 * gz - y2 * gw;
-    grad_q1[o + 2] = -y2 * gx + x2 * gy + w2 * gz - z2 * gw;
-    grad_q1[o + 3] = x2 * gx + y2 * gy + z2 * gz + w2 * gw;
-
-    // grad_q2 = J2^T * grad_out (q2 variable, q1 fixed); J2 is left-multiply by q1
-    grad_q2[o + 0] = w1 * gx + z1 * gy - y1 * gz - x1 * gw;
-    grad_q2[o + 1] = -z1 * gx + w1 * gy + x1 * gz - y1 * gw;
-    grad_q2[o + 2] = y1 * gx - x1 * gy + w1 * gz - z1 * gw;
-    grad_q2[o + 3] = x1 * gx + y1 * gy + z1 * gz + w1 * gw;
+    quat_multiply_bwd_impl(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        gx,
+        gy,
+        gz,
+        gw,
+        grad_q1 + o + 0,
+        grad_q1 + o + 1,
+        grad_q1 + o + 2,
+        grad_q1 + o + 3,
+        grad_q2 + o + 0,
+        grad_q2 + o + 1,
+        grad_q2 + o + 2,
+        grad_q2 + o + 3
+    );
 }
 
 // Batch row i: out_i = R(q_i) v_i. quat: (N,4) xyzw flat; vec/out: (N,3) row-major (o = i*3 / i*4).
@@ -1008,36 +1210,7 @@ __device__ void quat_slerp_batched_fwd_device(
     const scalar_t ti = t[i];
     const scalar_t x1 = q1[o + 0], y1 = q1[o + 1], z1 = q1[o + 2], w1 = q1[o + 3];
     const scalar_t x2 = q2[o + 0], y2 = q2[o + 1], z2 = q2[o + 2], w2 = q2[o + 3];
-    const scalar_t dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    scalar_t s         = dot < scalar_t(0) ? scalar_t(-1) : scalar_t(1);
-    const scalar_t sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const scalar_t c_raw = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const scalar_t c     = quat_slerp_clamp_dot(c_raw);
-
-    if(c > quat_slerp_small_angle_dot_threshold<scalar_t>())
-    {
-        const scalar_t om      = scalar_t(1) - ti;
-        const scalar_t rx      = om * x1 + ti * sx;
-        const scalar_t ry      = om * y1 + ti * sy;
-        const scalar_t rz      = om * z1 + ti * sz;
-        const scalar_t rw      = om * w1 + ti * sw;
-        const scalar_t norm_sq = rx * rx + ry * ry + rz * rz + rw * rw;
-        const scalar_t inv_n   = scalar_t(1) / sqrt(norm_sq);
-        out[o + 0]             = rx * inv_n;
-        out[o + 1]             = ry * inv_n;
-        out[o + 2]             = rz * inv_n;
-        out[o + 3]             = rw * inv_n;
-        return;
-    }
-
-    const scalar_t theta     = acos(c);
-    const scalar_t sin_theta = sin(theta);
-    const scalar_t w1s       = sin((scalar_t(1) - ti) * theta) / sin_theta;
-    const scalar_t w2s       = sin(ti * theta) / sin_theta;
-    out[o + 0]               = w1s * x1 + w2s * sx;
-    out[o + 1]               = w1s * y1 + w2s * sy;
-    out[o + 2]               = w1s * z1 + w2s * sz;
-    out[o + 3]               = w1s * w1 + w2s * sw;
+    quat_slerp_pair_fwd(x1, y1, z1, w1, x2, y2, z2, w2, ti, out + o + 0, out + o + 1, out + o + 2, out + o + 3);
 }
 
 // VJP for quat_slerp_batched_fwd_device: grad_out (xyzw), forward `result`; outputs grad_q1, grad_q2, grad_t[i].
@@ -1060,84 +1233,34 @@ __device__ void quat_slerp_batched_bwd_device(
     const scalar_t x1 = q1[o + 0], y1 = q1[o + 1], z1 = q1[o + 2], w1 = q1[o + 3];
     const scalar_t x2 = q2[o + 0], y2 = q2[o + 1], z2 = q2[o + 2], w2 = q2[o + 3];
     const scalar_t gx = grad_out[o + 0], gy = grad_out[o + 1], gz = grad_out[o + 2], gw = grad_out[o + 3];
-
-    const scalar_t dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const scalar_t s   = dot < scalar_t(0) ? scalar_t(-1) : scalar_t(1);
-    const scalar_t sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const scalar_t c_raw  = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const scalar_t c      = quat_slerp_clamp_dot(c_raw);
-    const bool interior_c = (c_raw > scalar_t(-1)) && (c_raw < scalar_t(1));
-    const scalar_t c_mask = interior_c ? scalar_t(1) : scalar_t(0);
-
-    if(c > quat_slerp_small_angle_dot_threshold<scalar_t>())
-    {
-        const scalar_t om      = scalar_t(1) - ti;
-        const scalar_t rx      = om * x1 + ti * sx;
-        const scalar_t ry      = om * y1 + ti * sy;
-        const scalar_t rz      = om * z1 + ti * sz;
-        const scalar_t rw      = om * w1 + ti * sw;
-        const scalar_t norm_sq = rx * rx + ry * ry + rz * rz + rw * rw;
-        const scalar_t r_norm  = sqrt(norm_sq);
-
-        const scalar_t yx = result[o + 0], yy = result[o + 1], yz = result[o + 2], yw = result[o + 3];
-        const scalar_t ydotg = yx * gx + yy * gy + yz * gz + yw * gw;
-        const scalar_t scale = scalar_t(1) / r_norm;
-        const scalar_t grx   = (gx - yx * ydotg) * scale;
-        const scalar_t gry   = (gy - yy * ydotg) * scale;
-        const scalar_t grz   = (gz - yz * ydotg) * scale;
-        const scalar_t grw   = (gw - yw * ydotg) * scale;
-
-        grad_q1[o + 0] = om * grx;
-        grad_q1[o + 1] = om * gry;
-        grad_q1[o + 2] = om * grz;
-        grad_q1[o + 3] = om * grw;
-
-        grad_q2[o + 0] = s * ti * grx;
-        grad_q2[o + 1] = s * ti * gry;
-        grad_q2[o + 2] = s * ti * grz;
-        grad_q2[o + 3] = s * ti * grw;
-
-        const scalar_t dq2m_dq1x = sx - x1, dq2m_dq1y = sy - y1, dq2m_dq1z = sz - z1, dq2m_dq1w = sw - w1;
-        grad_t[i] = grx * dq2m_dq1x + gry * dq2m_dq1y + grz * dq2m_dq1z + grw * dq2m_dq1w;
-        return;
-    }
-
-    const scalar_t theta     = acos(c);
-    const scalar_t sin_theta = sin(theta);
-    const scalar_t w1s       = sin((scalar_t(1) - ti) * theta) / sin_theta;
-    const scalar_t w2s       = sin(ti * theta) / sin_theta;
-
-    const scalar_t G1 = gx * x1 + gy * y1 + gz * z1 + gw * w1;
-    const scalar_t G2 = gx * sx + gy * sy + gz * sz + gw * sw;
-
-    const scalar_t den = sin_theta * sin_theta;
-    const scalar_t dw1_dtheta
-        = ((scalar_t(1) - ti) * cos((scalar_t(1) - ti) * theta) * sin_theta - sin((scalar_t(1) - ti) * theta) * c)
-        / den;
-    const scalar_t dw2_dtheta = (ti * cos(ti * theta) * sin_theta - sin(ti * theta) * c) / den;
-    const scalar_t dw1_dc     = sin_theta > scalar_t(1e-20) ? (-dw1_dtheta / sin_theta) * c_mask : scalar_t(0);
-    const scalar_t dw2_dc     = sin_theta > scalar_t(1e-20) ? (-dw2_dtheta / sin_theta) * c_mask : scalar_t(0);
-
-    const scalar_t K = G1 * dw1_dc + G2 * dw2_dc;
-
-    grad_q1[o + 0] = w1s * gx + K * sx;
-    grad_q1[o + 1] = w1s * gy + K * sy;
-    grad_q1[o + 2] = w1s * gz + K * sz;
-    grad_q1[o + 3] = w1s * gw + K * sw;
-
-    const scalar_t gq2ex = w2s * gx + K * x1;
-    const scalar_t gq2ey = w2s * gy + K * y1;
-    const scalar_t gq2ez = w2s * gz + K * z1;
-    const scalar_t gq2ew = w2s * gw + K * w1;
-
-    grad_q2[o + 0] = s * gq2ex;
-    grad_q2[o + 1] = s * gq2ey;
-    grad_q2[o + 2] = s * gq2ez;
-    grad_q2[o + 3] = s * gq2ew;
-
-    const scalar_t dw1_dt = -theta * cos((scalar_t(1) - ti) * theta) / sin_theta;
-    const scalar_t dw2_dt = theta * cos(ti * theta) / sin_theta;
-    grad_t[i]             = G1 * dw1_dt + G2 * dw2_dt;
+    quat_slerp_pair_bwd(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        ti,
+        result[o + 0],
+        result[o + 1],
+        result[o + 2],
+        result[o + 3],
+        gx,
+        gy,
+        gz,
+        gw,
+        grad_q1 + o + 0,
+        grad_q1 + o + 1,
+        grad_q1 + o + 2,
+        grad_q1 + o + 3,
+        grad_q2 + o + 0,
+        grad_q2 + o + 1,
+        grad_q2 + o + 2,
+        grad_q2 + o + 3,
+        grad_t + i
+    );
 }
 
 // Batch row i: angular distance 2·acos(|⟨q̂1,q̂2⟩|) radians after normalizing both quaternions (xyzw); dist_out[i] scalar.

--- a/gsplat/geometry/kernels/cuda/ext.cpp
+++ b/gsplat/geometry/kernels/cuda/ext.cpp
@@ -92,6 +92,26 @@ void se3pose_transform_point_cuda(
     const at::Tensor &translation, const at::Tensor &rotation, const at::Tensor &point, at::Tensor &out
 );
 void se3pose_transform_direction_cuda(const at::Tensor &rotation, const at::Tensor &direction, at::Tensor &out);
+void se3pose_compose_cuda(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation,
+    at::Tensor &out_translation,
+    at::Tensor &out_rotation
+);
+void se3pose_compose_bwd_cuda(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation,
+    const at::Tensor &grad_out_translation,
+    const at::Tensor &grad_out_rotation,
+    at::Tensor &grad_parent_translation,
+    at::Tensor &grad_parent_rotation,
+    at::Tensor &grad_child_translation,
+    at::Tensor &grad_child_rotation
+);
 void se3pose_inverse_transform_point_cuda(
     const at::Tensor &translation, const at::Tensor &rotation, const at::Tensor &point, at::Tensor &out
 );
@@ -195,6 +215,35 @@ void trajectory_transform_point_1pose_bwd_cuda(
     at::Tensor &grad_time,
     at::Tensor &grad_point,
     at::Tensor &grad_query_time
+);
+
+// Packed SE(3) pose-track interpolation. Rotations are Hamilton quaternions
+// stored as xyzw rows in pose_rotations/out_rotations.
+void se3_interpolate_tracks_cuda(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times,
+    at::Tensor &out_translations,
+    at::Tensor &out_rotations
+);
+
+void se3_interpolate_tracks_bwd_cuda(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times,
+    const at::Tensor &out_rotations,
+    const at::Tensor &grad_out_translations,
+    const at::Tensor &grad_out_rotations,
+    at::Tensor &grad_pose_translations,
+    at::Tensor &grad_pose_rotations,
+    at::Tensor &grad_pose_times,
+    at::Tensor &grad_query_times
 );
 
 void frame_transform_poses_tquat_cuda(
@@ -678,6 +727,121 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> se3pose_transform_direct
     return std::make_tuple(grad_translation, grad_rotation, grad_direction);
 }
 
+static void check_se3_pose_compose_inputs(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &child_translation,
+    const at::Tensor &child_rotation
+)
+{
+    CHECK_CUDA_TENSOR(parent_translation);
+    CHECK_CUDA_TENSOR(parent_rotation);
+    CHECK_CUDA_TENSOR(child_translation);
+    CHECK_CUDA_TENSOR(child_rotation);
+    CHECK_CONTIGUOUS(parent_translation);
+    CHECK_CONTIGUOUS(parent_rotation);
+    CHECK_CONTIGUOUS(child_translation);
+    CHECK_CONTIGUOUS(child_rotation);
+    CHECK_FLOATING(parent_translation);
+    TORCH_CHECK(
+        parent_rotation.dtype() == parent_translation.dtype()
+            && child_translation.dtype() == parent_translation.dtype()
+            && child_rotation.dtype() == parent_translation.dtype(),
+        "all pose compose inputs must have the same dtype"
+    );
+    TORCH_CHECK(
+        parent_rotation.device() == parent_translation.device()
+            && child_translation.device() == parent_translation.device()
+            && child_rotation.device() == parent_translation.device(),
+        "all pose compose inputs must be on the same CUDA device"
+    );
+    TORCH_CHECK(parent_translation.dim() == 2 && parent_translation.size(1) == 3, "parent_translation must be (N, 3)");
+    TORCH_CHECK(parent_rotation.dim() == 2 && parent_rotation.size(1) == 4, "parent_rotation must be (N, 4) xyzw");
+    TORCH_CHECK(child_translation.dim() == 2 && child_translation.size(1) == 3, "child_translation must be (N, 3)");
+    TORCH_CHECK(child_rotation.dim() == 2 && child_rotation.size(1) == 4, "child_rotation must be (N, 4) xyzw");
+    TORCH_CHECK(
+        parent_rotation.size(0) == parent_translation.size(0)
+            && child_translation.size(0) == parent_translation.size(0)
+            && child_rotation.size(0) == parent_translation.size(0),
+        "all pose compose inputs must share the same batch size N"
+    );
+}
+
+static void check_se3_pose_compose_grad_out(
+    const at::Tensor &parent_translation,
+    const at::Tensor &parent_rotation,
+    const at::Tensor &grad_t,
+    const at::Tensor &grad_q
+)
+{
+    CHECK_CUDA_TENSOR(grad_t);
+    CHECK_CUDA_TENSOR(grad_q);
+    CHECK_CONTIGUOUS(grad_t);
+    CHECK_CONTIGUOUS(grad_q);
+    TORCH_CHECK(
+        grad_t.device() == parent_translation.device(), "grad_out_translation must be on the same device as inputs"
+    );
+    TORCH_CHECK(
+        grad_q.device() == parent_translation.device(), "grad_out_rotation must be on the same device as inputs"
+    );
+    TORCH_CHECK(grad_t.dtype() == parent_translation.dtype(), "grad_out_translation dtype must match inputs");
+    TORCH_CHECK(grad_q.dtype() == parent_translation.dtype(), "grad_out_rotation dtype must match inputs");
+    TORCH_CHECK(grad_t.sizes() == parent_translation.sizes(), "grad_out_translation shape must match translations");
+    TORCH_CHECK(grad_q.sizes() == parent_rotation.sizes(), "grad_out_rotation shape must match rotations");
+}
+
+std::tuple<torch::Tensor, torch::Tensor> se3pose_compose(
+    const torch::Tensor &parent_translation,
+    const torch::Tensor &parent_rotation,
+    const torch::Tensor &child_translation,
+    const torch::Tensor &child_rotation
+)
+{
+    check_se3_pose_compose_inputs(parent_translation, parent_rotation, child_translation, child_rotation);
+    auto out_translation = torch::empty_like(parent_translation);
+    auto out_rotation    = torch::empty_like(parent_rotation);
+    if(parent_translation.size(0) > 0)
+    {
+        se3pose_compose_cuda(
+            parent_translation, parent_rotation, child_translation, child_rotation, out_translation, out_rotation
+        );
+    }
+    return std::make_tuple(out_translation, out_rotation);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> se3pose_compose_bwd(
+    const torch::Tensor &parent_translation,
+    const torch::Tensor &parent_rotation,
+    const torch::Tensor &child_translation,
+    const torch::Tensor &child_rotation,
+    const torch::Tensor &grad_out_translation,
+    const torch::Tensor &grad_out_rotation
+)
+{
+    check_se3_pose_compose_inputs(parent_translation, parent_rotation, child_translation, child_rotation);
+    check_se3_pose_compose_grad_out(parent_translation, parent_rotation, grad_out_translation, grad_out_rotation);
+    auto grad_parent_translation = torch::empty_like(parent_translation);
+    auto grad_parent_rotation    = torch::empty_like(parent_rotation);
+    auto grad_child_translation  = torch::empty_like(child_translation);
+    auto grad_child_rotation     = torch::empty_like(child_rotation);
+    if(parent_translation.size(0) > 0)
+    {
+        se3pose_compose_bwd_cuda(
+            parent_translation,
+            parent_rotation,
+            child_translation,
+            child_rotation,
+            grad_out_translation,
+            grad_out_rotation,
+            grad_parent_translation,
+            grad_parent_rotation,
+            grad_child_translation,
+            grad_child_rotation
+        );
+    }
+    return std::make_tuple(grad_parent_translation, grad_parent_rotation, grad_child_translation, grad_child_rotation);
+}
+
 torch::Tensor se3pose_inverse_transform_point(
     const torch::Tensor &translation, const torch::Tensor &rotation, const torch::Tensor &point
 )
@@ -965,6 +1129,184 @@ torch::Tensor se3pose_from_matrix_bwd(
         se3pose_from_matrix_bwd_cuda(matrix, grad_translation, grad_rotation, grad_matrix);
     }
     return grad_matrix;
+}
+
+// -----------------------------------------------------------------------------
+// Packed SE3 pose-track interpolation.
+// -----------------------------------------------------------------------------
+
+static bool is_pose_track_time_dtype(const at::Tensor &t)
+{
+    return t.dtype() == torch::kFloat32 || t.dtype() == torch::kFloat64 || t.dtype() == torch::kInt64;
+}
+
+static void check_se3_interpolate_tracks_inputs(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &pose_times,
+    const at::Tensor &pose_offsets,
+    const at::Tensor &pose_counts,
+    const at::Tensor &query_times
+)
+{
+    CHECK_CUDA_TENSOR(pose_translations);
+    CHECK_CUDA_TENSOR(pose_rotations);
+    CHECK_CUDA_TENSOR(pose_times);
+    CHECK_CUDA_TENSOR(pose_offsets);
+    CHECK_CUDA_TENSOR(pose_counts);
+    CHECK_CUDA_TENSOR(query_times);
+    CHECK_CONTIGUOUS(pose_translations);
+    CHECK_CONTIGUOUS(pose_rotations);
+    CHECK_CONTIGUOUS(pose_times);
+    CHECK_CONTIGUOUS(pose_offsets);
+    CHECK_CONTIGUOUS(pose_counts);
+    CHECK_CONTIGUOUS(query_times);
+    CHECK_FLOATING(pose_translations);
+    TORCH_CHECK(pose_rotations.dtype() == pose_translations.dtype(), "pose rotations dtype must match translations");
+    TORCH_CHECK(is_pose_track_time_dtype(pose_times), "pose_times must be float32, float64, or int64");
+    TORCH_CHECK(query_times.dtype() == pose_times.dtype(), "query_times dtype must match pose_times");
+    TORCH_CHECK(pose_offsets.dtype() == torch::kInt64, "pose_offsets must be int64");
+    TORCH_CHECK(pose_counts.dtype() == torch::kInt64, "pose_counts must be int64");
+    TORCH_CHECK(
+        pose_translations.device() == pose_rotations.device()
+            && pose_translations.device() == pose_times.device()
+            && pose_translations.device() == pose_offsets.device()
+            && pose_translations.device() == pose_counts.device()
+            && pose_translations.device() == query_times.device(),
+        "packed pose-track tensors must share one CUDA device"
+    );
+    const int64_t n_poses  = pose_translations.size(0);
+    const int64_t n_tracks = pose_offsets.size(0);
+    TORCH_CHECK(pose_translations.dim() == 2 && pose_translations.size(1) == 3, "pose_translations must be (M, 3)");
+    TORCH_CHECK(
+        pose_rotations.dim() == 2 && pose_rotations.size(0) == n_poses && pose_rotations.size(1) == 4,
+        "pose_rotations must be (M, 4)"
+    );
+    TORCH_CHECK(pose_times.dim() == 1 && pose_times.size(0) == n_poses, "pose_times must be flattened (M,)");
+    TORCH_CHECK(pose_offsets.dim() == 1, "pose_offsets must be flattened (C,)");
+    TORCH_CHECK(pose_counts.dim() == 1 && pose_counts.size(0) == n_tracks, "pose_counts must be flattened (C,)");
+    TORCH_CHECK(query_times.dim() == 1 && query_times.size(0) == n_tracks, "query_times must be flattened (C,)");
+}
+
+static void check_se3_interpolate_tracks_grad_outputs(
+    const at::Tensor &pose_translations,
+    const at::Tensor &pose_rotations,
+    const at::Tensor &query_times,
+    const at::Tensor &out_rotations,
+    const at::Tensor &grad_out_translations,
+    const at::Tensor &grad_out_rotations
+)
+{
+    CHECK_CUDA_TENSOR(out_rotations);
+    CHECK_CUDA_TENSOR(grad_out_translations);
+    CHECK_CUDA_TENSOR(grad_out_rotations);
+    CHECK_CONTIGUOUS(out_rotations);
+    CHECK_CONTIGUOUS(grad_out_translations);
+    CHECK_CONTIGUOUS(grad_out_rotations);
+    TORCH_CHECK(out_rotations.device() == pose_translations.device(), "out_rotations device must match inputs");
+    TORCH_CHECK(
+        grad_out_translations.device() == pose_translations.device(), "grad_out_translations device must match inputs"
+    );
+    TORCH_CHECK(
+        grad_out_rotations.device() == pose_translations.device(), "grad_out_rotations device must match inputs"
+    );
+    TORCH_CHECK(out_rotations.dtype() == pose_rotations.dtype(), "out_rotations dtype must match pose_rotations");
+    TORCH_CHECK(
+        grad_out_translations.dtype() == pose_translations.dtype(),
+        "grad_out_translations dtype must match pose_translations"
+    );
+    TORCH_CHECK(
+        grad_out_rotations.dtype() == pose_rotations.dtype(), "grad_out_rotations dtype must match pose_rotations"
+    );
+    const int64_t n_tracks = query_times.size(0);
+    TORCH_CHECK(
+        out_rotations.dim() == 2 && out_rotations.size(0) == n_tracks && out_rotations.size(1) == 4,
+        "out_rotations must be (C, 4)"
+    );
+    TORCH_CHECK(
+        grad_out_translations.dim() == 2
+            && grad_out_translations.size(0) == n_tracks
+            && grad_out_translations.size(1) == 3,
+        "grad_out_translations must be (C, 3)"
+    );
+    TORCH_CHECK(
+        grad_out_rotations.dim() == 2 && grad_out_rotations.size(0) == n_tracks && grad_out_rotations.size(1) == 4,
+        "grad_out_rotations must be (C, 4)"
+    );
+}
+
+std::tuple<torch::Tensor, torch::Tensor> se3_interpolate_tracks(
+    const torch::Tensor &pose_translations,
+    const torch::Tensor &pose_rotations,
+    const torch::Tensor &pose_times,
+    const torch::Tensor &pose_offsets,
+    const torch::Tensor &pose_counts,
+    const torch::Tensor &query_times
+)
+{
+    check_se3_interpolate_tracks_inputs(
+        pose_translations, pose_rotations, pose_times, pose_offsets, pose_counts, query_times
+    );
+    const int64_t n_tracks = pose_offsets.size(0);
+    auto out_translations  = torch::empty({n_tracks, 3}, pose_translations.options());
+    auto out_rotations     = torch::empty({n_tracks, 4}, pose_rotations.options());
+    if(n_tracks > 0)
+    {
+        se3_interpolate_tracks_cuda(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+            out_translations,
+            out_rotations
+        );
+    }
+    return std::make_tuple(out_translations, out_rotations);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> se3_interpolate_tracks_bwd(
+    const torch::Tensor &pose_translations,
+    const torch::Tensor &pose_rotations,
+    const torch::Tensor &pose_times,
+    const torch::Tensor &pose_offsets,
+    const torch::Tensor &pose_counts,
+    const torch::Tensor &query_times,
+    const torch::Tensor &out_rotations,
+    const torch::Tensor &grad_out_translations,
+    const torch::Tensor &grad_out_rotations
+)
+{
+    check_se3_interpolate_tracks_inputs(
+        pose_translations, pose_rotations, pose_times, pose_offsets, pose_counts, query_times
+    );
+    check_se3_interpolate_tracks_grad_outputs(
+        pose_translations, pose_rotations, query_times, out_rotations, grad_out_translations, grad_out_rotations
+    );
+    auto grad_pose_translations = torch::zeros_like(pose_translations);
+    auto grad_pose_rotations    = torch::zeros_like(pose_rotations);
+    auto grad_pose_times        = torch::zeros_like(pose_times);
+    auto grad_query_times       = torch::zeros_like(query_times);
+    if(pose_offsets.size(0) > 0)
+    {
+        se3_interpolate_tracks_bwd_cuda(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+            out_rotations,
+            grad_out_translations,
+            grad_out_rotations,
+            grad_pose_translations,
+            grad_pose_rotations,
+            grad_pose_times,
+            grad_query_times
+        );
+    }
+    return std::make_tuple(grad_pose_translations, grad_pose_rotations, grad_pose_times, grad_query_times);
 }
 
 // -----------------------------------------------------------------------------
@@ -1462,6 +1804,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         &se3pose_transform_direction_bwd,
         "Backward for se3pose_transform_direction -> (grad_translation, grad_rotation, grad_direction), CUDA"
     );
+    m.def("se3pose_compose", &se3pose_compose, "Compose SE3 poses row-wise: parent * child, rotations xyzw, CUDA");
+    m.def(
+        "se3pose_compose_bwd",
+        &se3pose_compose_bwd,
+        "Backward for se3pose_compose -> (grad_parent_translation, grad_parent_rotation, grad_child_translation, "
+        "grad_child_rotation), CUDA"
+    );
     m.def(
         "se3pose_inverse_transform_point",
         &se3pose_inverse_transform_point,
@@ -1507,6 +1856,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "se3pose_from_matrix_bwd",
         &se3pose_from_matrix_bwd,
         "Backward for se3pose_from_matrix -> grad_matrix (N,16), CUDA"
+    );
+    m.def(
+        "se3_interpolate_tracks", &se3_interpolate_tracks, "Packed SE3 pose-track interpolation, rotations xyzw, CUDA"
+    );
+    m.def(
+        "se3_interpolate_tracks_bwd",
+        &se3_interpolate_tracks_bwd,
+        "Backward for packed SE3 pose-track interpolation, CUDA"
     );
     m.def(
         "trajectory_transform_point_2poses",

--- a/gsplat/geometry/kernels/pose_ops.py
+++ b/gsplat/geometry/kernels/pose_ops.py
@@ -25,6 +25,9 @@ import torch
 
 from . import _backend
 
+_INTEGER_DTYPES = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+_POSE_TRACK_FLOAT_TIME_DTYPES = (torch.float32, torch.float64)
+
 
 def _expect_tensor(name: str, x: object) -> torch.Tensor:
     if not isinstance(x, torch.Tensor):
@@ -45,6 +48,29 @@ def _require_float32_or_float64(name: str, t: torch.Tensor) -> None:
 def _require_float32(name: str, t: torch.Tensor) -> None:
     if t.dtype != torch.float32:
         raise TypeError(f"{name} must have dtype float32, got {t.dtype}")
+
+
+def _require_integer(name: str, t: torch.Tensor) -> None:
+    if t.dtype not in _INTEGER_DTYPES:
+        raise TypeError(f"{name} must have an integer dtype, got {t.dtype}")
+
+
+def _require_numeric(name: str, t: torch.Tensor) -> None:
+    if not t.dtype.is_floating_point and t.dtype not in _INTEGER_DTYPES:
+        raise TypeError(
+            f"{name} must have a floating-point or integer dtype, got {t.dtype}"
+        )
+
+
+def _require_pose_track_time_dtype(name: str, t: torch.Tensor) -> None:
+    if t.dtype.is_floating_point and t.dtype not in _POSE_TRACK_FLOAT_TIME_DTYPES:
+        raise TypeError(
+            f"{name} must have dtype float32, float64, or integer, got {t.dtype}"
+        )
+    if not t.dtype.is_floating_point and t.dtype not in _INTEGER_DTYPES:
+        raise TypeError(
+            f"{name} must have dtype float32, float64, or integer, got {t.dtype}"
+        )
 
 
 def _same_device(names_tensors: Iterable[tuple[str, torch.Tensor]]) -> torch.device:
@@ -134,6 +160,159 @@ def _validate_se3_pose_pair(translation: torch.Tensor, rotation: torch.Tensor) -
             "translation and rotation must share the same batch size N; "
             f"got {translation.shape[0]} vs {rotation.shape[0]}"
         )
+
+
+def _validate_same_se3_pose_batch(
+    parent_translation: torch.Tensor,
+    parent_rotation: torch.Tensor,
+    child_translation: torch.Tensor,
+    child_rotation: torch.Tensor,
+) -> None:
+    _validate_se3_pose_pair(parent_translation, parent_rotation)
+    _validate_se3_pose_pair(child_translation, child_rotation)
+    if parent_translation.device != child_translation.device:
+        raise ValueError(
+            "parent and child poses must be on the same device; "
+            f"got {parent_translation.device} vs {child_translation.device}"
+        )
+    if parent_translation.dtype != child_translation.dtype:
+        raise TypeError(
+            "parent and child poses must have the same dtype; "
+            f"got {parent_translation.dtype} vs {child_translation.dtype}"
+        )
+    if parent_translation.shape[0] != child_translation.shape[0]:
+        raise ValueError(
+            "parent and child poses must share the same batch size N; "
+            f"got {parent_translation.shape[0]} vs {child_translation.shape[0]}"
+        )
+
+
+def _validate_se3_pose_tracks(
+    pose_translations: torch.Tensor,
+    pose_rotations: torch.Tensor,
+    pose_times: torch.Tensor,
+    pose_offsets: torch.Tensor,
+    pose_counts: torch.Tensor,
+) -> None:
+    pose_translations = _expect_tensor("pose_translations", pose_translations)
+    pose_rotations = _expect_tensor("pose_rotations", pose_rotations)
+    pose_times = _expect_tensor("pose_times", pose_times)
+    pose_offsets = _expect_tensor("pose_offsets", pose_offsets)
+    pose_counts = _expect_tensor("pose_counts", pose_counts)
+    for name, tensor in (
+        ("pose_translations", pose_translations),
+        ("pose_rotations", pose_rotations),
+        ("pose_times", pose_times),
+        ("pose_offsets", pose_offsets),
+        ("pose_counts", pose_counts),
+    ):
+        _require_cuda(name, tensor)
+    _require_float32_or_float64("pose_translations", pose_translations)
+    if pose_rotations.dtype != pose_translations.dtype:
+        raise TypeError(
+            "pose_translations and pose_rotations must have the same dtype; "
+            f"got {pose_translations.dtype} vs {pose_rotations.dtype}"
+        )
+    _require_pose_track_time_dtype("pose_times", pose_times)
+    _require_integer("pose_offsets", pose_offsets)
+    _require_integer("pose_counts", pose_counts)
+    _same_device(
+        [
+            ("pose_translations", pose_translations),
+            ("pose_rotations", pose_rotations),
+            ("pose_times", pose_times),
+            ("pose_offsets", pose_offsets),
+            ("pose_counts", pose_counts),
+        ]
+    )
+    if pose_translations.dim() != 2 or pose_translations.shape[1] != 3:
+        raise ValueError(
+            "pose_translations must have shape (M, 3); "
+            f"got {tuple(pose_translations.shape)}"
+        )
+    if pose_rotations.dim() != 2 or pose_rotations.shape[1] != 4:
+        raise ValueError(
+            "pose_rotations must have shape (M, 4) xyzw; "
+            f"got {tuple(pose_rotations.shape)}"
+        )
+    if pose_rotations.shape[0] != pose_translations.shape[0]:
+        raise ValueError(
+            "pose_translations and pose_rotations must share M rows; "
+            f"got {pose_translations.shape[0]} vs {pose_rotations.shape[0]}"
+        )
+    n_poses = pose_translations.shape[0]
+    if not (
+        (pose_times.dim() == 1 and pose_times.shape[0] == n_poses)
+        or (pose_times.dim() == 2 and pose_times.shape == (n_poses, 1))
+    ):
+        raise ValueError(
+            "pose_times must have shape (M,) or (M, 1) matching poses; "
+            f"got {tuple(pose_times.shape)} for M={n_poses}"
+        )
+    if pose_offsets.dim() == 1:
+        n_tracks = pose_offsets.shape[0]
+    elif pose_offsets.dim() == 2 and pose_offsets.shape[1] == 1:
+        n_tracks = pose_offsets.shape[0]
+    else:
+        raise ValueError(
+            f"pose_offsets must have shape (C,) or (C, 1); got {tuple(pose_offsets.shape)}"
+        )
+    pose_counts_valid = (
+        pose_counts.dim() == 1 and pose_counts.shape[0] == n_tracks
+    ) or (pose_counts.dim() == 2 and pose_counts.shape == (n_tracks, 1))
+    if not pose_counts_valid:
+        raise ValueError(
+            "pose_counts must have shape (C,) or (C, 1) matching pose_offsets; "
+            f"got {tuple(pose_counts.shape)} for C={n_tracks}"
+        )
+
+
+def _packed_pose_track_query_time(
+    query_time: float | torch.Tensor,
+    n_tracks: int,
+    ref: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if isinstance(query_time, (int, float)):
+        scalar_query_time = query_time if dtype == torch.int64 else float(query_time)
+        return torch.full(
+            (n_tracks,), scalar_query_time, device=ref.device, dtype=dtype
+        )
+
+    query_time = _expect_tensor("query_time", query_time)
+    _require_cuda("query_time", query_time)
+    _require_numeric("query_time", query_time)
+    if query_time.device != ref.device:
+        raise ValueError(
+            f"query_time must be on the same CUDA device as poses; got {query_time.device}"
+        )
+    query_time = query_time.to(dtype=dtype)
+    query_time_flat = query_time.reshape(-1)
+    if query_time_flat.numel() == 1:
+        return query_time_flat.expand(n_tracks)
+    if query_time_flat.numel() != n_tracks:
+        raise ValueError(
+            "query_time must be a scalar or flatten to one value per track; "
+            f"got {query_time_flat.numel()} values for C={n_tracks}"
+        )
+    return query_time_flat
+
+
+def _pose_track_time_dtype(
+    pose_times: torch.Tensor, query_time: float | torch.Tensor
+) -> torch.dtype:
+    if pose_times.is_floating_point():
+        if isinstance(query_time, torch.Tensor) and query_time.is_floating_point():
+            return torch.promote_types(pose_times.dtype, query_time.dtype)
+        return pose_times.dtype
+    if not pose_times.is_floating_point() and (
+        isinstance(query_time, int)
+        or (isinstance(query_time, torch.Tensor) and not query_time.is_floating_point())
+    ):
+        return torch.int64
+    if not pose_times.is_floating_point():
+        return torch.float64
+    raise TypeError(f"unsupported pose_times dtype: {pose_times.dtype}")
 
 
 def _validate_trajectory_time_tensor(
@@ -402,6 +581,63 @@ class SE3PoseInverseTransformDirectionFunction(torch.autograd.Function):
             translation, rotation, direction, grad_result
         )
         return grad_translation, grad_rotation, grad_direction
+
+
+class SE3PoseComposeFunction(torch.autograd.Function):
+    """Differentiable row-wise SE3 pose composition."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        parent_translation: torch.Tensor,
+        parent_rotation: torch.Tensor,
+        child_translation: torch.Tensor,
+        child_rotation: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        parent_translation = parent_translation.contiguous()
+        parent_rotation = parent_rotation.contiguous()
+        child_translation = child_translation.contiguous()
+        child_rotation = child_rotation.contiguous()
+        out_translation, out_rotation = _backend._GEOMETRY_CUDA.se3pose_compose(
+            parent_translation,
+            parent_rotation,
+            child_translation,
+            child_rotation,
+        )
+        ctx.save_for_backward(
+            parent_translation,
+            parent_rotation,
+            child_translation,
+            child_rotation,
+        )
+        return out_translation, out_rotation
+
+    @staticmethod
+    def backward(ctx, *grad_outputs: Any):
+        grad_out_translation = grad_outputs[0]
+        grad_out_rotation = grad_outputs[1]
+        (
+            parent_translation,
+            parent_rotation,
+            child_translation,
+            child_rotation,
+        ) = ctx.saved_tensors
+        if grad_out_translation is None:
+            grad_out_translation = torch.zeros_like(parent_translation)
+        else:
+            grad_out_translation = grad_out_translation.contiguous()
+        if grad_out_rotation is None:
+            grad_out_rotation = torch.zeros_like(parent_rotation)
+        else:
+            grad_out_rotation = grad_out_rotation.contiguous()
+        return _backend._GEOMETRY_CUDA.se3pose_compose_bwd(
+            parent_translation,
+            parent_rotation,
+            child_translation,
+            child_rotation,
+            grad_out_translation,
+            grad_out_rotation,
+        )
 
 
 class SE3PoseFromMatrixFunction(torch.autograd.Function):
@@ -765,6 +1001,102 @@ class TrajectoryTransformPoint1PoseFunction(torch.autograd.Function):
         return grad_trans, grad_rot, grad_time, grad_point, grad_query_time
 
 
+class SE3InterpolateTracksFunction(torch.autograd.Function):
+    """Differentiable packed SE3 pose-track interpolation."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        pose_translations: torch.Tensor,
+        pose_rotations: torch.Tensor,
+        pose_times: torch.Tensor,
+        pose_offsets: torch.Tensor,
+        pose_counts: torch.Tensor,
+        query_times: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        pose_translations = pose_translations.contiguous()
+        pose_rotations = pose_rotations.contiguous()
+        pose_times = pose_times.contiguous()
+        pose_offsets = pose_offsets.contiguous()
+        pose_counts = pose_counts.contiguous()
+        query_times = query_times.contiguous()
+        (
+            out_translations,
+            out_rotations,
+        ) = _backend._GEOMETRY_CUDA.se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+        )
+        ctx.save_for_backward(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+            out_rotations,
+        )
+        ctx.times_are_floating = pose_times.is_floating_point()
+        return out_translations, out_rotations
+
+    @staticmethod
+    def backward(ctx, *grad_outputs: Any):
+        grad_out_translations = grad_outputs[0]
+        grad_out_rotations = grad_outputs[1]
+        (
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+            out_rotations,
+        ) = ctx.saved_tensors
+        if grad_out_translations is None:
+            grad_out_translations = torch.zeros(
+                (query_times.shape[0], 3),
+                device=pose_translations.device,
+                dtype=pose_translations.dtype,
+            )
+        else:
+            grad_out_translations = grad_out_translations.contiguous()
+        if grad_out_rotations is None:
+            grad_out_rotations = torch.zeros_like(out_rotations)
+        else:
+            grad_out_rotations = grad_out_rotations.contiguous()
+        (
+            grad_pose_translations,
+            grad_pose_rotations,
+            grad_pose_times,
+            grad_query_times,
+        ) = _backend._GEOMETRY_CUDA.se3_interpolate_tracks_bwd(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+            out_rotations,
+            grad_out_translations,
+            grad_out_rotations,
+        )
+        if not ctx.times_are_floating:
+            grad_pose_times = None
+            grad_query_times = None
+        return (
+            grad_pose_translations,
+            grad_pose_rotations,
+            grad_pose_times,
+            None,
+            None,
+            grad_query_times,
+        )
+
+
 # ============================================================================
 # Public API - Differentiable Wrapper Functions
 # ============================================================================
@@ -882,6 +1214,92 @@ def se3pose_from_matrix(matrix: torch.Tensor) -> tuple[torch.Tensor, torch.Tenso
             "matrix must have shape (N, 4, 4) or (N, 16); " f"got {tuple(matrix.shape)}"
         )
     return SE3PoseFromMatrixFunction.apply(matrix)
+
+
+def se3pose_compose(
+    parent_translation: torch.Tensor,
+    parent_rotation: torch.Tensor,
+    child_translation: torch.Tensor,
+    child_rotation: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compose two batched SE3 poses row-wise.
+
+    The returned pose is ``parent * child``. Applying it to a point is equivalent
+    to first applying ``child`` and then applying ``parent``.
+
+    Args:
+        parent_translation: (N, 3) parent/world translations
+        parent_rotation: (N, 4) parent/world quaternions in xyzw format
+        child_translation: (N, 3) child/local translations
+        child_rotation: (N, 4) child/local quaternions in xyzw format
+
+    Returns:
+        Tuple ``(translation, rotation)`` with shapes ``(N, 3)`` and ``(N, 4)``.
+    """
+    _validate_same_se3_pose_batch(
+        parent_translation, parent_rotation, child_translation, child_rotation
+    )
+    return SE3PoseComposeFunction.apply(
+        parent_translation, parent_rotation, child_translation, child_rotation
+    )
+
+
+def se3_interpolate_tracks(
+    pose_translations: torch.Tensor,
+    pose_rotations: torch.Tensor,
+    pose_times: torch.Tensor,
+    pose_offsets: torch.Tensor,
+    pose_counts: torch.Tensor,
+    query_time: float | torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Interpolate packed SE3 pose tracks at one or more query times.
+
+    Tracks are represented by keyframe translations, keyframe rotations, and
+    per-track ``pose_offsets`` / ``pose_counts``. Offsets/counts must describe
+    valid packed ranges, and times must be sorted non-decreasing within each
+    track. Query times outside a track are clamped to that track's first or last
+    keyframe.
+
+    Args:
+        pose_translations: (M, 3) keyframe translations
+        pose_rotations: (M, 4) keyframe quaternions in xyzw format
+        pose_times: (M,) or (M, 1) keyframe times
+        pose_offsets: (C,) or (C, 1) start row for each track
+        pose_counts: (C,) or (C, 1) keyframe count for each track
+        query_time: Scalar time for all tracks or tensor with one time per track
+
+    Returns:
+        Tuple ``(translation, rotation)`` with shapes ``(C, 3)`` and ``(C, 4)``.
+    """
+    _validate_se3_pose_tracks(
+        pose_translations,
+        pose_rotations,
+        pose_times,
+        pose_offsets,
+        pose_counts,
+    )
+    offsets = pose_offsets.reshape(-1).to(dtype=torch.long)
+    counts = pose_counts.reshape(-1).to(dtype=torch.long)
+    n_tracks = offsets.numel()
+    if n_tracks == 0:
+        return pose_translations[:0], pose_rotations[:0]
+
+    time_dtype = _pose_track_time_dtype(pose_times, query_time)
+    query_times = _packed_pose_track_query_time(
+        query_time, n_tracks, pose_translations, time_dtype
+    )
+    times = pose_times.reshape(-1).to(dtype=time_dtype).contiguous()
+    offsets = offsets.contiguous()
+    counts = counts.contiguous()
+    query_times = query_times.contiguous()
+    return SE3InterpolateTracksFunction.apply(
+        pose_translations,
+        pose_rotations,
+        times,
+        offsets,
+        counts,
+        query_times,
+    )
 
 
 def se3pose_to_inverse_matrix(

--- a/gsplat/losses.py
+++ b/gsplat/losses.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import math
 import os
 from typing import Callable, Optional
+import warnings
 
 import torch
 import torch.nn.functional as F
@@ -180,10 +181,15 @@ def ssim_loss(
     try:
         from fused_ssim import fused_ssim
 
-        if window_size == 11 and not img2.requires_grad and img1.is_cuda:
+        if window_size == 11 and not img2.requires_grad and not img1.is_cpu:
             return 1.0 - fused_ssim(img1, img2, padding="valid")
     except ImportError:
         pass
+    except NotImplementedError:
+        warnings.warn(
+            f"fused_ssim implementation not available for {img1.device}. Falling back to reference implementation.",
+            stacklevel=2,
+        )
 
     channel = img1.shape[1]
     key = (window_size, channel, img1.device, img1.dtype)

--- a/gsplat/relocation.py
+++ b/gsplat/relocation.py
@@ -27,6 +27,7 @@ def compute_relocation(
     scales: Tensor,  # [N, 3]
     ratios: Tensor,  # [N]
     binoms: Tensor,  # [n_max, n_max]
+    min_opacity: float = 0.005,
 ) -> Tuple[Tensor, Tensor]:
     """Compute new Gaussians from a set of old Gaussians.
 
@@ -41,6 +42,8 @@ def compute_relocation(
         ratios: The relative frequencies for each of the Gaussians. [N]
         binoms: Precomputed lookup table for binomial coefficients used in
           Equation 9 in the paper. [n_max, n_max]
+        min_opacity: Lower clamp applied to the new opacity before computing
+          new scales. Defaults to 0.005.
 
     Returns:
         A tuple:
@@ -59,6 +62,6 @@ def compute_relocation(
     ratios = ratios.int().contiguous()
 
     new_opacities, new_scales = _make_lazy_cuda_func("relocation")(
-        opacities, scales, ratios, binoms, n_max
+        opacities, scales, ratios, binoms, n_max, min_opacity
     )
     return new_opacities, new_scales

--- a/gsplat/strategy/mcmc.py
+++ b/gsplat/strategy/mcmc.py
@@ -24,7 +24,13 @@ import torch
 from torch import Tensor
 
 from .base import Strategy
-from .ops import inject_noise_to_position, relocate, sample_add
+from .ops import (
+    DEFAULT_MCMC_OPACITY_K,
+    DEFAULT_MCMC_OPACITY_T,
+    inject_noise_to_position,
+    relocate,
+    sample_add,
+)
 
 if TYPE_CHECKING:
     from gsplat.scene import Scene
@@ -52,6 +58,10 @@ class MCMCStrategy(Strategy):
         refine_every (int): Refine GSs every this steps. Default to 100.
         min_opacity (float): GSs with opacity below this value will be pruned. Default to 0.005.
         verbose (bool): Whether to print verbose information. Default to False.
+        noise_opacity_t (float): Opacity transition point for noise suppression.
+            Default to 0.005.
+        noise_opacity_k (float): Sharpness of the opacity noise-suppression gate.
+            Default to 100.
 
     Examples:
 
@@ -77,6 +87,8 @@ class MCMCStrategy(Strategy):
     refine_every: int = 100
     min_opacity: float = 0.005
     verbose: bool = False
+    noise_opacity_t: float = DEFAULT_MCMC_OPACITY_T
+    noise_opacity_k: float = DEFAULT_MCMC_OPACITY_K
 
     def initialize_state(self) -> Dict[str, Any]:
         """Initialize and return the running state for this strategy."""
@@ -175,7 +187,9 @@ class MCMCStrategy(Strategy):
                 params=params,
                 optimizers=optimizers,
                 state={},
-                scaler=lr * self.noise_lr,
+                noise_scale=lr * self.noise_lr,
+                t=self.noise_opacity_t,
+                k=self.noise_opacity_k,
             )
 
     @torch.no_grad()

--- a/gsplat/strategy/ops.py
+++ b/gsplat/strategy/ops.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
 _MCMC_BACKEND_TORCH = {"torch", "pytorch", "py"}
 _MCMC_BACKEND_CUDA = {"cuda", "native", ""}
+DEFAULT_MCMC_OPACITY_T = 0.005
+DEFAULT_MCMC_OPACITY_K = 100.0
 _raw = os.environ.get("GSPLAT_MCMC_BACKEND", "").strip().lower()
 _force_torch_backend = _raw in _MCMC_BACKEND_TORCH
 if _raw and _raw not in _MCMC_BACKEND_TORCH | _MCMC_BACKEND_CUDA:
@@ -42,6 +44,18 @@ if _raw and _raw not in _MCMC_BACKEND_TORCH | _MCMC_BACKEND_CUDA:
         f" fallback). Valid: {sorted(_MCMC_BACKEND_TORCH | _MCMC_BACKEND_CUDA)}",
         stacklevel=2,
     )
+
+
+def _resolve_noise_scale(noise_scale: float | None, scaler: float | None) -> float:
+    if noise_scale is None:
+        if scaler is None:
+            raise TypeError("noise_scale must be provided")
+        return float(scaler)
+    if scaler is not None and float(noise_scale) != float(scaler):
+        raise ValueError(
+            "noise_scale and scaler aliases were both provided with different values"
+        )
+    return float(noise_scale)
 
 
 @torch.no_grad()
@@ -309,7 +323,6 @@ def relocate(
     n = len(dead_indices)
 
     # Sample for new GSs
-    eps = torch.finfo(torch.float32).eps
     probs = opacities[alive_indices].flatten()  # ensure its shape is [N,]
     sampled_idxs = _multinomial_sample(probs, n, replacement=True)
     sampled_idxs = alive_indices[sampled_idxs]
@@ -318,8 +331,8 @@ def relocate(
         scales=torch.exp(params["scales"])[sampled_idxs],
         ratios=torch.bincount(sampled_idxs)[sampled_idxs] + 1,
         binoms=binoms,
+        min_opacity=min_opacity,
     )
-    new_opacities = torch.clamp(new_opacities, max=1.0 - eps, min=min_opacity)
 
     def param_fn(name: str, p: Tensor) -> Tensor:
         if name == "opacities":
@@ -355,7 +368,6 @@ def sample_add(
 ):
     opacities = torch.sigmoid(params["opacities"])
 
-    eps = torch.finfo(torch.float32).eps
     probs = opacities.flatten()
     sampled_idxs = _multinomial_sample(probs, n, replacement=True)
     new_opacities, new_scales = compute_relocation(
@@ -363,8 +375,8 @@ def sample_add(
         scales=torch.exp(params["scales"])[sampled_idxs],
         ratios=torch.bincount(sampled_idxs)[sampled_idxs] + 1,
         binoms=binoms,
+        min_opacity=min_opacity,
     )
-    new_opacities = torch.clamp(new_opacities, max=1.0 - eps, min=min_opacity)
 
     def param_fn(name: str, p: Tensor) -> Tensor:
         if name == "opacities":
@@ -395,7 +407,11 @@ def _cuda_fused_mcmc_perturb(
     quats: Tensor,
     scales: Tensor,
     opacities: Tensor,
-    scaler: float,
+    noise_scale: float | None = None,
+    *,
+    scaler: float | None = None,
+    t: float = DEFAULT_MCMC_OPACITY_T,
+    k: float = DEFAULT_MCMC_OPACITY_K,
 ) -> bool:
     """Try the fused CUDA kernel for MCMC perturbation; return False if not applicable.
 
@@ -414,10 +430,11 @@ def _cuda_fused_mcmc_perturb(
     if not positions.is_contiguous():
         return False
     # All inputs must be float32 CUDA tensors
-    for t in (positions, quats, scales, opacities):
-        if t.dtype != torch.float32 or not t.is_cuda:
+    for tensor in (positions, quats, scales, opacities):
+        if tensor.dtype != torch.float32 or not tensor.is_cuda:
             return False
     try:
+        resolved_noise_scale = _resolve_noise_scale(noise_scale, scaler)
         noise = torch.randn_like(positions)
         torch.ops.gsplat.mcmc_perturb_positions(
             positions,
@@ -425,7 +442,9 @@ def _cuda_fused_mcmc_perturb(
             scales.contiguous(),
             opacities.flatten().contiguous(),
             noise,
-            float(scaler),
+            resolved_noise_scale,
+            float(t),
+            float(k),
         )
         return True
     except AttributeError:
@@ -445,7 +464,11 @@ def inject_noise_to_position(
     params: Union[Dict[str, torch.nn.Parameter], torch.nn.ParameterDict],
     optimizers: Dict[str, torch.optim.Optimizer],
     state: Dict[str, Tensor],
-    scaler: float,
+    noise_scale: float | None = None,
+    *,
+    scaler: float | None = None,
+    t: float = DEFAULT_MCMC_OPACITY_T,
+    k: float = DEFAULT_MCMC_OPACITY_K,
 ):
     """Add covariance- and opacity-weighted Gaussian noise to ``params["means"]`` in-place.
 
@@ -454,6 +477,7 @@ def inject_noise_to_position(
       * ``cuda`` / ``native`` / unset (default) — prefer the fused CUDA kernel.
       * ``torch`` / ``pytorch`` / ``py`` — force the PyTorch fallback.
     """
+    resolved_noise_scale = _resolve_noise_scale(noise_scale, scaler)
     if not _force_torch_backend:
         # Priority 1: native CUDA (single kernel launch)
         if _cuda_fused_mcmc_perturb(
@@ -461,7 +485,9 @@ def inject_noise_to_position(
             quats=params["quats"],
             scales=params["scales"],
             opacities=params["opacities"],
-            scaler=scaler,
+            noise_scale=resolved_noise_scale,
+            t=t,
+            k=k,
         ):
             return
 
@@ -476,13 +502,10 @@ def inject_noise_to_position(
         triu=False,
     )
 
-    def op_sigmoid(x, k=100, x0=0.995):
-        return 1 / (1 + torch.exp(-k * (x - x0)))
-
     noise = (
         torch.randn_like(params["means"])
-        * (op_sigmoid(1 - opacities)).unsqueeze(-1)
-        * scaler
+        * torch.sigmoid(-float(k) * (opacities - float(t))).unsqueeze(-1)
+        * resolved_noise_scale
     )
     noise = torch.einsum("bij,bj->bi", covars, noise)
     params["means"].add_(noise)

--- a/tests/geometry/functional/test_pose.py
+++ b/tests/geometry/functional/test_pose.py
@@ -24,6 +24,7 @@ relaxed tolerances. ``frame_transform_poses_tquat`` is not registered for
 autograd (frame transform is passed as Python floats), so it has no gradcheck.
 """
 
+import math
 import unittest
 import warnings
 
@@ -53,6 +54,8 @@ quat_from_axis_angle = geom.quat_from_axis_angle
 quat_rotate_vector = geom.quat_rotate_vector
 quat_slerp = geom.quat_slerp
 quat_to_matrix = geom.quat_to_matrix
+se3_interpolate_tracks = geom.se3_interpolate_tracks
+se3pose_compose = geom.se3pose_compose
 se3pose_from_matrix = geom.se3pose_from_matrix
 se3pose_inverse_transform_direction = geom.se3pose_inverse_transform_direction
 se3pose_inverse_transform_point = geom.se3pose_inverse_transform_point
@@ -942,6 +945,80 @@ class TestSE3Pose(unittest.TestCase):
 
         self.assertTrue(torch.allclose(result_matrix, result_sequential, atol=ATOL))
 
+    def test_se3pose_compose_known_values(self):
+        """Row-wise pose composition matches explicit SE(3) cases."""
+        dtype = torch.float32
+        q_identity = torch.tensor([0.0, 0.0, 0.0, 1.0], device=device, dtype=dtype)
+        q_z90 = quat_from_axis_angle(
+            torch.tensor([[0.0, 0.0, 1.0]], device=device, dtype=dtype),
+            torch.tensor([[math.pi / 2.0]], device=device, dtype=dtype),
+        )[0]
+        q_z180 = quat_from_axis_angle(
+            torch.tensor([[0.0, 0.0, 1.0]], device=device, dtype=dtype),
+            torch.tensor([[math.pi]], device=device, dtype=dtype),
+        )[0]
+
+        parent_t = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 2.0, 0.0],
+                [1.0, 2.0, 3.0],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        parent_q = torch.stack([q_identity, q_z90, q_z90], dim=0)
+        child_t = torch.tensor(
+            [
+                [3.0, 4.0, 5.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 2.0, 0.0],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        child_q = torch.stack([q_z90, q_identity, q_z90], dim=0)
+
+        composed_t, composed_q = se3pose_compose(parent_t, parent_q, child_t, child_q)
+
+        expected_t = torch.tensor(
+            [
+                [3.0, 4.0, 5.0],
+                [1.0, 3.0, 0.0],
+                [-1.0, 2.0, 3.0],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        expected_q = torch.stack([q_z90, q_z90, q_z180], dim=0)
+
+        torch.testing.assert_close(composed_t, expected_t, atol=ATOL_STRICT, rtol=RTOL)
+        torch.testing.assert_close(composed_q, expected_q, atol=ATOL, rtol=RTOL)
+
+    def test_se3pose_compose_gradcheck(self):
+        n = GC_SE3_BATCH
+        parent_t, parent_q_raw, _ = _se3_gradcheck_tensors(n, device)
+        child_t, child_q_raw, _ = _se3_gradcheck_tensors(n, device)
+
+        def fn(pt, pq, ct, cq):
+            out_t, out_q = se3pose_compose(
+                pt,
+                _se3_normalized_quat(pq),
+                ct,
+                _se3_normalized_quat(cq),
+            )
+            return torch.cat([out_t, out_q], dim=-1)
+
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                fn,
+                (parent_t, parent_q_raw, child_t, child_q_raw),
+                eps=GC_SE3_EPS,
+                atol=GC_SE3_ATOL,
+                rtol=GC_SE3_RTOL,
+            )
+        )
+
     def test_se3_transform_point_backward(self):
         """Test that gradients flow correctly through SE3 point transformation"""
         N = NUM_POSES_SMALL
@@ -992,6 +1069,875 @@ class TestSE3Pose(unittest.TestCase):
         self.assertIsNotNone(rotations.grad)
         self.assertTrue(torch.any(translations.grad != 0))
         self.assertTrue(torch.any(rotations.grad != 0))
+
+
+class TestPackedSE3TrackInterpolation(unittest.TestCase):
+    """Tests for packed variable-length SE3 pose track interpolation."""
+
+    def setUp(self):
+        torch.manual_seed(TEST_SEED)
+        torch.cuda.manual_seed_all(TEST_SEED)
+
+    def _z_quat(
+        self, degrees: float, dtype: torch.dtype = torch.float32
+    ) -> torch.Tensor:
+        axis = torch.tensor([[0.0, 0.0, 1.0]], device=device, dtype=dtype)
+        angle = torch.tensor([[math.radians(degrees)]], device=device, dtype=dtype)
+        return quat_from_axis_angle(axis, angle)[0]
+
+    def _pose(
+        self,
+        translation: list[float],
+        yaw_degrees: float,
+        dtype: torch.dtype = torch.float32,
+    ) -> torch.Tensor:
+        return torch.cat(
+            [
+                torch.tensor(translation, device=device, dtype=dtype),
+                self._z_quat(yaw_degrees, dtype=dtype),
+            ]
+        )
+
+    def _split_poses(self, poses: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return poses[:, :3], poses[:, 3:7]
+
+    def _two_pose_track(
+        self, dtype: torch.dtype = torch.float32
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        poses = torch.stack(
+            [
+                self._pose([0.0, 0.0, 0.0], 0.0, dtype=dtype),
+                self._pose([2.0, 0.0, 0.0], 90.0, dtype=dtype),
+            ],
+            dim=0,
+        )
+        pose_times = torch.tensor([0.0, 1.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2], device=device, dtype=torch.int32)
+        pose_translations, pose_rotations = self._split_poses(poses)
+        return pose_translations, pose_rotations, pose_times, pose_offsets, pose_counts
+
+    def test_interpolate_tracks_variable_counts_and_per_track_times(self):
+        dtype = torch.float32
+        q0 = self._z_quat(0.0, dtype=dtype)
+        q90 = self._z_quat(90.0, dtype=dtype)
+        q180 = self._z_quat(180.0, dtype=dtype)
+
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q0]),
+                torch.cat([torch.tensor([2.0, 0.0, 0.0], device=device), q90]),
+                torch.cat([torch.tensor([4.0, 0.0, 0.0], device=device), q180]),
+                torch.cat([torch.tensor([5.0, 6.0, 7.0], device=device), q90]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q0]),
+                torch.cat([torch.tensor([20.0, 0.0, 0.0], device=device), q180]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_times = torch.tensor(
+            [0.0, 1.0, 2.0, 4.0, 0.0, 10.0], device=device, dtype=dtype
+        )
+        pose_offsets = torch.tensor([0, 3, 4], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([3, 1, 2], device=device, dtype=torch.int32)
+        query_times = torch.tensor([0.5, 123.0, -5.0], device=device, dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+        )
+
+        expected_q0 = quat_slerp(q0.reshape(1, 4), q90.reshape(1, 4), 0.5)[0]
+        self.assertEqual(out_t.shape, (3, 3))
+        self.assertEqual(out_q.shape, (3, 4))
+        self.assertTrue(
+            torch.allclose(
+                out_t[0],
+                torch.tensor([1.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(torch.allclose(out_q[0], expected_q0, atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_t[1], poses[3, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_q[1], poses[3, 3:], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_t[2], poses[4, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_q[2], poses[4, 3:], atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_clamps_to_last_pose(self):
+        dtype = torch.float32
+        q0 = self._z_quat(0.0, dtype=dtype)
+        q90 = self._z_quat(90.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([1.0, 0.0, 0.0], device=device), q0]),
+                torch.cat([torch.tensor([3.0, 0.0, 0.0], device=device), q90]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_times = torch.tensor([0.0, 1.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int64)
+        pose_counts = torch.tensor([2], device=device, dtype=torch.int64)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            4.0,
+        )
+
+        self.assertTrue(torch.allclose(out_t[0], poses[1, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_q[0], poses[1, 3:], atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_duplicate_timestamp_uses_first_match(self):
+        dtype = torch.float32
+        q = self._z_quat(0.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([11.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([20.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_times = torch.tensor([0.0, 1.0, 1.0, 2.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([4], device=device, dtype=torch.int32)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            1.0,
+        )
+
+        self.assertTrue(torch.isfinite(out_t).all())
+        self.assertTrue(torch.isfinite(out_q).all())
+        self.assertTrue(torch.allclose(out_t[0], poses[1, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_q[0], poses[1, 3:], atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_duplicate_terminal_timestamp_uses_first_match(self):
+        dtype = torch.float32
+        q = self._z_quat(0.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([11.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_times = torch.tensor([0.0, 1.0, 1.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([3], device=device, dtype=torch.int32)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            1.0,
+        )
+
+        self.assertTrue(torch.allclose(out_t[0], poses[1, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_q[0], poses[1, 3:], atol=ATOL_STRICT))
+
+    def test_interpolate_then_compose_gaussian_local_poses(self):
+        """Integration-style check for the intended track-to-Gaussian flow."""
+        dtype = torch.float32
+        track_poses = torch.stack(
+            [
+                self._pose([0.0, 0.0, 0.0], 0.0, dtype=dtype),
+                self._pose([2.0, 0.0, 0.0], 90.0, dtype=dtype),
+                self._pose([0.0, 10.0, 0.0], 0.0, dtype=dtype),
+                self._pose([0.0, 20.0, 0.0], 0.0, dtype=dtype),
+            ],
+            dim=0,
+        )
+        pose_translations, pose_rotations = self._split_poses(track_poses)
+        pose_times = torch.tensor([0.0, 1.0, 0.0, 1.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0, 2], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2, 2], device=device, dtype=torch.int32)
+
+        track_t, track_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            0.5,
+        )
+
+        gaussian_track_ids = torch.tensor([0, 0, 1], device=device, dtype=torch.long)
+        local_t = torch.tensor(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [3.0, 0.0, 0.0],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        local_q = torch.stack(
+            [
+                self._z_quat(0.0, dtype=dtype),
+                self._z_quat(45.0, dtype=dtype),
+                self._z_quat(90.0, dtype=dtype),
+            ],
+            dim=0,
+        )
+
+        world_t, world_q = se3pose_compose(
+            track_t[gaussian_track_ids],
+            track_q[gaussian_track_ids],
+            local_t,
+            local_q,
+        )
+
+        sqrt_half = math.sqrt(0.5)
+        expected_t = torch.tensor(
+            [
+                [1.0 + sqrt_half, sqrt_half, 0.0],
+                [1.0 - sqrt_half, sqrt_half, 0.0],
+                [3.0, 15.0, 0.0],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        expected_q0 = self._z_quat(45.0, dtype=dtype)
+        expected_q1 = self._z_quat(90.0, dtype=dtype)
+        expected_q2 = self._z_quat(90.0, dtype=dtype)
+        expected_q = torch.stack([expected_q0, expected_q1, expected_q2], dim=0)
+
+        self.assertTrue(
+            torch.allclose(
+                track_t[0],
+                torch.tensor([1.0, 0.0, 0.0], device=device),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                track_t[1],
+                torch.tensor([0.0, 15.0, 0.0], device=device),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(torch.allclose(world_t, expected_t, atol=ATOL))
+        self.assertTrue(torch.allclose(world_q, expected_q, atol=ATOL))
+
+    def test_interpolate_tracks_empty_track_set(self):
+        pose_translations = torch.empty(
+            (0, 3), device=device, dtype=torch.float32, requires_grad=True
+        )
+        pose_rotations = torch.empty(
+            (0, 4), device=device, dtype=torch.float32, requires_grad=True
+        )
+        pose_times = torch.empty((0,), device=device, dtype=torch.float32)
+        pose_offsets = torch.empty((0,), device=device, dtype=torch.int32)
+        pose_counts = torch.empty((0,), device=device, dtype=torch.int32)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            0.0,
+        )
+
+        self.assertEqual(out_t.shape, (0, 3))
+        self.assertEqual(out_q.shape, (0, 4))
+        self.assertEqual(out_t.device, pose_translations.device)
+        self.assertEqual(out_q.device, pose_rotations.device)
+        self.assertEqual(out_t.dtype, pose_translations.dtype)
+        self.assertEqual(out_q.dtype, pose_rotations.dtype)
+        (out_t.sum() + out_q.sum()).backward()
+        self.assertIsNotNone(pose_translations.grad)
+        self.assertIsNotNone(pose_rotations.grad)
+        self.assertEqual(pose_translations.grad.shape, pose_translations.shape)
+        self.assertEqual(pose_rotations.grad.shape, pose_rotations.shape)
+
+    def test_interpolate_tracks_float64_correctness(self):
+        dtype = torch.float64
+        (
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+        ) = self._two_pose_track(dtype=dtype)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            0.25,
+        )
+
+        expected_q = quat_slerp(
+            pose_rotations[0:1],
+            pose_rotations[1:2],
+            torch.tensor([0.25], device=device),
+        )[0]
+        self.assertEqual(out_t.dtype, dtype)
+        self.assertEqual(out_q.dtype, dtype)
+        self.assertTrue(
+            torch.allclose(
+                out_t[0],
+                torch.tensor([0.5, 0.0, 0.0], device=device, dtype=dtype),
+                atol=1e-12,
+                rtol=1e-12,
+            )
+        )
+        self.assertTrue(torch.allclose(out_q[0], expected_q, atol=1e-12, rtol=1e-12))
+
+    def test_interpolate_tracks_preserves_large_integer_time_precision(self):
+        dtype = torch.float32
+        q0 = self._z_quat(0.0, dtype=dtype)
+        q90 = self._z_quat(90.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q0]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q90]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+        base_time_ns = 10**18
+        pose_times = torch.tensor(
+            [base_time_ns, base_time_ns + 10],
+            device=device,
+            dtype=torch.int64,
+        )
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2], device=device, dtype=torch.int32)
+        query_time = torch.tensor([base_time_ns + 5], device=device, dtype=torch.int64)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_time,
+        )
+
+        expected_q = quat_slerp(
+            q0.reshape(1, 4),
+            q90.reshape(1, 4),
+            torch.tensor([[0.5]], device=device, dtype=dtype),
+        )[0]
+        self.assertTrue(
+            torch.allclose(
+                out_t[0],
+                torch.tensor([5.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(torch.allclose(out_q[0], expected_q, atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_integer_query_uses_float_pose_time_precision(self):
+        dtype = torch.float32
+        q = self._z_quat(0.0, dtype=dtype)
+        base_time = 2**24
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+        pose_times = torch.tensor(
+            [base_time, base_time + 2],
+            device=device,
+            dtype=dtype,
+        )
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2], device=device, dtype=torch.int32)
+        query_time = torch.tensor([base_time + 1], device=device, dtype=torch.int64)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_time,
+        )
+
+        self.assertTrue(torch.allclose(out_t[0], poses[0, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_q[0], poses[0, 3:], atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_integer_time_delta_extreme_span_no_overflow(self):
+        dtype = torch.float32
+        q = self._z_quat(0.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+        pose_times = torch.tensor(
+            [torch.iinfo(torch.int64).min, torch.iinfo(torch.int64).max],
+            device=device,
+            dtype=torch.int64,
+        )
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2], device=device, dtype=torch.int32)
+        query_time = torch.tensor([0], device=device, dtype=torch.int64)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_time,
+        )
+
+        self.assertTrue(
+            torch.allclose(
+                out_t[0],
+                torch.tensor([5.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(torch.allclose(out_q[0], q, atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_exact_middle_and_last_keyframes(self):
+        dtype = torch.float32
+        poses = torch.stack(
+            [
+                self._pose([0.0, 0.0, 0.0], 0.0, dtype=dtype),
+                self._pose([5.0, 0.0, 0.0], 90.0, dtype=dtype),
+                self._pose([9.0, 0.0, 0.0], 180.0, dtype=dtype),
+            ],
+            dim=0,
+        )
+        pose_times = torch.tensor([0.0, 1.0, 2.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([3], device=device, dtype=torch.int32)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_middle_t, out_middle_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            1.0,
+        )
+        out_last_t, out_last_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            2.0,
+        )
+
+        self.assertTrue(torch.allclose(out_middle_t[0], poses[1, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_middle_q[0], poses[1, 3:], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_last_t[0], poses[2, :3], atol=ATOL_STRICT))
+        self.assertTrue(torch.allclose(out_last_q[0], poses[2, 3:], atol=ATOL_STRICT))
+
+    def test_interpolate_tracks_accepts_column_times_offsets_and_counts(self):
+        dtype = torch.float32
+        poses = torch.stack(
+            [
+                self._pose([0.0, 0.0, 0.0], 0.0, dtype=dtype),
+                self._pose([2.0, 0.0, 0.0], 90.0, dtype=dtype),
+                self._pose([10.0, 0.0, 0.0], 0.0, dtype=dtype),
+                self._pose([20.0, 0.0, 0.0], 180.0, dtype=dtype),
+            ],
+            dim=0,
+        )
+        pose_times = torch.tensor(
+            [[0.0], [1.0], [0.0], [2.0]], device=device, dtype=dtype
+        )
+        pose_offsets = torch.tensor([[0], [2]], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([[2], [2]], device=device, dtype=torch.int32)
+        query_times = torch.tensor([0.5, 1.0], device=device, dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+        )
+
+        self.assertEqual(out_t.shape, (2, 3))
+        self.assertEqual(out_q.shape, (2, 4))
+        self.assertTrue(
+            torch.allclose(
+                out_t[0],
+                torch.tensor([1.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                out_t[1],
+                torch.tensor([15.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+
+    def test_interpolate_tracks_duplicate_timestamp_neighbor_segments(self):
+        dtype = torch.float32
+        q = self._z_quat(0.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([11.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([31.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_times = torch.tensor([0.0, 1.0, 1.0, 3.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([4], device=device, dtype=torch.int32)
+        pose_translations, pose_rotations = self._split_poses(poses)
+
+        out_left_t, _ = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            0.5,
+        )
+        out_right_t, _ = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            2.0,
+        )
+
+        self.assertTrue(
+            torch.allclose(
+                out_left_t[0],
+                torch.tensor([5.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                out_right_t[0],
+                torch.tensor([21.0, 0.0, 0.0], device=device, dtype=dtype),
+                atol=ATOL_STRICT,
+            )
+        )
+
+    def test_interpolate_tracks_validation_failures(self):
+        (
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+        ) = self._two_pose_track()
+        invalid_cases = [
+            (
+                "bad pose_translations shape",
+                pose_translations[:, :2],
+                pose_rotations,
+                pose_times,
+                pose_offsets,
+                pose_counts,
+                0.5,
+            ),
+            (
+                "bad pose_rotations shape",
+                pose_translations,
+                pose_rotations[:, :3],
+                pose_times,
+                pose_offsets,
+                pose_counts,
+                0.5,
+            ),
+            (
+                "bad pose_times shape",
+                pose_translations,
+                pose_rotations,
+                pose_times.reshape(1, 2),
+                pose_offsets,
+                pose_counts,
+                0.5,
+            ),
+            (
+                "bad pose_offsets shape",
+                pose_translations,
+                pose_rotations,
+                pose_times,
+                torch.tensor([[0, 1]], device=device, dtype=torch.int32),
+                pose_counts,
+                0.5,
+            ),
+            (
+                "bad pose_counts shape",
+                pose_translations,
+                pose_rotations,
+                pose_times,
+                pose_offsets,
+                torch.tensor([[2, 2]], device=device, dtype=torch.int32),
+                0.5,
+            ),
+            (
+                "cpu tensor",
+                pose_translations.cpu(),
+                pose_rotations,
+                pose_times,
+                pose_offsets,
+                pose_counts,
+                0.5,
+            ),
+            (
+                "mismatched pose rows",
+                pose_translations,
+                pose_rotations[:1],
+                pose_times,
+                pose_offsets,
+                pose_counts,
+                0.5,
+            ),
+            (
+                "unsupported float16 times",
+                pose_translations,
+                pose_rotations,
+                pose_times.to(dtype=torch.float16),
+                pose_offsets,
+                pose_counts,
+                0.5,
+            ),
+        ]
+
+        for (
+            name,
+            case_translations,
+            case_rotations,
+            case_times,
+            case_offsets,
+            case_counts,
+            query,
+        ) in invalid_cases:
+            with self.subTest(name=name), self.assertRaises((TypeError, ValueError)):
+                se3_interpolate_tracks(
+                    case_translations,
+                    case_rotations,
+                    case_times,
+                    case_offsets,
+                    case_counts,
+                    query,
+                )
+
+    def test_interpolate_tracks_invalid_ranges_are_defensive_noop(self):
+        (
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            _pose_offsets,
+            _pose_counts,
+        ) = self._two_pose_track()
+        pose_offsets = torch.tensor([-1, 0, 999], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2, 0, 1], device=device, dtype=torch.int32)
+        query_time = torch.full((3,), 0.5, device=device, dtype=pose_times.dtype)
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_time,
+        )
+
+        self.assertTrue(torch.allclose(out_t, torch.zeros_like(out_t)))
+        expected_q = torch.tensor(
+            [[0.0, 0.0, 0.0, 1.0]], device=device, dtype=out_q.dtype
+        ).expand_as(out_q)
+        self.assertTrue(torch.allclose(out_q, expected_q))
+
+    def test_interpolate_tracks_query_time_shape_mismatch_raises(self):
+        (
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+        ) = self._two_pose_track()
+        bad_query_times = torch.tensor([0.25, 0.75], device=device)
+
+        with self.assertRaises(ValueError):
+            se3_interpolate_tracks(
+                pose_translations,
+                pose_rotations,
+                pose_times,
+                pose_offsets,
+                pose_counts,
+                bad_query_times,
+            )
+
+    def test_interpolate_tracks_backward_selected_segment(self):
+        dtype = torch.float64
+        q = self._z_quat(0.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([4.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+        pose_translations = pose_translations.clone().requires_grad_(True)
+        pose_rotations = pose_rotations.clone().requires_grad_(True)
+        pose_times = torch.tensor([0.0, 1.0], device=device, dtype=dtype)
+        pose_offsets = torch.tensor([0], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([2], device=device, dtype=torch.int32)
+        query_time = torch.tensor(
+            [0.25], device=device, dtype=dtype, requires_grad=True
+        )
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_time,
+        )
+        (out_t[:, 0].sum() + out_q[:, 0].sum()).backward()
+
+        self.assertIsNotNone(pose_translations.grad)
+        self.assertIsNotNone(pose_rotations.grad)
+        self.assertIsNotNone(query_time.grad)
+        self.assertTrue(torch.isfinite(pose_translations.grad).all())
+        self.assertTrue(torch.isfinite(pose_rotations.grad).all())
+        self.assertTrue(torch.isfinite(query_time.grad).all())
+        self.assertTrue(
+            torch.allclose(
+                query_time.grad, torch.tensor([4.0], device=device, dtype=dtype)
+            )
+        )
+
+    def test_interpolate_tracks_boundary_backward_time_grads_are_zero(self):
+        dtype = torch.float64
+        q = self._z_quat(0.0, dtype=dtype)
+        poses = torch.stack(
+            [
+                torch.cat([torch.tensor([0.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([10.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([20.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([30.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([40.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([50.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([60.0, 0.0, 0.0], device=device), q]),
+                torch.cat([torch.tensor([70.0, 0.0, 0.0], device=device), q]),
+            ],
+            dim=0,
+        ).to(dtype=dtype)
+        pose_translations, pose_rotations = self._split_poses(poses)
+        pose_translations = pose_translations.clone().requires_grad_(True)
+        pose_rotations = pose_rotations.clone().requires_grad_(True)
+        pose_times = torch.tensor(
+            [0.0, 1.0, 2.0, 0.0, 1.0, 0.0, 1.0, 3.0],
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        pose_offsets = torch.tensor([0, 3, 5, 7], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([3, 2, 2, 1], device=device, dtype=torch.int32)
+        query_times = torch.tensor(
+            [1.0, -2.0, 5.0, 9.0],
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+
+        out_t, out_q = se3_interpolate_tracks(
+            pose_translations,
+            pose_rotations,
+            pose_times,
+            pose_offsets,
+            pose_counts,
+            query_times,
+        )
+        (out_t.sum() + out_q.sum()).backward()
+
+        self.assertTrue(torch.isfinite(pose_translations.grad).all())
+        self.assertTrue(torch.isfinite(pose_rotations.grad).all())
+        self.assertTrue(torch.isfinite(pose_times.grad).all())
+        self.assertTrue(torch.isfinite(query_times.grad).all())
+        torch.testing.assert_close(pose_times.grad, torch.zeros_like(pose_times))
+        torch.testing.assert_close(query_times.grad, torch.zeros_like(query_times))
+
+    def test_interpolate_tracks_gradcheck_overlapping_tracks(self):
+        dtype = torch.float64
+        poses = torch.stack(
+            [
+                self._pose([0.0, 0.0, 0.0], 0.0, dtype=dtype),
+                self._pose([2.0, 0.5, 0.0], 45.0, dtype=dtype),
+                self._pose([4.0, 1.0, 0.0], 90.0, dtype=dtype),
+                self._pose([6.0, 1.5, 0.0], 135.0, dtype=dtype),
+            ],
+            dim=0,
+        )
+        pose_translations, pose_rotations = self._split_poses(poses)
+        pose_translations = pose_translations.clone().requires_grad_(True)
+        pose_rotations = pose_rotations.clone().requires_grad_(True)
+        pose_times = torch.tensor(
+            [0.0, 1.0, 2.5, 4.0], device=device, dtype=dtype, requires_grad=True
+        )
+        pose_offsets = torch.tensor([0, 1], device=device, dtype=torch.int32)
+        pose_counts = torch.tensor([3, 3], device=device, dtype=torch.int32)
+        query_times = torch.tensor(
+            [0.75, 3.25], device=device, dtype=dtype, requires_grad=True
+        )
+
+        def fn(translations, rotations, times, queries):
+            return se3_interpolate_tracks(
+                translations,
+                rotations,
+                times,
+                pose_offsets,
+                pose_counts,
+                queries,
+            )
+
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                fn,
+                (pose_translations, pose_rotations, pose_times, query_times),
+                eps=GC_SE3_EPS,
+                atol=GC_SE3_ATOL,
+                rtol=GC_SE3_RTOL,
+                nondet_tol=1e-7,
+            )
+        )
 
 
 class TestTrajectory2Poses(unittest.TestCase):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4033,8 +4033,10 @@ def test_rasterize_to_pixels_eval3d(
     # Rolling-shutter viewmat perturbations are now seeded, so the background
     # structural-gradient bracket is repeatable. The deterministic tile_size=16
     # no-ray case reaches 1.7891e-3; keep the old global-shutter cap and use a
-    # measured rolling-shutter cap with a small margin.
-    background_atol = 1.9e-3 if rs_type != RollingShutterType.GLOBAL else 1.6e-3
+    # measured rolling-shutter cap with a small margin. Blackwell lidar global
+    # shutter can land just above the old 1.6e-3 cap in a single background
+    # gradient entry, so keep that path narrowly widened too.
+    background_atol = 1.9e-3 if rs_type != RollingShutterType.GLOBAL else 2.0e-3
     assert_grad_reference_close(
         v_backgrounds_struct * backgrounds_mask.float(),
         _v_backgrounds_struct * backgrounds_mask.float(),

--- a/tests/test_mcmc_perturb.py
+++ b/tests/test_mcmc_perturb.py
@@ -19,7 +19,16 @@ import gsplat
 device = torch.device("cuda:0")
 
 
-def _pytorch_mcmc_perturb(positions, quats, scales_log, opacities_logit, noise, scaler):
+def _pytorch_mcmc_perturb(
+    positions,
+    quats,
+    scales_log,
+    opacities_logit,
+    noise,
+    noise_scale,
+    t=0.005,
+    k=100.0,
+):
     """Pure-PyTorch reference matching the CUDA kernel logic."""
     from gsplat import quat_scale_to_covar_preci
 
@@ -30,10 +39,7 @@ def _pytorch_mcmc_perturb(positions, quats, scales_log, opacities_logit, noise, 
 
     density = torch.sigmoid(opacities_logit)
 
-    def op_sigmoid(x, k=100, x0=0.995):
-        return 1.0 / (1.0 + torch.exp(-k * (x - x0)))
-
-    w = op_sigmoid(1.0 - density) * scaler
+    w = torch.sigmoid(-float(k) * (density - float(t))) * noise_scale
     weighted_noise = noise * w.unsqueeze(-1)
     delta = torch.einsum("bij,bj->bi", covars, weighted_noise)
     return positions + delta
@@ -49,7 +55,16 @@ def _make_inputs(N=1024, seed=42):
     return positions, quats, scales_log, opacities_logit, noise
 
 
-def _cuda_mcmc_perturb(positions, quats, scales_log, opacities_logit, noise, scaler):
+def _cuda_mcmc_perturb(
+    positions,
+    quats,
+    scales_log,
+    opacities_logit,
+    noise,
+    noise_scale,
+    t=0.005,
+    k=100.0,
+):
     """Call the fused CUDA kernel via torch.ops.gsplat."""
     pos = positions.clone()
     torch.ops.gsplat.mcmc_perturb_positions(
@@ -58,7 +73,9 @@ def _cuda_mcmc_perturb(positions, quats, scales_log, opacities_logit, noise, sca
         scales_log.contiguous(),
         opacities_logit.flatten().contiguous(),
         noise.contiguous(),
-        float(scaler),
+        float(noise_scale),
+        float(t),
+        float(k),
     )
     return pos
 
@@ -93,6 +110,26 @@ class TestMCMCPerturbCUDA:
         )
 
         torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-3)
+
+    def test_cuda_matches_pytorch_custom_gate(self):
+        """Consistency when overriding the default t/k opacity-gate parameters."""
+        positions, quats, scales_log, opacities_logit, noise = _make_inputs()
+        scaler = 0.25
+        t = 0.25
+        k = 8.0
+
+        expected = _pytorch_mcmc_perturb(
+            positions, quats, scales_log, opacities_logit, noise, scaler, t=t, k=k
+        )
+        actual = _cuda_mcmc_perturb(
+            positions, quats, scales_log, opacities_logit, noise, scaler, t=t, k=k
+        )
+        default_actual = _cuda_mcmc_perturb(
+            positions, quats, scales_log, opacities_logit, noise, scaler
+        )
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-4)
+        assert not torch.allclose(actual, default_actual, rtol=1e-4, atol=1e-5)
 
     def test_in_place_modification(self):
         """Kernel should modify positions in-place."""
@@ -280,7 +317,7 @@ class TestMCMCPerturbFallback:
 
         rng_state = torch.cuda.get_rng_state(device)
         gsplat_ops.inject_noise_to_position(
-            params, optimizers={}, state={}, scaler=scaler
+            params, optimizers={}, state={}, noise_scale=scaler, t=0.25, k=8.0
         )
 
         torch.cuda.set_rng_state(rng_state, device)
@@ -292,6 +329,8 @@ class TestMCMCPerturbFallback:
             params["opacities"].detach(),
             noise,
             scaler,
+            t=0.25,
+            k=8.0,
         )
         torch.testing.assert_close(means.detach(), expected, atol=1e-5, rtol=1e-4)
 

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -569,6 +569,7 @@ def test_rasterization(
 
     rtol = 1e-4
     atol = 1e-4
+    extra_signals_atol = atol
     if (
         execution_mode == _RENDER_EXECUTION
         and with_eval3d
@@ -582,6 +583,10 @@ def test_rasterization(
         # slightly from the exact-metadata reference.
         rtol = 3e-4
         atol = 3e-4
+        # Extra signals follow the same approximate fwd-only path, but Blackwell
+        # lidar cases can leave a few isolated metadata pixels just above the
+        # render-color envelope. Keep the wider bound scoped to that metadata.
+        extra_signals_atol = 4e-4
 
     torch.testing.assert_close(alphas, _alphas, rtol=rtol, atol=atol)
     if gaussians.extra_signals is not None:
@@ -589,7 +594,7 @@ def test_rasterization(
             meta["render_extra_signals"],
             _meta["render_extra_signals"],
             rtol=rtol,
-            atol=atol,
+            atol=extra_signals_atol,
         )
 
     if render_mode_has_hit_distance(render_mode):

--- a/tests/test_relocation.py
+++ b/tests/test_relocation.py
@@ -39,6 +39,41 @@ def _binomial_table(n_max: int, device: torch.device) -> torch.Tensor:
     return binoms
 
 
+def _reference_relocation(
+    opacities: torch.Tensor,
+    scales: torch.Tensor,
+    ratios: torch.Tensor,
+    binoms: torch.Tensor,
+    min_opacity: float,
+):
+    opacities = opacities.cpu()
+    scales = scales.cpu()
+    ratios = ratios.cpu().to(torch.int64)
+    binoms = binoms.cpu()
+
+    new_opacities = torch.empty_like(opacities)
+    new_scales = torch.empty_like(scales)
+    eps = torch.finfo(opacities.dtype).eps
+    for idx in range(opacities.shape[0]):
+        n_idx = int(ratios[idx].item())
+        new_opacity = 1.0 - (1.0 - float(opacities[idx])) ** (1.0 / n_idx)
+        new_opacity = min(max(new_opacity, min_opacity), 1.0 - eps)
+        new_opacities[idx] = new_opacity
+
+        denom_sum = 0.0
+        for i in range(1, n_idx + 1):
+            for k in range(i):
+                sign = 1.0 if k % 2 == 0 else -1.0
+                denom_sum += (
+                    float(binoms[i - 1, k])
+                    * sign
+                    * (new_opacity ** (k + 1))
+                    / math.sqrt(k + 1)
+                )
+        new_scales[idx] = scales[idx] * (float(opacities[idx]) / denom_sum)
+    return new_opacities.to(opacities.device), new_scales.to(scales.device)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="relocation is a CUDA op")
 @pytest.mark.parametrize("n_max", [5, 51])
 def test_compute_relocation_smoke(n_max: int):
@@ -51,10 +86,38 @@ def test_compute_relocation_smoke(n_max: int):
     # indexes binoms by ratio so the table must be (n_max, n_max) or larger.
     ratios = torch.randint(1, n_max + 1, (N,), device=device).float()
 
-    new_opacities, new_scales = compute_relocation(opacities, scales, ratios, binoms)
+    new_opacities, new_scales = compute_relocation(
+        opacities, scales, ratios, binoms, min_opacity=0.0
+    )
 
     assert new_opacities.shape == (N,)
     assert new_scales.shape == (N, 3)
     assert (new_opacities > 0).all() and (new_opacities <= 1).all()
     assert torch.isfinite(new_scales).all()
     assert (new_scales >= 0).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="relocation is a CUDA op")
+def test_compute_relocation_min_opacity_clamps_before_scale():
+    n_max = 8
+    binoms = _binomial_table(n_max, device)
+    opacities = torch.tensor([1e-6, 2e-3, 0.2], device=device, dtype=torch.float32)
+    scales = torch.tensor(
+        [[1.0, 0.5, 0.25], [0.25, 0.5, 1.0], [1.5, 0.75, 0.5]],
+        device=device,
+        dtype=torch.float32,
+    )
+    ratios = torch.tensor([8.0, 4.0, 2.0], device=device, dtype=torch.float32)
+    min_opacity = 0.005
+
+    new_opacities, new_scales = compute_relocation(
+        opacities, scales, ratios, binoms, min_opacity=min_opacity
+    )
+    ref_opacities, ref_scales = _reference_relocation(
+        opacities, scales, ratios, binoms, min_opacity
+    )
+
+    torch.testing.assert_close(new_opacities.cpu(), ref_opacities, rtol=1e-6, atol=1e-7)
+    torch.testing.assert_close(new_scales.cpu(), ref_scales, rtol=1e-5, atol=1e-6)
+    assert torch.all(new_opacities[:2] >= min_opacity)
+    assert torch.all(new_opacities[:2] <= min_opacity + 1e-8)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -29,6 +29,23 @@ import gsplat
 device = torch.device("cuda:0")
 
 
+def test_mcmc_strategy_positional_constructor():
+    from gsplat.strategy import MCMCStrategy
+
+    strategy = MCMCStrategy(123, 4.5, 6, 7, 8, 9, 0.1, True, 0.2, 30.0)
+
+    assert strategy.cap_max == 123
+    assert strategy.noise_lr == 4.5
+    assert strategy.refine_start_iter == 6
+    assert strategy.refine_stop_iter == 7
+    assert strategy.noise_injection_stop_iter == 8
+    assert strategy.refine_every == 9
+    assert strategy.min_opacity == 0.1
+    assert strategy.verbose is True
+    assert strategy.noise_opacity_t == 0.2
+    assert strategy.noise_opacity_k == 30.0
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
 def test_strategy():


### PR DESCRIPTION
## Stage 08 - features, perf, and test fixes

Nine MRs merged consecutively:
- `Add parameters for perturbation and relocation ops`
- `dynamic content support` (rigid dynamic tracks in the example dataset loader)
- `fix(tests): Blackwell eval3d parity exceeds tight bounds` - widens the lidar global-shutter background gradient cap (1.6e-3 -> 2.0e-3) and lidar extra-signals metadata cap (-> 4e-4); **this clears the 3 pre-existing Blackwell lidar flakes**.
- `Fix distributed collective schema for PyTorch >= 2.12`
- `perf(cuda): speed up 3DGUT projection across sensor models`
- `feat(geometry): fused SE3 transform helpers`
- multi-backend / mGPU: `Support multiple backends for fused_ssim`, `Add mGPU support for dense 3DGS`, `Add backend CLI option`

**Tests:** full dev:10 suite - **2642 passed, 0 failed**. The stack is fully green from this stage onward.

Stacked on stage 07.