### PR TITLE
[NV] Single-source 3DGS kernel math (addressing + gaussian weight)

### DIFF
--- a/gsplat/cuda/csrc/RasterizeContributingCommon.cuh
+++ b/gsplat/cuda/csrc/RasterizeContributingCommon.cuh
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "Common.h"
+#include "RasterizeToPixels3DGSDevice.cuh"
 
 namespace gsplat
 {
@@ -156,13 +157,13 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_kernel
                     continue;
                 }
 
-                const float dy    = xy_opac.y - py[p];
-                const float sigma = 0.5f * (conic.x * dx * dx + conic.z * dy * dy) + conic.y * dx * dy;
-                const float alpha = min(MAX_ALPHA, opac * __expf(-sigma));
-                if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+                const float dy          = xy_opac.y - py[p];
+                const GaussianWeight gw = eval_gaussian_weight(conic, dx, dy, opac);
+                if(!gw.valid)
                 {
                     continue;
                 }
+                const float alpha = gw.alpha;
 
                 const float T      = accum.transmittance(p);
                 const float next_T = T * (1.0f - alpha);

--- a/gsplat/cuda/csrc/RasterizeContributingCommonSparse.cuh
+++ b/gsplat/cuda/csrc/RasterizeContributingCommonSparse.cuh
@@ -18,6 +18,8 @@
 #pragma once
 
 #include "Common.h"
+#include "RasterizeSparseAddressing.cuh"
+#include "RasterizeToPixels3DGSDevice.cuh"
 
 namespace gsplat
 {
@@ -66,12 +68,12 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
     static_assert(PIXELS_PER_THREAD > 0, "PIXELS_PER_THREAD == 0 - CTA_SIZE must not exceed TILE_SIZE * TILE_SIZE");
 
     // Each block owns one active tile; decode its dense (image, tile) id.
-    const uint32_t ord           = blockIdx.x;
-    const uint32_t n_tiles       = tile_width * tile_height;
-    const uint32_t global_tile   = static_cast<uint32_t>(active_tiles[ord]);
-    const uint32_t tile_in_image = global_tile % n_tiles;
-    const uint32_t tile_y        = tile_in_image / tile_width;
-    const uint32_t tile_x        = tile_in_image % tile_width;
+    const uint32_t ord        = blockIdx.x;
+    const uint32_t n_tiles    = tile_width * tile_height;
+    const int32_t global_tile = active_tiles[ord];
+    uint32_t image_id, tile_x, tile_y;
+    sparse_decode_tile(global_tile, n_tiles, tile_width, image_id, tile_x, tile_y);
+    (void)image_id; // outputs are global [P, ...]; no per-image offset needed
 
     const uint32_t tid      = threadIdx.x;
     const uint32_t thread_x = tid & TILE_MASK;
@@ -100,20 +102,13 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
 
         // Raster-order index within the tile, matching build_sparse_tile_layout.
         const uint32_t in_tile = local_row * TILE_SIZE + thread_x;
-        const uint32_t word    = in_tile >> 6;
-        const uint32_t bit     = in_tile & 63u;
-        if(!((tile_mask_words[word] >> bit) & 1ull))
+        const int64_t slot     = sparse_pixel_slot(tile_mask_words, in_tile, pix_start, pixel_map);
+        if(slot < 0)
         {
             done_mask |= (1u << p);
             continue;
         }
-        uint32_t rank = 0;
-        for(uint32_t w = 0; w < word; ++w)
-        {
-            rank += __popcll(tile_mask_words[w]);
-        }
-        rank        += __popcll(tile_mask_words[word] & (((uint64_t)1 << bit) - 1));
-        pix_slot[p]  = static_cast<int32_t>(pixel_map[pix_start + rank]);
+        pix_slot[p] = static_cast<int32_t>(slot);
     }
 
     const int32_t range_start  = tile_offsets[ord];
@@ -173,13 +168,13 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
                     continue;
                 }
 
-                const float dy    = xy_opac.y - py[p];
-                const float sigma = 0.5f * (conic.x * dx * dx + conic.z * dy * dy) + conic.y * dx * dy;
-                const float alpha = min(MAX_ALPHA, opac * __expf(-sigma));
-                if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+                const float dy          = xy_opac.y - py[p];
+                const GaussianWeight gw = eval_gaussian_weight(conic, dx, dy, opac);
+                if(!gw.valid)
                 {
                     continue;
                 }
+                const float alpha = gw.alpha;
 
                 const float T      = accum.transmittance(p);
                 const float next_T = T * (1.0f - alpha);

--- a/gsplat/cuda/csrc/RasterizeSparseAddressing.cuh
+++ b/gsplat/cuda/csrc/RasterizeSparseAddressing.cuh
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+// Addressing shared by the sparse 3DGS ops (rasterizer fwd/bwd and the
+// contributing-gaussian harness). Each block owns one active tile; outputs are
+// packed in original-pixel order ([P, ...]). These map a block's active tile and
+// a thread's in-tile pixel to the dense (image, tile) coordinates and the packed
+// output slot, via the per-tile bitmask (popcount rank) and pixel_map produced
+// by build_sparse_tile_layout.
+
+namespace gsplat
+{
+// Decode a dense global tile id into (image, tile_x, tile_y).
+__device__ __forceinline__ void sparse_decode_tile(
+    const int32_t global_tile,
+    const uint32_t n_tiles,
+    const uint32_t tile_width,
+    uint32_t &image_id,
+    uint32_t &tile_x,
+    uint32_t &tile_y
+)
+{
+    const uint32_t gt            = static_cast<uint32_t>(global_tile);
+    image_id                     = gt / n_tiles;
+    const uint32_t tile_in_image = gt % n_tiles;
+    tile_y                       = tile_in_image / tile_width;
+    tile_x                       = tile_in_image % tile_width;
+}
+
+// Packed [P] output slot for the active pixel at raster-order in-tile position
+// `in_tile` of an active tile. `tile_mask_words` points at that tile's bitmask
+// words (tile_pixel_mask + ord * words) and `pix_start` is the exclusive start
+// of the tile's active pixels in pixel_map (tile_pixel_cumsum[ord - 1], or 0).
+// Returns -1 if the position holds no requested pixel. The rank is the number of
+// active pixels before this in-tile position, so pixel_map maps it to the
+// original (output) pixel index.
+__device__ __forceinline__ int64_t sparse_pixel_slot(
+    const uint64_t *__restrict__ tile_mask_words,
+    const uint32_t in_tile,
+    const int64_t pix_start,
+    const int64_t *__restrict__ pixel_map
+)
+{
+    const uint32_t word = in_tile >> 6;
+    const uint32_t bit  = in_tile & 63u;
+    if(!((tile_mask_words[word] >> bit) & 1ull))
+    {
+        return -1;
+    }
+    uint32_t rank = 0;
+    for(uint32_t w = 0; w < word; ++w)
+    {
+        rank += __popcll(tile_mask_words[w]);
+    }
+    rank += __popcll(tile_mask_words[word] & (((uint64_t)1 << bit) - 1));
+    return pixel_map[pix_start + rank];
+}
+} // namespace gsplat

--- a/gsplat/cuda/csrc/RasterizeToIndices3DGSSerialBatch.cu
+++ b/gsplat/cuda/csrc/RasterizeToIndices3DGSSerialBatch.cu
@@ -27,6 +27,7 @@
 
 #    include "Common.h"
 #    include "Rasterization.h"
+#    include "RasterizeToPixels3DGSDevice.cuh"
 
 namespace gsplat
 {
@@ -154,18 +155,15 @@ __global__ void rasterize_to_indices_3dgs_kernel(
         uint32_t batch_size = min(block_size, isect_range_end - batch_start);
         for(uint32_t t = 0; (t < batch_size) && !done; ++t)
         {
-            const vec3 conic   = conic_batch[t];
-            const vec3 xy_opac = xy_opacity_batch[t];
-            const float opac   = xy_opac.z;
-            const vec2 delta   = {xy_opac.x - px, xy_opac.y - py};
-            const float sigma
-                = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;
-            float alpha = min(MAX_ALPHA, opac * __expf(-sigma));
-
-            if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+            const vec3 conic        = conic_batch[t];
+            const vec3 xy_opac      = xy_opacity_batch[t];
+            const float opac        = xy_opac.z;
+            const GaussianWeight gw = eval_gaussian_weight(conic, xy_opac.x - px, xy_opac.y - py, opac);
+            if(!gw.valid)
             {
                 continue;
             }
+            const float alpha = gw.alpha;
 
             next_trans = trans * (1.0f - alpha);
             if(next_trans <= TRANSMITTANCE_THRESHOLD)

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSDevice.cuh
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSDevice.cuh
@@ -28,6 +28,32 @@
 
 namespace gsplat
 {
+// Per-(gaussian, pixel) gaussian-weight evaluation shared by every 3DGS
+// conic-based kernel. Computes the Mahalanobis exponent from the conic and the
+// pixel offset (dx, dy) = (mean - pixel), the resulting alpha (clamped to
+// MAX_ALPHA), and whether the sample contributes. `valid == false` means the
+// caller skips this gaussian (negative exponent or sub-threshold alpha). `vis`
+// (== exp(-sigma)) is retained for the backward pass, which needs it directly.
+struct GaussianWeight
+{
+    float vis;   // __expf(-sigma)
+    float alpha; // min(MAX_ALPHA, opac * vis)
+    bool valid;  // sigma >= 0 and alpha >= ALPHA_THRESHOLD
+};
+
+__device__ __forceinline__ GaussianWeight
+    eval_gaussian_weight(const vec3 &conic, const float dx, const float dy, const float opac)
+{
+    const float sigma = 0.5f * (conic.x * dx * dx + conic.z * dy * dy) + conic.y * dx * dy;
+    const float vis   = __expf(-sigma);
+    const float alpha = min(MAX_ALPHA, opac * vis);
+    GaussianWeight out;
+    out.vis   = vis;
+    out.alpha = alpha;
+    out.valid = !(sigma < 0.f || alpha < ALPHA_THRESHOLD);
+    return out;
+}
+
 // Forward: blend one gaussian into one pixel's running color/transmittance.
 // Returns true when the pixel has saturated (transmittance fell to the
 // threshold) and should stop accumulating -- the caller marks it done and the
@@ -45,15 +71,15 @@ __device__ __forceinline__ bool rasterize_to_pixels_3dgs_blend_fwd(
     uint32_t &cur_idx                    // last contributing gaussian, updated
 )
 {
-    const float opac  = xy_opacity.z;
-    const float dx    = xy_opacity.x - px;
-    const float dy    = xy_opacity.y - py;
-    const float sigma = 0.5f * (conic.x * dx * dx + conic.z * dy * dy) + conic.y * dx * dy;
-    const float alpha = min(MAX_ALPHA, opac * __expf(-sigma));
-    if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+    const float opac        = xy_opacity.z;
+    const float dx          = xy_opacity.x - px;
+    const float dy          = xy_opacity.y - py;
+    const GaussianWeight gw = eval_gaussian_weight(conic, dx, dy, opac);
+    if(!gw.valid)
     {
         return false; // negligible contribution; pixel not done
     }
+    const float alpha  = gw.alpha;
     const float next_T = T * (1.0f - alpha);
     if(next_T <= TRANSMITTANCE_THRESHOLD)
     {

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
@@ -28,6 +28,7 @@
 
 #    include "Common.h"
 #    include "Rasterization.h"
+#    include "RasterizeToPixels3DGSDevice.cuh"
 #    include "Utils.cuh"
 #    include "Dispatch.h"
 
@@ -198,15 +199,14 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
 
             if(valid)
             {
-                conic        = conic_batch[t];
-                vec3 xy_opac = xy_opacity_batch[t];
-                opac         = xy_opac.z;
-                delta        = {xy_opac.x - px, xy_opac.y - py};
-                float sigma
-                    = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;
-                vis   = __expf(-sigma);
-                alpha = min(MAX_ALPHA, opac * vis);
-                if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+                conic                   = conic_batch[t];
+                vec3 xy_opac            = xy_opacity_batch[t];
+                opac                    = xy_opac.z;
+                delta                   = {xy_opac.x - px, xy_opac.y - py};
+                const GaussianWeight gw = eval_gaussian_weight(conic, delta.x, delta.y, opac);
+                vis                     = gw.vis;
+                alpha                   = gw.alpha;
+                if(!gw.valid)
                 {
                     valid = false;
                 }

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
@@ -27,6 +27,7 @@
 #    include "Common.h"
 #    include "Dispatch.h"
 #    include "Rasterization.h"
+#    include "RasterizeToPixels3DGSDevice.cuh"
 #    include "Utils.cuh"
 
 namespace gsplat
@@ -234,13 +235,13 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
                     continue;
                 }
 
-                const float dy    = xy_opac.y - py[p];
-                const float sigma = 0.5f * (conic.x * dx * dx + conic.z * dy * dy) + conic.y * dx * dy;
-                float alpha       = min(MAX_ALPHA, opac * __expf(-sigma));
-                if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+                const float dy          = xy_opac.y - py[p];
+                const GaussianWeight gw = eval_gaussian_weight(conic, dx, dy, opac);
+                if(!gw.valid)
                 {
                     continue;
                 }
+                const float alpha = gw.alpha;
 
                 const float next_T = T[p] * (1.0f - alpha);
                 if(next_T <= TRANSMITTANCE_THRESHOLD)

--- a/gsplat/cuda/csrc/RasterizeToPixelsSparseBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsSparseBwd.cu
@@ -28,6 +28,7 @@
 #    include "Common.h"
 #    include "Dispatch.h"
 #    include "Rasterization.h"
+#    include "RasterizeSparseAddressing.cuh"
 #    include "RasterizeToPixels3DGSDevice.cuh"
 #    include "Utils.cuh"
 
@@ -85,21 +86,19 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
     float *__restrict__ v_opacities   // [I, N] or [nnz]
 )
 {
-    auto block                   = cg::this_thread_block();
-    const uint32_t ord           = block.group_index().x;
-    const uint32_t n_tiles       = tile_width * tile_height;
-    const uint32_t global_tile   = (uint32_t)active_tiles[ord];
-    const uint32_t image_id      = global_tile / n_tiles;
-    const uint32_t tile_in_image = global_tile % n_tiles;
-    const uint32_t tile_y        = tile_in_image / tile_width;
-    const uint32_t tile_x        = tile_in_image % tile_width;
+    auto block                = cg::this_thread_block();
+    const uint32_t ord        = block.group_index().x;
+    const uint32_t n_tiles    = tile_width * tile_height;
+    const int32_t global_tile = active_tiles[ord];
+    uint32_t image_id, tile_x, tile_y;
+    sparse_decode_tile(global_tile, n_tiles, tile_width, image_id, tile_x, tile_y);
 
     if(backgrounds != nullptr)
     {
         backgrounds += image_id * CDIM;
     }
     // Masked tile contributes only a constant background -> zero gradient.
-    if(masks != nullptr && !masks[image_id * n_tiles + tile_in_image])
+    if(masks != nullptr && !masks[global_tile])
     {
         return;
     }
@@ -114,20 +113,8 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
     const int64_t pix_start         = (ord == 0) ? 0 : tile_pixel_cumsum[ord - 1];
     const uint64_t *tile_mask_words = tile_pixel_mask + (int64_t)ord * words;
     const uint32_t in_tile          = local_row * tile_size + local_col;
-    const uint32_t word             = in_tile >> 6;
-    const uint32_t bit              = in_tile & 63u;
-    const bool inside               = (tile_mask_words[word] >> bit) & 1ull;
-    int64_t out_idx                 = -1;
-    if(inside)
-    {
-        uint32_t rank = 0;
-        for(uint32_t w = 0; w < word; ++w)
-        {
-            rank += __popcll(tile_mask_words[w]);
-        }
-        rank    += __popcll(tile_mask_words[word] & (((uint64_t)1 << bit) - 1));
-        out_idx  = pixel_map[pix_start + rank];
-    }
+    const int64_t out_idx           = sparse_pixel_slot(tile_mask_words, in_tile, pix_start, pixel_map);
+    const bool inside               = out_idx >= 0;
 
     const int32_t range_start  = tile_offsets[ord];
     const int32_t range_end    = tile_offsets[ord + 1];
@@ -202,15 +189,14 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
 
             if(valid)
             {
-                conic        = conic_batch[t];
-                vec3 xy_opac = xy_opacity_batch[t];
-                opac         = xy_opac.z;
-                delta        = {xy_opac.x - px, xy_opac.y - py};
-                float sigma
-                    = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;
-                vis   = __expf(-sigma);
-                alpha = min(MAX_ALPHA, opac * vis);
-                if(sigma < 0.f || alpha < ALPHA_THRESHOLD)
+                conic                   = conic_batch[t];
+                vec3 xy_opac            = xy_opacity_batch[t];
+                opac                    = xy_opac.z;
+                delta                   = {xy_opac.x - px, xy_opac.y - py};
+                const GaussianWeight gw = eval_gaussian_weight(conic, delta.x, delta.y, opac);
+                vis                     = gw.vis;
+                alpha                   = gw.alpha;
+                if(!gw.valid)
                 {
                     valid = false;
                 }

--- a/gsplat/cuda/csrc/RasterizeToPixelsSparseFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsSparseFwd.cu
@@ -26,6 +26,7 @@
 #    include "Common.h"
 #    include "Dispatch.h"
 #    include "Rasterization.h"
+#    include "RasterizeSparseAddressing.cuh"
 #    include "RasterizeToPixels3DGSDevice.cuh"
 
 namespace gsplat
@@ -80,13 +81,11 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
     static_assert(PIXELS_PER_THREAD > 0, "PIXELS_PER_THREAD == 0 - CTA_SIZE must not exceed TILE_SIZE * TILE_SIZE");
 
     // Each block owns one active tile; decode its dense (image, tile) id.
-    const uint32_t ord           = blockIdx.x;
-    const uint32_t n_tiles       = tile_width * tile_height;
-    const uint32_t global_tile   = (uint32_t)active_tiles[ord];
-    const uint32_t image_id      = global_tile / n_tiles;
-    const uint32_t tile_in_image = global_tile % n_tiles;
-    const uint32_t tile_y        = tile_in_image / tile_width;
-    const uint32_t tile_x        = tile_in_image % tile_width;
+    const uint32_t ord        = blockIdx.x;
+    const uint32_t n_tiles    = tile_width * tile_height;
+    const int32_t global_tile = active_tiles[ord];
+    uint32_t image_id, tile_x, tile_y;
+    sparse_decode_tile(global_tile, n_tiles, tile_width, image_id, tile_x, tile_y);
 
     const uint32_t tid      = threadIdx.x;
     const uint32_t thread_x = tid & TILE_MASK;
@@ -121,28 +120,18 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
         // Raster-order index within the tile, matching the bitmask packing of
         // build_sparse_tile_layout (in_tile = (row % ts) * ts + (col % ts)).
         const uint32_t in_tile = local_row * TILE_SIZE + thread_x;
-        const uint32_t word    = in_tile >> 6;
-        const uint32_t bit     = in_tile & 63u;
-        const bool active      = (tile_mask_words[word] >> bit) & 1ull;
-        if(!active)
+        const int64_t slot     = sparse_pixel_slot(tile_mask_words, in_tile, pix_start, pixel_map);
+        if(slot < 0)
         {
             done_mask |= (1u << p);
             continue;
         }
-        // Rank among the tile's active pixels = set bits before this in-tile
-        // index; the matching pixel_map entry is the original (output) index.
-        uint32_t rank = 0;
-        for(uint32_t w = 0; w < word; ++w)
-        {
-            rank += __popcll(tile_mask_words[w]);
-        }
-        rank       += __popcll(tile_mask_words[word] & (((uint64_t)1 << bit) - 1));
-        out_idx[p]  = pixel_map[pix_start + rank];
+        out_idx[p] = slot;
     }
 
     // Masked-off tile: write background to its active pixels and return, so no
     // active output slot is left uninitialized.
-    if(masks != nullptr && !masks[image_id * n_tiles + tile_in_image])
+    if(masks != nullptr && !masks[global_tile])
     {
 #    pragma unroll
         for(uint32_t p = 0; p < PIXELS_PER_THREAD; ++p)


### PR DESCRIPTION
## Stage 09 - single-source 3DGS kernel math

Upstreams `mjh/single-source-raster-math`: factors the 3DGS kernel addressing + gaussian-weight math into shared headers so dense and sparse paths single-source it (adds `RasterizeSparseAddressing.cuh`). Behavior-preserving refactor.

**Tests:** full dev:10 suite - 2642 passed, 0 failed.

Stacked on stage 08.