### PR TITLE
[NV] Sensor SLERP consolidation, autograd-output cleanup, compile-time trim

### DIFF
--- a/gsplat/cuda/_torch_impl.py
+++ b/gsplat/cuda/_torch_impl.py
@@ -252,8 +252,9 @@ def _world_to_cam(
     means_c = (
         torch.einsum("...cij,...nj->...cni", R, means) + t[..., None, :]
     )  # [..., C, N, 3]
-    covars_c = torch.einsum(
-        "...cij,...njk,...clk->...cnil", R, covars, R
+    R_expanded = R[..., :, None, :, :]  # [..., C, 1, 3, 3]
+    covars_c = (
+        R_expanded @ covars[..., None, :, :, :] @ R_expanded.transpose(-1, -2)
     )  # [..., C, N, 3, 3]
     return means_c, covars_c
 

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -71,18 +71,6 @@ def _has_schema(op_name: str) -> bool:
     return True
 
 
-def _dense_contiguous(t: Optional[Tensor]) -> Optional[Tensor]:
-    """Materialize an incoming output gradient as a dense, contiguous tensor.
-
-    Backward CUDA ops index raw dense storage and require contiguous inputs, so a
-    sparse gradient is densified and any gradient is made contiguous. ``None`` (a
-    disabled or non-differentiable output) passes through unchanged.
-    """
-    if t is None:
-        return None
-    return (t.to_dense() if t.is_sparse else t).contiguous()
-
-
 def _register_autograd(register: type) -> None:
     """Attach a Python autograd backward to the C++ forward op ``gsplat::<base>``.
 
@@ -495,7 +483,7 @@ class RegisterSphericalHarmonics:
             dirs,
             coeffs,
             masks,
-            _dense_contiguous(v_colors),
+            v_colors,
             compute_v_dirs,
         )
         return (
@@ -556,8 +544,8 @@ class RegisterQuatScaleToCovarPreci:
             quats,
             scales,
             ctx.triu,
-            _dense_contiguous(v_covars),
-            _dense_contiguous(v_precis),
+            v_covars,
+            v_precis,
         )
         return (
             v_quats,
@@ -654,8 +642,8 @@ class RegisterProjectionEWASimple:
             ctx.width,
             ctx.height,
             ctx.camera_model,
-            _dense_contiguous(v_means2d),
-            _dense_contiguous(v_covars2d),
+            v_means2d,
+            v_covars2d,
         )
         return (
             v_means,
@@ -887,10 +875,10 @@ class RegisterProjectionEWA3DGSFused:
             radii,
             conics,
             compensations,
-            _dense_contiguous(v_means2d),
-            _dense_contiguous(v_depths),
-            _dense_contiguous(v_conics),
-            _dense_contiguous(v_compensations),
+            v_means2d,
+            v_depths,
+            v_conics,
+            v_compensations,
             ctx.needs_input_grad[
                 5
             ],  # viewmats_requires_grad (viewmats is input index 5)
@@ -1015,10 +1003,10 @@ class RegisterProjectionEWA3DGSPacked:
             gaussian_ids,
             conics,
             compensations,
-            _dense_contiguous(v_means2d),
-            _dense_contiguous(v_depths),
-            _dense_contiguous(v_conics),
-            _dense_contiguous(v_compensations),
+            v_means2d,
+            v_depths,
+            v_conics,
+            v_compensations,
             ctx.needs_input_grad[
                 5
             ],  # viewmats_requires_grad (viewmats is input index 5)
@@ -1942,8 +1930,8 @@ class RegisterRasterizeToPixels3DGS:
             ctx.height,
             ctx.tile_size,
             ctx.absgrad,
-            _dense_contiguous(v_render_colors),
-            _dense_contiguous(v_render_alphas),
+            v_render_colors,
+            v_render_alphas,
             ctx.needs_input_grad[
                 4
             ],  # compute_v_backgrounds (backgrounds is input index 4)
@@ -2078,8 +2066,8 @@ class RegisterRasterizeToPixelsSparse:
             ctx.tile_width,
             ctx.tile_height,
             ctx.absgrad,
-            _dense_contiguous(v_render_colors),
-            _dense_contiguous(v_render_alphas),
+            v_render_colors,
+            v_render_alphas,
             ctx.needs_input_grad[
                 4
             ],  # compute_v_backgrounds (backgrounds is input index 4)
@@ -2629,10 +2617,10 @@ class RegisterProjection2DGSFused:
             ctx.height,
             radii,
             ray_transforms,
-            _dense_contiguous(v_means2d),
-            _dense_contiguous(v_depths),
-            _dense_contiguous(v_ray_transforms),
-            _dense_contiguous(v_normals),
+            v_means2d,
+            v_depths,
+            v_ray_transforms,
+            v_normals,
             ctx.needs_input_grad[
                 3
             ],  # viewmats_requires_grad (viewmats is input index 3)
@@ -2738,10 +2726,10 @@ class RegisterProjection2DGSPacked:
             camera_ids,
             gaussian_ids,
             ray_transforms,
-            _dense_contiguous(v_means2d),
-            _dense_contiguous(v_depths),
-            _dense_contiguous(v_ray_transforms),
-            _dense_contiguous(v_normals),
+            v_means2d,
+            v_depths,
+            v_ray_transforms,
+            v_normals,
             ctx.needs_input_grad[
                 3
             ],  # viewmats_requires_grad (viewmats is input index 3)
@@ -2965,11 +2953,11 @@ class RegisterRasterizeToPixels2DGS:
             ctx.height,
             ctx.tile_size,
             ctx.absgrad,
-            _dense_contiguous(v_render_colors),
-            _dense_contiguous(v_render_alphas),
-            _dense_contiguous(v_render_normals),
-            _dense_contiguous(v_render_distort),
-            _dense_contiguous(v_render_median),
+            v_render_colors,
+            v_render_alphas,
+            v_render_normals,
+            v_render_distort,
+            v_render_median,
             ctx.needs_input_grad[
                 6
             ],  # compute_v_backgrounds (backgrounds is input index 6)

--- a/gsplat/cuda/csrc/Projection.cpp
+++ b/gsplat/cuda/csrc/Projection.cpp
@@ -613,11 +613,14 @@ ProjectionEWA3DGSFusedBwdResult projection_ewa_3dgs_fused_bwd(
     CHECK_INPUT(radii);
     CHECK_INPUT(conics);
     CHECK_DENSE(grad.means2d);
-    CHECK_INPUT(grad.means2d);
     CHECK_DENSE(grad.depths);
-    CHECK_INPUT(grad.depths);
     CHECK_DENSE(grad.conics);
-    CHECK_INPUT(grad.conics);
+    at::Tensor grad_means2d = grad.means2d.contiguous();
+    at::Tensor grad_depths  = grad.depths.contiguous();
+    at::Tensor grad_conics  = grad.conics.contiguous();
+    CHECK_INPUT(grad_means2d);
+    CHECK_INPUT(grad_depths);
+    CHECK_INPUT(grad_conics);
     if(compensations.has_value())
     {
         CHECK_INPUT(compensations.value());
@@ -626,11 +629,13 @@ ProjectionEWA3DGSFusedBwdResult projection_ewa_3dgs_fused_bwd(
     // computed; under materialize_grads a compensations output that was not
     // requested can still receive a zero gradient, which is ignored here.
     at::optional<at::Tensor> compensation_grad;
+    at::Tensor grad_compensations;
     if(compensations.has_value() && grad.compensations.has_value())
     {
         CHECK_DENSE(grad.compensations.value());
-        CHECK_INPUT(grad.compensations.value());
-        compensation_grad = grad.compensations;
+        grad_compensations = grad.compensations.value().contiguous();
+        CHECK_INPUT(grad_compensations);
+        compensation_grad = grad_compensations;
     }
 
     at::Tensor v_means = at::zeros_like(means);
@@ -665,9 +670,9 @@ ProjectionEWA3DGSFusedBwdResult projection_ewa_3dgs_fused_bwd(
         radii,
         conics,
         compensations,
-        grad.means2d,
-        grad.depths,
-        grad.conics,
+        grad_means2d,
+        grad_depths,
+        grad_conics,
         compensation_grad,
         viewmats_requires_grad,
         // outputs
@@ -1091,9 +1096,12 @@ ProjectionEWA3DGSPackedBwdResult projection_ewa_3dgs_packed_bwd(
     CHECK_DENSE(grad.means2d);
     CHECK_DENSE(grad.depths);
     CHECK_DENSE(grad.conics);
-    CHECK_INPUT(grad.means2d);
-    CHECK_INPUT(grad.depths);
-    CHECK_INPUT(grad.conics);
+    at::Tensor grad_means2d = grad.means2d.contiguous();
+    at::Tensor grad_depths  = grad.depths.contiguous();
+    at::Tensor grad_conics  = grad.conics.contiguous();
+    CHECK_INPUT(grad_means2d);
+    CHECK_INPUT(grad_depths);
+    CHECK_INPUT(grad_conics);
     if(compensations.has_value())
     {
         CHECK_INPUT(compensations.value());
@@ -1102,11 +1110,13 @@ ProjectionEWA3DGSPackedBwdResult projection_ewa_3dgs_packed_bwd(
     // computed; under materialize_grads a compensations output that was not
     // requested can still receive a zero gradient, which is ignored here.
     at::optional<at::Tensor> compensation_grad;
+    at::Tensor grad_compensations;
     if(compensations.has_value() && grad.compensations.has_value())
     {
         CHECK_DENSE(grad.compensations.value());
-        CHECK_INPUT(grad.compensations.value());
-        compensation_grad = grad.compensations;
+        grad_compensations = grad.compensations.value().contiguous();
+        CHECK_INPUT(grad_compensations);
+        compensation_grad = grad_compensations;
     }
 
     auto opt     = means.options();
@@ -1162,9 +1172,9 @@ ProjectionEWA3DGSPackedBwdResult projection_ewa_3dgs_packed_bwd(
         conics,
         compensations,
         // grad outputs
-        grad.means2d,
-        grad.depths,
-        grad.conics,
+        grad_means2d,
+        grad_depths,
+        grad_conics,
         compensation_grad,
         sparse_grad,
         // outputs

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -501,9 +501,11 @@ RasterizeToPixels3DGSBwdResult rasterize_to_pixels_3dgs_bwd(
     CHECK_INPUT(render_alphas);
     CHECK_INPUT(last_ids);
     CHECK_DENSE(grad.renders);
-    CHECK_INPUT(grad.renders);
     CHECK_DENSE(grad.alphas);
-    CHECK_INPUT(grad.alphas);
+    at::Tensor v_render_colors = grad.renders.contiguous();
+    at::Tensor v_render_alphas = grad.alphas.contiguous();
+    CHECK_INPUT(v_render_colors);
+    CHECK_INPUT(v_render_alphas);
     if(backgrounds.has_value())
     {
         CHECK_INPUT(backgrounds.value());
@@ -537,8 +539,8 @@ RasterizeToPixels3DGSBwdResult rasterize_to_pixels_3dgs_bwd(
         flatten_ids,
         render_alphas,
         last_ids,
-        grad.renders,
-        grad.alphas,
+        v_render_colors,
+        v_render_alphas,
         as_optional_tensor(v_means2d_abs),
         v_means2d,
         v_conics,
@@ -554,7 +556,7 @@ RasterizeToPixels3DGSBwdResult rasterize_to_pixels_3dgs_bwd(
     {
         const at::Tensor one_minus_alpha
             = at::sub(at::ones_like(render_alphas).to(at::kFloat), render_alphas.to(at::kFloat));
-        v_backgrounds = at::mul(grad.renders, one_minus_alpha).sum({-3, -2});
+        v_backgrounds = at::mul(v_render_colors, one_minus_alpha).sum({-3, -2});
     }
 
     return RasterizeToPixels3DGSBwdResult{
@@ -2023,15 +2025,20 @@ RasterizeToPixels2DGSBwdResult rasterize_to_pixels_2dgs_bwd(
     CHECK_INPUT(last_ids);
     CHECK_INPUT(median_ids);
     CHECK_DENSE(grad.renders);
-    CHECK_INPUT(grad.renders);
     CHECK_DENSE(grad.alphas);
-    CHECK_INPUT(grad.alphas);
     CHECK_DENSE(grad.render_normals);
-    CHECK_INPUT(grad.render_normals);
     CHECK_DENSE(grad.render_distort);
-    CHECK_INPUT(grad.render_distort);
     CHECK_DENSE(grad.render_median);
-    CHECK_INPUT(grad.render_median);
+    at::Tensor v_render_colors  = grad.renders.contiguous();
+    at::Tensor v_render_alphas  = grad.alphas.contiguous();
+    at::Tensor v_render_normals = grad.render_normals.contiguous();
+    at::Tensor v_render_distort = grad.render_distort.contiguous();
+    at::Tensor v_render_median  = grad.render_median.contiguous();
+    CHECK_INPUT(v_render_colors);
+    CHECK_INPUT(v_render_alphas);
+    CHECK_INPUT(v_render_normals);
+    CHECK_INPUT(v_render_distort);
+    CHECK_INPUT(v_render_median);
     if(backgrounds.has_value())
     {
         CHECK_INPUT(backgrounds.value());
@@ -2071,11 +2078,11 @@ RasterizeToPixels2DGSBwdResult rasterize_to_pixels_2dgs_bwd(
         render_alphas,
         last_ids,
         median_ids,
-        grad.renders,
-        grad.alphas,
-        grad.render_normals,
-        grad.render_distort,
-        grad.render_median,
+        v_render_colors,
+        v_render_alphas,
+        v_render_normals,
+        v_render_distort,
+        v_render_median,
         absgrad ? c10::optional<at::Tensor>(v_means2d_abs) : c10::nullopt,
         v_means2d,
         v_ray_transforms,
@@ -2093,7 +2100,7 @@ RasterizeToPixels2DGSBwdResult rasterize_to_pixels_2dgs_bwd(
     {
         const at::Tensor one_minus_alpha
             = at::sub(at::ones_like(render_alphas).to(at::kFloat), render_alphas.to(at::kFloat));
-        v_backgrounds = at::mul(grad.renders, one_minus_alpha).sum({-3, -2});
+        v_backgrounds = at::mul(v_render_colors, one_minus_alpha).sum({-3, -2});
     }
 
     return RasterizeToPixels2DGSBwdResult{

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
@@ -710,7 +710,6 @@ template<
     uint32_t TILE_SIZE,
     uint32_t CTA_SIZE,
     bool ReturnNormals,
-    bool UseHitDistance,
     bool ForBackward,
     // When false (unsafe_masked_tile_outputs=True), the masked-tile safe-store
     // below compiles out — masked outputs are left undefined. Mirrors the
@@ -1822,7 +1821,6 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
                 TILE_SIZE,
                 CTA_SIZE,
                 ReturnNormals,
-                UseHitDistance,
                 ForBackward,
                 SAFE_MASKED_OUTPUTS,
                 float

--- a/gsplat/cuda/csrc/SphericalHarmonics.cpp
+++ b/gsplat/cuda/csrc/SphericalHarmonics.cpp
@@ -186,11 +186,12 @@ SphericalHarmonicsBwdResult spherical_harmonics_bwd(
     check_spherical_harmonics_inputs(degrees_to_use, dirs, coeffs, masks);
     TORCH_INTERNAL_ASSERT(grad.colors.defined());
     CHECK_DENSE(grad.colors);
-    CHECK_INPUT(grad.colors);
+    at::Tensor grad_colors = grad.colors.contiguous();
+    CHECK_INPUT(grad_colors);
     TORCH_CHECK(
-        grad.colors.size(-1) == coeffs.size(-1),
+        grad_colors.size(-1) == coeffs.size(-1),
         "v_colors last dim (",
-        grad.colors.size(-1),
+        grad_colors.size(-1),
         ") must match coeffs last dim (",
         coeffs.size(-1),
         ")"
@@ -207,7 +208,7 @@ SphericalHarmonicsBwdResult spherical_harmonics_bwd(
     }
 
     launch_spherical_harmonics_bwd_kernel(
-        degrees_to_use, dirs, coeffs, masks, grad.colors, v_coeffs_accum, as_optional_tensor(v_dirs)
+        degrees_to_use, dirs, coeffs, masks, grad_colors, v_coeffs_accum, as_optional_tensor(v_dirs)
     );
 
     at::Tensor v_coeffs

--- a/gsplat/geometry/design.md
+++ b/gsplat/geometry/design.md
@@ -206,7 +206,7 @@ host exports stay in the `.cu` translation units.
 **`quaternion.cuh` / `quaternion.cu`**
 
 - `quaternion.cuh`: template and small `__device__` helpers (e.g. `cross3`,
-  `quat_multiply_impl`, `quat_rotate_vector_*_impl`, `quat_to_matrix_fwd_write`,
+  `quat_multiply_impl`, `quat_rotate_vector_*_impl`, `quat_slerp_pair_*`, `quat_to_matrix_fwd_write`,
   `quat_normalize_safe_*_write`), per-row `*_fwd_device` / `*_bwd_device` bodies
   (which delegate to those scalars where applicable), and related constants/traits
   (`QuatNormEps`, etc.). Intended to be included from quaternion kernels and,
@@ -220,7 +220,7 @@ host exports stay in the `.cu` translation units.
 - `pose.cuh` includes `quaternion.cuh` so pose and trajectory kernels can reuse
   quaternion device math **without** introducing a third shared-only device
   header. It adds pose-specific device helpers (e.g. Shepperd matrix→quaternion,
-  SE3 transforms, `trajectory_cuda` orchestration using quaternion.cuh templates)
+  SE3 transforms, trajectory orchestration using quaternion.cuh templates)
   and the pose `*_device` entry bodies.
 - `pose.cu` mirrors the quaternion pattern: globals, launches, and exported
   pose/trajectory CUDA entry points.

--- a/gsplat/geometry/design.md
+++ b/gsplat/geometry/design.md
@@ -71,6 +71,7 @@ gsplat/geometry/
       build.py
       ext.cpp
       csrc/
+        coordinate_conversions.cuh
         quaternion.cu
         quaternion.cuh
         pose.cu
@@ -198,6 +199,9 @@ basename). Each `.cu` file includes only its matching header; the header
 holds the device-side implementation that kernels need, and the translation unit
 holds launch helpers, `__global__` kernels, and the extension entry points
 (`*_cuda`, `*_bwd_cuda`) bound from C++/Python.
+
+Reusable device helpers live in the owning `.cuh` under `gsplat_geometry`;
+host exports stay in the `.cu` translation units.
 
 **`quaternion.cuh` / `quaternion.cu`**
 
@@ -336,7 +340,8 @@ The test suite verifies that:
 
 - Public geometry functions are defined in `functional/`.
 - Backend implementation details are defined in `kernels/`.
-- Shared implementation helpers are defined in `include/`.
+- Reserve `include/` for shared public or host-side headers; keep CUDA device
+  helpers with their owning sources under `kernels/cuda/csrc/`.
 - The package remains conceptually organized around geometry concepts first and
   implementation details second.
 - Directory structure should make it clear which code is public, which code is

--- a/gsplat/geometry/kernels/cuda/csrc/coordinate_conversions.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/coordinate_conversions.cuh
@@ -26,6 +26,8 @@
 
 #include <cuda_runtime.h>
 
+namespace gsplat_geometry
+{
 // sincos_t — one sincos call per angle (float -> sincosf, double -> sincos),
 // so the paired sin/cos of each angle issue a single special-function op
 // instead of two separate transcendentals.
@@ -64,3 +66,4 @@ __device__ __forceinline__ void cartesian_to_spherical(T x, T y, T z, T &out_ele
     out_elevation = atan2(z, xy_norm);
     out_azimuth   = atan2(y, x);
 }
+} // namespace gsplat_geometry

--- a/gsplat/geometry/kernels/cuda/csrc/pose.cu
+++ b/gsplat/geometry/kernels/cuda/csrc/pose.cu
@@ -76,7 +76,7 @@ __global__ void se3pose_compose_fwd_kernel(
     {
         return;
     }
-    se3pose_compose_fwd_device(
+    gsplat_geometry::se3pose_compose_fwd_device(
         i, n, parent_translation, parent_rotation, child_translation, child_rotation, out_translation, out_rotation
     );
 }
@@ -102,7 +102,7 @@ __global__ void se3pose_compose_bwd_kernel(
     {
         return;
     }
-    se3pose_compose_bwd_device(
+    gsplat_geometry::se3pose_compose_bwd_device(
         i,
         n,
         parent_translation,
@@ -647,7 +647,7 @@ void se3pose_from_matrix_bwd_cuda(
 // 2-pose trajectories, float32 only.
 // -----------------------------------------------------------------------------
 
-namespace gsplat_geometry::trajectory_cuda
+namespace gsplat_geometry
 {
 // Grid-stride float: 2-keyframe trajectory point + OOB; strides st0,st1,sqt index time/query_time rows (see device).
 __global__ void trajectory_transform_point_2poses_fwd_kernel(
@@ -1199,9 +1199,9 @@ void launch_trajectory_get_rotation_2poses_bwd(
     );
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
-} // namespace gsplat_geometry::trajectory_cuda
+} // namespace gsplat_geometry
 
-namespace packed_track_cuda
+namespace gsplat_geometry::packed_track_cuda
 {
 template<typename scalar_t, typename time_t>
 __global__ void se3_interpolate_tracks_fwd_kernel(
@@ -1376,7 +1376,7 @@ __global__ void se3_interpolate_tracks_bwd_kernel(
 
     const int64_t r4 = right * 4;
     scalar_t glqx, glqy, glqz, glqw, grqx, grqy, grqz, grqw, grad_alpha_q;
-    quat_slerp_pair_bwd(
+    quat_slerp_pair_bwd_with_time_grad(
         pose_rotations[l4 + 0],
         pose_rotations[l4 + 1],
         pose_rotations[l4 + 2],
@@ -1498,7 +1498,7 @@ void launch_se3_interpolate_tracks_bwd(
     );
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
-} // namespace packed_track_cuda
+} // namespace gsplat_geometry::packed_track_cuda
 
 void se3_interpolate_tracks_cuda(
     const at::Tensor &pose_translations,
@@ -1518,7 +1518,7 @@ void se3_interpolate_tracks_cuda(
         {
             if(pose_times.scalar_type() == at::kLong)
             {
-                packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, int64_t>(
+                gsplat_geometry::packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, int64_t>(
                     pose_translations,
                     pose_rotations,
                     pose_times,
@@ -1531,7 +1531,7 @@ void se3_interpolate_tracks_cuda(
             }
             else if(pose_times.scalar_type() == at::kFloat)
             {
-                packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, float>(
+                gsplat_geometry::packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, float>(
                     pose_translations,
                     pose_rotations,
                     pose_times,
@@ -1544,7 +1544,7 @@ void se3_interpolate_tracks_cuda(
             }
             else if(pose_times.scalar_type() == at::kDouble)
             {
-                packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, double>(
+                gsplat_geometry::packed_track_cuda::launch_se3_interpolate_tracks_fwd<scalar_t, double>(
                     pose_translations,
                     pose_rotations,
                     pose_times,
@@ -1586,7 +1586,7 @@ void se3_interpolate_tracks_bwd_cuda(
         {
             if(pose_times.scalar_type() == at::kLong)
             {
-                packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, int64_t>(
+                gsplat_geometry::packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, int64_t>(
                     pose_translations,
                     pose_rotations,
                     pose_times,
@@ -1604,7 +1604,7 @@ void se3_interpolate_tracks_bwd_cuda(
             }
             else if(pose_times.scalar_type() == at::kFloat)
             {
-                packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, float>(
+                gsplat_geometry::packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, float>(
                     pose_translations,
                     pose_rotations,
                     pose_times,
@@ -1622,7 +1622,7 @@ void se3_interpolate_tracks_bwd_cuda(
             }
             else if(pose_times.scalar_type() == at::kDouble)
             {
-                packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, double>(
+                gsplat_geometry::packed_track_cuda::launch_se3_interpolate_tracks_bwd<scalar_t, double>(
                     pose_translations,
                     pose_rotations,
                     pose_times,
@@ -1663,7 +1663,7 @@ void trajectory_transform_point_2poses_cuda(
 )
 {
     TORCH_CHECK(trans0.scalar_type() == at::kFloat, "trajectory_transform_point_2poses_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_2poses_fwd(
+    gsplat_geometry::launch_trajectory_transform_point_2poses_fwd(
         trans0, rot0, time0, trans1, rot1, time1, point, query_time, result_point, result_out_of_bounds
     );
 }
@@ -1692,7 +1692,7 @@ void trajectory_transform_point_2poses_bwd_cuda(
 )
 {
     TORCH_CHECK(trans0.scalar_type() == at::kFloat, "trajectory_transform_point_2poses_bwd_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_2poses_bwd(
+    gsplat_geometry::launch_trajectory_transform_point_2poses_bwd(
         trans0,
         rot0,
         time0,
@@ -1729,7 +1729,7 @@ void trajectory_get_rotation_2poses_cuda(
 )
 {
     TORCH_CHECK(rot0.scalar_type() == at::kFloat, "trajectory_get_rotation_2poses_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_trajectory_get_rotation_2poses_fwd(
+    gsplat_geometry::launch_trajectory_get_rotation_2poses_fwd(
         trans0, rot0, time0, trans1, rot1, time1, query_time, result_quat, result_out_of_bounds
     );
 }
@@ -1758,7 +1758,7 @@ void trajectory_get_rotation_2poses_bwd_cuda(
     (void)trans0;
     (void)trans1;
     TORCH_CHECK(rot0.scalar_type() == at::kFloat, "trajectory_get_rotation_2poses_bwd_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_trajectory_get_rotation_2poses_bwd(
+    gsplat_geometry::launch_trajectory_get_rotation_2poses_bwd(
         time0,
         time1,
         query_time,
@@ -1787,7 +1787,7 @@ void trajectory_transform_point_1pose_cuda(
 )
 {
     TORCH_CHECK(trans.scalar_type() == at::kFloat, "trajectory_transform_point_1pose_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_1pose_fwd(
+    gsplat_geometry::launch_trajectory_transform_point_1pose_fwd(
         trans, rot, time, point, query_time, result_point, result_out_of_bounds
     );
 }
@@ -1810,7 +1810,7 @@ void trajectory_transform_point_1pose_bwd_cuda(
 )
 {
     TORCH_CHECK(rot.scalar_type() == at::kFloat, "trajectory_transform_point_1pose_bwd_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_1pose_bwd(
+    gsplat_geometry::launch_trajectory_transform_point_1pose_bwd(
         trans,
         rot,
         time,
@@ -1842,7 +1842,7 @@ void frame_transform_poses_tquat_cuda(
 )
 {
     TORCH_CHECK(input_poses.scalar_type() == at::kFloat, "frame_transform_poses_tquat_cuda: float32 only");
-    gsplat_geometry::trajectory_cuda::launch_frame_transform_poses_tquat_fwd(
+    gsplat_geometry::launch_frame_transform_poses_tquat_fwd(
         input_poses, frx, fry, frz, frw, ftx, fty, ftz, scale, output_poses
     );
 }

--- a/gsplat/geometry/kernels/cuda/csrc/pose.cu
+++ b/gsplat/geometry/kernels/cuda/csrc/pose.cu
@@ -42,7 +42,7 @@ __global__ void se3pose_transform_point_fwd_kernel(
     {
         return;
     }
-    se3pose_transform_point_fwd_device(i, n, translation, rotation, point, out);
+    gsplat_geometry::se3pose_transform_point_fwd_device(i, n, translation, rotation, point, out);
 }
 
 // Grid-stride: direction (N,3), rotation (N,4) → R(q)d per row.
@@ -56,7 +56,7 @@ __global__ void se3pose_transform_direction_fwd_kernel(
     {
         return;
     }
-    se3pose_transform_direction_fwd_device(i, n, rotation, direction, out);
+    gsplat_geometry::se3pose_transform_direction_fwd_device(i, n, rotation, direction, out);
 }
 
 // Grid-stride: row-wise SE(3) pose composition parent * child.
@@ -133,7 +133,7 @@ __global__ void se3pose_inverse_transform_point_fwd_kernel(
     {
         return;
     }
-    se3pose_inverse_transform_point_fwd_device(i, n, translation, rotation, point, out);
+    gsplat_geometry::se3pose_inverse_transform_point_fwd_device(i, n, translation, rotation, point, out);
 }
 
 // Grid-stride: R^T d per row (no translation).
@@ -147,7 +147,7 @@ __global__ void se3pose_inverse_transform_direction_fwd_kernel(
     {
         return;
     }
-    se3pose_inverse_transform_direction_fwd_device(i, n, rotation, direction, out);
+    gsplat_geometry::se3pose_inverse_transform_direction_fwd_device(i, n, rotation, direction, out);
 }
 
 // Launch the forward SE(3) point transform kernel on the current CUDA stream.
@@ -325,7 +325,7 @@ void se3pose_transform_point_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         point.scalar_type(),
         "se3pose_transform_point_cuda",
-        [&] { launch_se3pose_transform_point_fwd<scalar_t>(translation, rotation, point, out); }
+        ([&] { launch_se3pose_transform_point_fwd<scalar_t>(translation, rotation, point, out); })
     );
 }
 
@@ -337,7 +337,7 @@ void se3pose_transform_direction_cuda(const at::Tensor &rotation, const at::Tens
     AT_DISPATCH_FLOATING_TYPES(
         direction.scalar_type(),
         "se3pose_transform_direction_cuda",
-        [&] { launch_se3pose_transform_direction_fwd<scalar_t>(rotation, direction, out); }
+        ([&] { launch_se3pose_transform_direction_fwd<scalar_t>(rotation, direction, out); })
     );
 }
 
@@ -409,7 +409,7 @@ void se3pose_inverse_transform_point_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         point.scalar_type(),
         "se3pose_inverse_transform_point_cuda",
-        [&] { launch_se3pose_inverse_transform_point_fwd<scalar_t>(translation, rotation, point, out); }
+        ([&] { launch_se3pose_inverse_transform_point_fwd<scalar_t>(translation, rotation, point, out); })
     );
 }
 
@@ -421,7 +421,7 @@ void se3pose_inverse_transform_direction_cuda(const at::Tensor &rotation, const 
     AT_DISPATCH_FLOATING_TYPES(
         direction.scalar_type(),
         "se3pose_inverse_transform_direction_cuda",
-        [&] { launch_se3pose_inverse_transform_direction_fwd<scalar_t>(rotation, direction, out); }
+        ([&] { launch_se3pose_inverse_transform_direction_fwd<scalar_t>(rotation, direction, out); })
     );
 }
 
@@ -440,7 +440,7 @@ __global__ void se3pose_to_matrix_pack_kernel(
     {
         return;
     }
-    se3pose_to_matrix_pack_device(i, n, translation, R9, out16);
+    gsplat_geometry::se3pose_to_matrix_pack_device(i, n, translation, R9, out16);
 }
 
 // Launch homogeneous matrix packing from translation and row-major rotation blocks.
@@ -471,7 +471,7 @@ void se3pose_to_matrix_pack_cuda(const at::Tensor &translation, const at::Tensor
     AT_DISPATCH_FLOATING_TYPES(
         translation.scalar_type(),
         "se3pose_to_matrix_pack_cuda",
-        [&] { launch_se3pose_to_matrix_pack<scalar_t>(translation, R9, out_flat); }
+        ([&] { launch_se3pose_to_matrix_pack<scalar_t>(translation, R9, out_flat); })
     );
 }
 
@@ -490,7 +490,7 @@ __global__ void se3pose_to_inverse_matrix_fwd_kernel(
     {
         return;
     }
-    se3pose_to_inverse_matrix_fwd_device(i, n, translation, rotation, out16, wxyz_format);
+    gsplat_geometry::se3pose_to_inverse_matrix_fwd_device(i, n, translation, rotation, out16, wxyz_format);
 }
 
 // Launch inverse homogeneous matrix construction for a batch of SE(3) poses.
@@ -529,7 +529,7 @@ void se3pose_to_inverse_matrix_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         translation.scalar_type(),
         "se3pose_to_inverse_matrix_cuda",
-        [&] { launch_se3pose_to_inverse_matrix_fwd<scalar_t>(translation, rotation, out_flat, wxyz_format); }
+        ([&] { launch_se3pose_to_inverse_matrix_fwd<scalar_t>(translation, rotation, out_flat, wxyz_format); })
     );
 }
 
@@ -544,7 +544,7 @@ __global__ void se3pose_from_matrix_fwd_kernel(
     {
         return;
     }
-    se3pose_from_matrix_fwd_device(i, n, m16, translation, rotation);
+    gsplat_geometry::se3pose_from_matrix_fwd_device(i, n, m16, translation, rotation);
 }
 
 // Grid-stride: VJP for se3pose_from_matrix; per row fills grad_m16 (row-major) from grad_translation and grad_rotation.
@@ -562,7 +562,7 @@ __global__ void se3pose_from_matrix_bwd_kernel(
     {
         return;
     }
-    se3pose_from_matrix_bwd_device(i, n, m16, grad_translation, grad_rotation, grad_m16);
+    gsplat_geometry::se3pose_from_matrix_bwd_device(i, n, m16, grad_translation, grad_rotation, grad_m16);
 }
 
 // Launch matrix -> pose decomposition for a batch of row-major homogeneous transforms.
@@ -622,7 +622,7 @@ void se3pose_from_matrix_cuda(const at::Tensor &matrix, at::Tensor &translation,
     AT_DISPATCH_FLOATING_TYPES(
         matrix.scalar_type(),
         "se3pose_from_matrix_cuda",
-        [&] { launch_se3pose_from_matrix_fwd<scalar_t>(matrix, translation, rotation); }
+        ([&] { launch_se3pose_from_matrix_fwd<scalar_t>(matrix, translation, rotation); })
     );
 }
 
@@ -639,7 +639,7 @@ void se3pose_from_matrix_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         matrix.scalar_type(),
         "se3pose_from_matrix_bwd_cuda",
-        [&] { launch_se3pose_from_matrix_bwd<scalar_t>(matrix, grad_translation, grad_rotation, grad_matrix); }
+        ([&] { launch_se3pose_from_matrix_bwd<scalar_t>(matrix, grad_translation, grad_rotation, grad_matrix); })
     );
 }
 
@@ -647,7 +647,7 @@ void se3pose_from_matrix_bwd_cuda(
 // 2-pose trajectories, float32 only.
 // -----------------------------------------------------------------------------
 
-namespace trajectory_cuda
+namespace gsplat_geometry::trajectory_cuda
 {
 // Grid-stride float: 2-keyframe trajectory point + OOB; strides st0,st1,sqt index time/query_time rows (see device).
 __global__ void trajectory_transform_point_2poses_fwd_kernel(
@@ -1199,7 +1199,7 @@ void launch_trajectory_get_rotation_2poses_bwd(
     );
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
-} // namespace trajectory_cuda
+} // namespace gsplat_geometry::trajectory_cuda
 
 namespace packed_track_cuda
 {
@@ -1663,7 +1663,7 @@ void trajectory_transform_point_2poses_cuda(
 )
 {
     TORCH_CHECK(trans0.scalar_type() == at::kFloat, "trajectory_transform_point_2poses_cuda: float32 only");
-    trajectory_cuda::launch_trajectory_transform_point_2poses_fwd(
+    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_2poses_fwd(
         trans0, rot0, time0, trans1, rot1, time1, point, query_time, result_point, result_out_of_bounds
     );
 }
@@ -1692,7 +1692,7 @@ void trajectory_transform_point_2poses_bwd_cuda(
 )
 {
     TORCH_CHECK(trans0.scalar_type() == at::kFloat, "trajectory_transform_point_2poses_bwd_cuda: float32 only");
-    trajectory_cuda::launch_trajectory_transform_point_2poses_bwd(
+    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_2poses_bwd(
         trans0,
         rot0,
         time0,
@@ -1729,7 +1729,7 @@ void trajectory_get_rotation_2poses_cuda(
 )
 {
     TORCH_CHECK(rot0.scalar_type() == at::kFloat, "trajectory_get_rotation_2poses_cuda: float32 only");
-    trajectory_cuda::launch_trajectory_get_rotation_2poses_fwd(
+    gsplat_geometry::trajectory_cuda::launch_trajectory_get_rotation_2poses_fwd(
         trans0, rot0, time0, trans1, rot1, time1, query_time, result_quat, result_out_of_bounds
     );
 }
@@ -1758,7 +1758,7 @@ void trajectory_get_rotation_2poses_bwd_cuda(
     (void)trans0;
     (void)trans1;
     TORCH_CHECK(rot0.scalar_type() == at::kFloat, "trajectory_get_rotation_2poses_bwd_cuda: float32 only");
-    trajectory_cuda::launch_trajectory_get_rotation_2poses_bwd(
+    gsplat_geometry::trajectory_cuda::launch_trajectory_get_rotation_2poses_bwd(
         time0,
         time1,
         query_time,
@@ -1787,7 +1787,7 @@ void trajectory_transform_point_1pose_cuda(
 )
 {
     TORCH_CHECK(trans.scalar_type() == at::kFloat, "trajectory_transform_point_1pose_cuda: float32 only");
-    trajectory_cuda::launch_trajectory_transform_point_1pose_fwd(
+    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_1pose_fwd(
         trans, rot, time, point, query_time, result_point, result_out_of_bounds
     );
 }
@@ -1810,7 +1810,7 @@ void trajectory_transform_point_1pose_bwd_cuda(
 )
 {
     TORCH_CHECK(rot.scalar_type() == at::kFloat, "trajectory_transform_point_1pose_bwd_cuda: float32 only");
-    trajectory_cuda::launch_trajectory_transform_point_1pose_bwd(
+    gsplat_geometry::trajectory_cuda::launch_trajectory_transform_point_1pose_bwd(
         trans,
         rot,
         time,
@@ -1842,7 +1842,7 @@ void frame_transform_poses_tquat_cuda(
 )
 {
     TORCH_CHECK(input_poses.scalar_type() == at::kFloat, "frame_transform_poses_tquat_cuda: float32 only");
-    trajectory_cuda::launch_frame_transform_poses_tquat_fwd(
+    gsplat_geometry::trajectory_cuda::launch_frame_transform_poses_tquat_fwd(
         input_poses, frx, fry, frz, frw, ftx, fty, ftz, scale, output_poses
     );
 }

--- a/gsplat/geometry/kernels/cuda/csrc/pose.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/pose.cuh
@@ -231,639 +231,569 @@ __device__ void shepperd_from_matrix_bwd(
     }
 }
 
-// SLERP q1 -> q2 at ti (xyzw, unit-quaternion inputs).
-template<typename T>
-__device__ __forceinline__ void quat_slerp_pair_fwd(
-    T x1, T y1, T z1, T w1, T x2, T y2, T z2, T w2, T ti, T *ox, T *oy, T *oz, T *ow
-);
-
-// VJP for quat_slerp_pair_fwd when interpolation time is non-differentiable.
-template<typename T>
-__device__ __forceinline__ void quat_slerp_pair_bwd_no_time_grad(
-    T x1,
-    T y1,
-    T z1,
-    T w1,
-    T x2,
-    T y2,
-    T z2,
-    T w2,
-    T ti,
-    T rx,
-    T ry,
-    T rz,
-    T rw,
-    T gx,
-    T gy,
-    T gz,
-    T gw,
-    T *gq1x,
-    T *gq1y,
-    T *gq1z,
-    T *gq1w,
-    T *gq2x,
-    T *gq2y,
-    T *gq2z,
-    T *gq2w
-);
-
-// VJP variant for differentiable interpolation time; grad_t must be non-null.
-template<typename T>
-__device__ __forceinline__ void quat_slerp_pair_bwd_with_time_grad(
-    T x1,
-    T y1,
-    T z1,
-    T w1,
-    T x2,
-    T y2,
-    T z2,
-    T w2,
-    T ti,
-    T rx,
-    T ry,
-    T rz,
-    T rw,
-    T gx,
-    T gy,
-    T gz,
-    T gw,
-    T *gq1x,
-    T *gq1y,
-    T *gq1z,
-    T *gq1w,
-    T *gq2x,
-    T *gq2y,
-    T *gq2z,
-    T *gq2w,
-    T *grad_t
-);
-
-namespace trajectory_cuda
+// Time-interpolation chain rule: grad_alpha = ∂L/∂α with α=(qt-t_min)/(t_max-t_min), d=t_max-t_min.
+// Outputs *g_t0,*g_t1,*g_qt for ∂L/∂time0, ∂L/∂time1, ∂L/∂query_time (handles t0>t1 swap).
+__forceinline__ __device__ void trajectory_alpha_time_grads_f(
+    float t0s, float t1s, float qt, float d, float grad_alpha, float *g_t0, float *g_t1, float *g_qt
+)
 {
-    // Time-interpolation chain rule: grad_alpha = ∂L/∂α with α=(qt-t_min)/(t_max-t_min), d=t_max-t_min.
-    // Outputs *g_t0,*g_t1,*g_qt for ∂L/∂time0, ∂L/∂time1, ∂L/∂query_time (handles t0>t1 swap).
-    __forceinline__ __device__ void trajectory_alpha_time_grads_f(
-        float t0s, float t1s, float qt, float d, float grad_alpha, float *g_t0, float *g_t1, float *g_qt
-    )
+    if(d <= 0.0f)
     {
-        if(d <= 0.0f)
-        {
-            *g_t0 = *g_t1 = *g_qt = 0.0f;
-            return;
-        }
-        const float inv_d = 1.0f / d;
-        *g_qt             = grad_alpha * inv_d;
-        if(t0s <= t1s)
-        {
-            const float d2 = d * d;
-            *g_t0          = grad_alpha * (qt - t1s) / d2;
-            *g_t1          = -grad_alpha * (qt - t0s) / d2;
-        }
-        else
-        {
-            const float d2 = d * d;
-            *g_t1          = grad_alpha * (qt - t0s) / d2;
-            *g_t0          = -grad_alpha * (qt - t1s) / d2;
-        }
+        *g_t0 = *g_t1 = *g_qt = 0.0f;
+        return;
+    }
+    const float inv_d = 1.0f / d;
+    *g_qt             = grad_alpha * inv_d;
+    if(t0s <= t1s)
+    {
+        const float d2 = d * d;
+        *g_t0          = grad_alpha * (qt - t1s) / d2;
+        *g_t1          = -grad_alpha * (qt - t0s) / d2;
+    }
+    else
+    {
+        const float d2 = d * d;
+        *g_t1          = grad_alpha * (qt - t0s) / d2;
+        *g_t0          = -grad_alpha * (qt - t1s) / d2;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Float32 trajectory: two-keyframe SLERP + helpers; OOB flags when query time leaves the span.
+// -----------------------------------------------------------------------------
+
+// Row i: interpolate pose between keyframes 0/1 at query_time. trans* (N,3), rot* xyzw (N,4), time* indexed by strides st0/st1; query_time stride sqt.
+// result_point (N,3) = R(qi)(point) + ti; result_oob[i]∈{0,1} if qt outside [min(t0,t1), max(t0,t1)].
+__forceinline__ __device__ void trajectory_transform_point_2poses_fwd_device(
+    int64_t i,
+    int64_t n,
+    int64_t st0,
+    int64_t st1,
+    int64_t sqt,
+    const float *__restrict__ trans0,
+    const float *__restrict__ rot0,
+    const float *__restrict__ time0,
+    const float *__restrict__ trans1,
+    const float *__restrict__ rot1,
+    const float *__restrict__ time1,
+    const float *__restrict__ point,
+    const float *__restrict__ query_time,
+    float *__restrict__ result_point,
+    float *__restrict__ result_oob
+)
+{
+    const int64_t o3  = i * 3;
+    const int64_t o4  = i * 4;
+    const float t0s   = time0[i * st0];
+    const float t1s   = time1[i * st1];
+    const float qt    = query_time[i * sqt];
+    const float t_min = fminf(t0s, t1s);
+    const float t_max = fmaxf(t0s, t1s);
+    const bool oob    = (qt < t_min) || (qt > t_max);
+    const float d     = t_max - t_min;
+    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+
+    float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
+    float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
+    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+    float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+
+    float tix, tiy, tiz;
+    float qix, qiy, qiz, qiw;
+    if(t0s <= t1s)
+    {
+        const float om = 1.0f - alpha;
+        tix            = om * tx0 + alpha * tx1;
+        tiy            = om * ty0 + alpha * ty1;
+        tiz            = om * tz0 + alpha * tz1;
+        quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
+    }
+    else
+    {
+        const float om = 1.0f - alpha;
+        tix            = om * tx1 + alpha * tx0;
+        tiy            = om * ty1 + alpha * ty0;
+        tiz            = om * tz1 + alpha * tz0;
+        quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
+    }
+    float rx, ry, rz;
+    quat_rotate_vector_fwd_impl<float>(qix, qiy, qiz, qiw, px, py, pz, &rx, &ry, &rz);
+    result_point[o3 + 0] = rx + tix;
+    result_point[o3 + 1] = ry + tiy;
+    result_point[o3 + 2] = rz + tiz;
+    result_oob[i]        = oob ? 1.0f : 0.0f;
+}
+
+// VJP for 2-pose point transform: grad_result_point (N,3) → grads for trans0/1, rot0/1 (xyzw), time strides, point, query_time.
+__forceinline__ __device__ void trajectory_transform_point_2poses_bwd_device(
+    int64_t i,
+    int64_t n,
+    int64_t st0,
+    int64_t st1,
+    int64_t sqt,
+    const float *__restrict__ trans0,
+    const float *__restrict__ rot0,
+    const float *__restrict__ time0,
+    const float *__restrict__ trans1,
+    const float *__restrict__ rot1,
+    const float *__restrict__ time1,
+    const float *__restrict__ point,
+    const float *__restrict__ query_time,
+    const float *__restrict__ grad_result_point,
+    float *__restrict__ grad_trans0,
+    float *__restrict__ grad_rot0,
+    float *__restrict__ grad_time0,
+    float *__restrict__ grad_trans1,
+    float *__restrict__ grad_rot1,
+    float *__restrict__ grad_time1,
+    float *__restrict__ grad_point,
+    float *__restrict__ grad_query_time
+)
+{
+    const int64_t o3  = i * 3;
+    const int64_t o4  = i * 4;
+    const float t0s   = time0[i * st0];
+    const float t1s   = time1[i * st1];
+    const float qt    = query_time[i * sqt];
+    const float t_min = fminf(t0s, t1s);
+    const float t_max = fmaxf(t0s, t1s);
+    const float d     = t_max - t_min;
+    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+
+    float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
+    float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
+    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+    float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+
+    float qix, qiy, qiz, qiw;
+    if(t0s <= t1s)
+    {
+        quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
+    }
+    else
+    {
+        quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
     }
 
-    // -----------------------------------------------------------------------------
-    // Float32 trajectory: two-keyframe SLERP + helpers; OOB flags when query time leaves the span.
-    // -----------------------------------------------------------------------------
+    const float gtx = grad_result_point[o3 + 0];
+    const float gty = grad_result_point[o3 + 1];
+    const float gtz = grad_result_point[o3 + 2];
 
-    // Row i: interpolate pose between keyframes 0/1 at query_time. trans* (N,3), rot* xyzw (N,4), time* indexed by strides st0/st1; query_time stride sqt.
-    // result_point (N,3) = R(qi)(point) + ti; result_oob[i]∈{0,1} if qt outside [min(t0,t1), max(t0,t1)].
-    __forceinline__ __device__ void trajectory_transform_point_2poses_fwd_device(
-        int64_t i,
-        int64_t n,
-        int64_t st0,
-        int64_t st1,
-        int64_t sqt,
-        const float *__restrict__ trans0,
-        const float *__restrict__ rot0,
-        const float *__restrict__ time0,
-        const float *__restrict__ trans1,
-        const float *__restrict__ rot1,
-        const float *__restrict__ time1,
-        const float *__restrict__ point,
-        const float *__restrict__ query_time,
-        float *__restrict__ result_point,
-        float *__restrict__ result_oob
-    )
+    float gqix, gqiy, gqiz, gqiw;
+    float gpx, gpy, gpz;
+    quat_rotate_vector_bwd_impl<float>(
+        qix, qiy, qiz, qiw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
+    );
+
+    grad_point[o3 + 0] = gpx;
+    grad_point[o3 + 1] = gpy;
+    grad_point[o3 + 2] = gpz;
+
+    float grad_alpha = 0.0f;
+
+    if(t0s <= t1s)
     {
-        const int64_t o3  = i * 3;
-        const int64_t o4  = i * 4;
-        const float t0s   = time0[i * st0];
-        const float t1s   = time1[i * st1];
-        const float qt    = query_time[i * sqt];
-        const float t_min = fminf(t0s, t1s);
-        const float t_max = fmaxf(t0s, t1s);
-        const bool oob    = (qt < t_min) || (qt > t_max);
-        const float d     = t_max - t_min;
-        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-
-        float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
-        float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
-        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-        float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-
-        float tix, tiy, tiz;
-        float qix, qiy, qiz, qiw;
-        if(t0s <= t1s)
-        {
-            const float om = 1.0f - alpha;
-            tix            = om * tx0 + alpha * tx1;
-            tiy            = om * ty0 + alpha * ty1;
-            tiz            = om * tz0 + alpha * tz1;
-            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
-        }
-        else
-        {
-            const float om = 1.0f - alpha;
-            tix            = om * tx1 + alpha * tx0;
-            tiy            = om * ty1 + alpha * ty0;
-            tiz            = om * tz1 + alpha * tz0;
-            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
-        }
-        float rx, ry, rz;
-        quat_rotate_vector_fwd_impl<float>(qix, qiy, qiz, qiw, px, py, pz, &rx, &ry, &rz);
-        result_point[o3 + 0] = rx + tix;
-        result_point[o3 + 1] = ry + tiy;
-        result_point[o3 + 2] = rz + tiz;
-        result_oob[i]        = oob ? 1.0f : 0.0f;
+        grad_trans0[o3 + 0]  = (1.0f - alpha) * gtx;
+        grad_trans0[o3 + 1]  = (1.0f - alpha) * gty;
+        grad_trans0[o3 + 2]  = (1.0f - alpha) * gtz;
+        grad_trans1[o3 + 0]  = alpha * gtx;
+        grad_trans1[o3 + 1]  = alpha * gty;
+        grad_trans1[o3 + 2]  = alpha * gtz;
+        grad_alpha          += gtx * (tx1 - tx0) + gty * (ty1 - ty0) + gtz * (tz1 - tz0);
+    }
+    else
+    {
+        grad_trans1[o3 + 0]  = (1.0f - alpha) * gtx;
+        grad_trans1[o3 + 1]  = (1.0f - alpha) * gty;
+        grad_trans1[o3 + 2]  = (1.0f - alpha) * gtz;
+        grad_trans0[o3 + 0]  = alpha * gtx;
+        grad_trans0[o3 + 1]  = alpha * gty;
+        grad_trans0[o3 + 2]  = alpha * gtz;
+        grad_alpha          += gtx * (tx0 - tx1) + gty * (ty0 - ty1) + gtz * (tz0 - tz1);
     }
 
-    // VJP for 2-pose point transform: grad_result_point (N,3) → grads for trans0/1, rot0/1 (xyzw), time strides, point, query_time.
-    __forceinline__ __device__ void trajectory_transform_point_2poses_bwd_device(
-        int64_t i,
-        int64_t n,
-        int64_t st0,
-        int64_t st1,
-        int64_t sqt,
-        const float *__restrict__ trans0,
-        const float *__restrict__ rot0,
-        const float *__restrict__ time0,
-        const float *__restrict__ trans1,
-        const float *__restrict__ rot1,
-        const float *__restrict__ time1,
-        const float *__restrict__ point,
-        const float *__restrict__ query_time,
-        const float *__restrict__ grad_result_point,
-        float *__restrict__ grad_trans0,
-        float *__restrict__ grad_rot0,
-        float *__restrict__ grad_time0,
-        float *__restrict__ grad_trans1,
-        float *__restrict__ grad_rot1,
-        float *__restrict__ grad_time1,
-        float *__restrict__ grad_point,
-        float *__restrict__ grad_query_time
-    )
+    float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
+    if(t0s <= t1s)
     {
-        const int64_t o3  = i * 3;
-        const int64_t o4  = i * 4;
-        const float t0s   = time0[i * st0];
-        const float t1s   = time1[i * st1];
-        const float qt    = query_time[i * sqt];
-        const float t_min = fminf(t0s, t1s);
-        const float t_max = fmaxf(t0s, t1s);
-        const float d     = t_max - t_min;
-        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-
-        float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
-        float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
-        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-        float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-
-        float qix, qiy, qiz, qiw;
-        if(t0s <= t1s)
-        {
-            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
-        }
-        else
-        {
-            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
-        }
-
-        const float gtx = grad_result_point[o3 + 0];
-        const float gty = grad_result_point[o3 + 1];
-        const float gtz = grad_result_point[o3 + 2];
-
-        float gqix, gqiy, gqiz, gqiw;
-        float gpx, gpy, gpz;
-        quat_rotate_vector_bwd_impl<float>(
-            qix, qiy, qiz, qiw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
+        quat_slerp_pair_bwd_with_time_grad<float>(
+            qx0,
+            qy0,
+            qz0,
+            qw0,
+            qx1,
+            qy1,
+            qz1,
+            qw1,
+            alpha,
+            qix,
+            qiy,
+            qiz,
+            qiw,
+            gqix,
+            gqiy,
+            gqiz,
+            gqiw,
+            &gq1x,
+            &gq1y,
+            &gq1z,
+            &gq1w,
+            &gq2x,
+            &gq2y,
+            &gq2z,
+            &gq2w,
+            &ga_slerp
         );
-
-        grad_point[o3 + 0] = gpx;
-        grad_point[o3 + 1] = gpy;
-        grad_point[o3 + 2] = gpz;
-
-        float grad_alpha = 0.0f;
-
-        if(t0s <= t1s)
-        {
-            grad_trans0[o3 + 0]  = (1.0f - alpha) * gtx;
-            grad_trans0[o3 + 1]  = (1.0f - alpha) * gty;
-            grad_trans0[o3 + 2]  = (1.0f - alpha) * gtz;
-            grad_trans1[o3 + 0]  = alpha * gtx;
-            grad_trans1[o3 + 1]  = alpha * gty;
-            grad_trans1[o3 + 2]  = alpha * gtz;
-            grad_alpha          += gtx * (tx1 - tx0) + gty * (ty1 - ty0) + gtz * (tz1 - tz0);
-        }
-        else
-        {
-            grad_trans1[o3 + 0]  = (1.0f - alpha) * gtx;
-            grad_trans1[o3 + 1]  = (1.0f - alpha) * gty;
-            grad_trans1[o3 + 2]  = (1.0f - alpha) * gtz;
-            grad_trans0[o3 + 0]  = alpha * gtx;
-            grad_trans0[o3 + 1]  = alpha * gty;
-            grad_trans0[o3 + 2]  = alpha * gtz;
-            grad_alpha          += gtx * (tx0 - tx1) + gty * (ty0 - ty1) + gtz * (tz0 - tz1);
-        }
-
-        float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
-        if(t0s <= t1s)
-        {
-            quat_slerp_pair_bwd_with_time_grad<float>(
-                qx0,
-                qy0,
-                qz0,
-                qw0,
-                qx1,
-                qy1,
-                qz1,
-                qw1,
-                alpha,
-                qix,
-                qiy,
-                qiz,
-                qiw,
-                gqix,
-                gqiy,
-                gqiz,
-                gqiw,
-                &gq1x,
-                &gq1y,
-                &gq1z,
-                &gq1w,
-                &gq2x,
-                &gq2y,
-                &gq2z,
-                &gq2w,
-                &ga_slerp
-            );
-            grad_rot0[o4 + 0] = gq1x;
-            grad_rot0[o4 + 1] = gq1y;
-            grad_rot0[o4 + 2] = gq1z;
-            grad_rot0[o4 + 3] = gq1w;
-            grad_rot1[o4 + 0] = gq2x;
-            grad_rot1[o4 + 1] = gq2y;
-            grad_rot1[o4 + 2] = gq2z;
-            grad_rot1[o4 + 3] = gq2w;
-        }
-        else
-        {
-            quat_slerp_pair_bwd_with_time_grad<float>(
-                qx1,
-                qy1,
-                qz1,
-                qw1,
-                qx0,
-                qy0,
-                qz0,
-                qw0,
-                alpha,
-                qix,
-                qiy,
-                qiz,
-                qiw,
-                gqix,
-                gqiy,
-                gqiz,
-                gqiw,
-                &gq1x,
-                &gq1y,
-                &gq1z,
-                &gq1w,
-                &gq2x,
-                &gq2y,
-                &gq2z,
-                &gq2w,
-                &ga_slerp
-            );
-            grad_rot1[o4 + 0] = gq1x;
-            grad_rot1[o4 + 1] = gq1y;
-            grad_rot1[o4 + 2] = gq1z;
-            grad_rot1[o4 + 3] = gq1w;
-            grad_rot0[o4 + 0] = gq2x;
-            grad_rot0[o4 + 1] = gq2y;
-            grad_rot0[o4 + 2] = gq2z;
-            grad_rot0[o4 + 3] = gq2w;
-        }
-        grad_alpha += ga_slerp;
-
-        float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
-        trajectory_alpha_time_grads_f(t0s, t1s, qt, d, grad_alpha, &g_t0, &g_t1, &g_qt);
-        grad_time0[i * st0]      = g_t0;
-        grad_time1[i * st1]      = g_t1;
-        grad_query_time[i * sqt] = g_qt;
+        grad_rot0[o4 + 0] = gq1x;
+        grad_rot0[o4 + 1] = gq1y;
+        grad_rot0[o4 + 2] = gq1z;
+        grad_rot0[o4 + 3] = gq1w;
+        grad_rot1[o4 + 0] = gq2x;
+        grad_rot1[o4 + 1] = gq2y;
+        grad_rot1[o4 + 2] = gq2z;
+        grad_rot1[o4 + 3] = gq2w;
     }
-
-    // Row i: SLERP rot0/rot1 at query_time (same α and OOB semantics as 2-pose point); result_quat (N,4) xyzw.
-    __forceinline__ __device__ void trajectory_get_rotation_2poses_fwd_device(
-        int64_t i,
-        int64_t n,
-        int64_t st0,
-        int64_t st1,
-        int64_t sqt,
-        const float *__restrict__ time0,
-        const float *__restrict__ time1,
-        const float *__restrict__ query_time,
-        const float *__restrict__ rot0,
-        const float *__restrict__ rot1,
-        float *__restrict__ result_quat,
-        float *__restrict__ result_oob
-    )
+    else
     {
-        const int64_t o4  = i * 4;
-        const float t0s   = time0[i * st0];
-        const float t1s   = time1[i * st1];
-        const float qt    = query_time[i * sqt];
-        const float t_min = fminf(t0s, t1s);
-        const float t_max = fmaxf(t0s, t1s);
-        const bool oob    = (qt < t_min) || (qt > t_max);
-        const float d     = t_max - t_min;
-        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-        float ox, oy, oz, ow;
-        if(t0s <= t1s)
-        {
-            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &ox, &oy, &oz, &ow);
-        }
-        else
-        {
-            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &ox, &oy, &oz, &ow);
-        }
-        result_quat[o4 + 0] = ox;
-        result_quat[o4 + 1] = oy;
-        result_quat[o4 + 2] = oz;
-        result_quat[o4 + 3] = ow;
-        result_oob[i]       = oob ? 1.0f : 0.0f;
-    }
-
-    // VJP: grad_result_quat (N,4) → grad_rot0, grad_rot1; time grads via trajectory_alpha_time_grads_f on SLERP ∂L/∂α.
-    __forceinline__ __device__ void trajectory_get_rotation_2poses_bwd_device(
-        int64_t i,
-        int64_t n,
-        int64_t st0,
-        int64_t st1,
-        int64_t sqt,
-        const float *__restrict__ time0,
-        const float *__restrict__ time1,
-        const float *__restrict__ query_time,
-        const float *__restrict__ rot0,
-        const float *__restrict__ rot1,
-        const float *__restrict__ grad_result_quat,
-        float *__restrict__ grad_rot0,
-        float *__restrict__ grad_rot1,
-        float *__restrict__ grad_time0,
-        float *__restrict__ grad_time1,
-        float *__restrict__ grad_query_time
-    )
-    {
-        const int64_t o4  = i * 4;
-        const float t0s   = time0[i * st0];
-        const float t1s   = time1[i * st1];
-        const float qt    = query_time[i * sqt];
-        const float t_min = fminf(t0s, t1s);
-        const float t_max = fmaxf(t0s, t1s);
-        const float d     = t_max - t_min;
-        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-
-        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-
-        float qix, qiy, qiz, qiw;
-        if(t0s <= t1s)
-        {
-            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
-        }
-        else
-        {
-            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
-        }
-
-        const float gx = grad_result_quat[o4 + 0];
-        const float gy = grad_result_quat[o4 + 1];
-        const float gz = grad_result_quat[o4 + 2];
-        const float gw = grad_result_quat[o4 + 3];
-
-        float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
-        if(t0s <= t1s)
-        {
-            quat_slerp_pair_bwd_with_time_grad<float>(
-                qx0,
-                qy0,
-                qz0,
-                qw0,
-                qx1,
-                qy1,
-                qz1,
-                qw1,
-                alpha,
-                qix,
-                qiy,
-                qiz,
-                qiw,
-                gx,
-                gy,
-                gz,
-                gw,
-                &gq1x,
-                &gq1y,
-                &gq1z,
-                &gq1w,
-                &gq2x,
-                &gq2y,
-                &gq2z,
-                &gq2w,
-                &ga_slerp
-            );
-            grad_rot0[o4 + 0] = gq1x;
-            grad_rot0[o4 + 1] = gq1y;
-            grad_rot0[o4 + 2] = gq1z;
-            grad_rot0[o4 + 3] = gq1w;
-            grad_rot1[o4 + 0] = gq2x;
-            grad_rot1[o4 + 1] = gq2y;
-            grad_rot1[o4 + 2] = gq2z;
-            grad_rot1[o4 + 3] = gq2w;
-        }
-        else
-        {
-            quat_slerp_pair_bwd_with_time_grad<float>(
-                qx1,
-                qy1,
-                qz1,
-                qw1,
-                qx0,
-                qy0,
-                qz0,
-                qw0,
-                alpha,
-                qix,
-                qiy,
-                qiz,
-                qiw,
-                gx,
-                gy,
-                gz,
-                gw,
-                &gq1x,
-                &gq1y,
-                &gq1z,
-                &gq1w,
-                &gq2x,
-                &gq2y,
-                &gq2z,
-                &gq2w,
-                &ga_slerp
-            );
-            grad_rot1[o4 + 0] = gq1x;
-            grad_rot1[o4 + 1] = gq1y;
-            grad_rot1[o4 + 2] = gq1z;
-            grad_rot1[o4 + 3] = gq1w;
-            grad_rot0[o4 + 0] = gq2x;
-            grad_rot0[o4 + 1] = gq2y;
-            grad_rot0[o4 + 2] = gq2z;
-            grad_rot0[o4 + 3] = gq2w;
-        }
-
-        float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
-        trajectory_alpha_time_grads_f(t0s, t1s, qt, d, ga_slerp, &g_t0, &g_t1, &g_qt);
-        grad_time0[i * st0]      = g_t0;
-        grad_time1[i * st1]      = g_t1;
-        grad_query_time[i * sqt] = g_qt;
-    }
-
-    // -----------------------------------------------------------------------------
-    // Single-keyframe trajectory (float32): OOB = (query_time != keyframe time), transform still applied.
-    // -----------------------------------------------------------------------------
-
-    // Row i: result = R(rot_i) point_i + trans_i; result_oob[i]=1 if query_time[i*sqt] != time[i*st] (exact float compare).
-    __forceinline__ __device__ void trajectory_transform_point_1pose_fwd_device(
-        int64_t i,
-        int64_t n,
-        int64_t st,
-        int64_t sqt,
-        const float *__restrict__ trans,
-        const float *__restrict__ rot,
-        const float *__restrict__ time,
-        const float *__restrict__ point,
-        const float *__restrict__ query_time,
-        float *__restrict__ result_point,
-        float *__restrict__ result_oob
-    )
-    {
-        const int64_t o3 = i * 3;
-        const int64_t o4 = i * 4;
-        const float tt   = time[i * st];
-        const float qt   = query_time[i * sqt];
-        const bool oob   = (qt != tt);
-
-        const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
-        const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-        const float tx = trans[o3 + 0], ty = trans[o3 + 1], tz = trans[o3 + 2];
-        float rx = 0, ry = 0, rz = 0;
-        quat_rotate_vector_fwd_impl<float>(qx, qy, qz, qw, px, py, pz, &rx, &ry, &rz);
-        result_point[o3 + 0] = rx + tx;
-        result_point[o3 + 1] = ry + ty;
-        result_point[o3 + 2] = rz + tz;
-        result_oob[i]        = oob ? 1.0f : 0.0f;
-    }
-
-    // VJP: grad_result_point → grad_trans, grad_rot (xyzw), grad_point; grad_time/grad_query_time not populated by device body (kernel may ignore).
-    __forceinline__ __device__ void trajectory_transform_point_1pose_bwd_device(
-        int64_t i,
-        int64_t n,
-        const float *__restrict__ trans,
-        const float *__restrict__ rot,
-        const float *__restrict__ time,
-        const float *__restrict__ point,
-        const float *__restrict__ query_time,
-        const float *__restrict__ grad_result_point,
-        float *__restrict__ grad_trans,
-        float *__restrict__ grad_rot,
-        float *__restrict__ grad_time,
-        float *__restrict__ grad_point,
-        float *__restrict__ grad_query_time
-    )
-    {
-        const int64_t o3 = i * 3;
-        const int64_t o4 = i * 4;
-        const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
-        const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-
-        const float gtx = grad_result_point[o3 + 0];
-        const float gty = grad_result_point[o3 + 1];
-        const float gtz = grad_result_point[o3 + 2];
-
-        float gqix, gqiy, gqiz, gqiw;
-        float gpx, gpy, gpz;
-        quat_rotate_vector_bwd_impl<float>(
-            qx, qy, qz, qw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
+        quat_slerp_pair_bwd_with_time_grad<float>(
+            qx1,
+            qy1,
+            qz1,
+            qw1,
+            qx0,
+            qy0,
+            qz0,
+            qw0,
+            alpha,
+            qix,
+            qiy,
+            qiz,
+            qiw,
+            gqix,
+            gqiy,
+            gqiz,
+            gqiw,
+            &gq1x,
+            &gq1y,
+            &gq1z,
+            &gq1w,
+            &gq2x,
+            &gq2y,
+            &gq2z,
+            &gq2w,
+            &ga_slerp
         );
-
-        grad_trans[o3 + 0] = gtx;
-        grad_trans[o3 + 1] = gty;
-        grad_trans[o3 + 2] = gtz;
-        grad_rot[o4 + 0]   = gqix;
-        grad_rot[o4 + 1]   = gqiy;
-        grad_rot[o4 + 2]   = gqiz;
-        grad_rot[o4 + 3]   = gqiw;
-        grad_point[o3 + 0] = gpx;
-        grad_point[o3 + 1] = gpy;
-        grad_point[o3 + 2] = gpz;
+        grad_rot1[o4 + 0] = gq1x;
+        grad_rot1[o4 + 1] = gq1y;
+        grad_rot1[o4 + 2] = gq1z;
+        grad_rot1[o4 + 3] = gq1w;
+        grad_rot0[o4 + 0] = gq2x;
+        grad_rot0[o4 + 1] = gq2y;
+        grad_rot0[o4 + 2] = gq2z;
+        grad_rot0[o4 + 3] = gq2w;
     }
+    grad_alpha += ga_slerp;
 
-    // Row i: 7-D pose (tx,ty,tz, qx,qy,qz,qw) → new_q = fr⊗iq, new_t = scale * (R(fr)*it + fxyz); frame quat fr is xyzw.
-    __forceinline__ __device__ void frame_transform_poses_tquat_fwd_device(
-        int64_t i,
-        int64_t n,
-        float frx,
-        float fry,
-        float frz,
-        float frw,
-        float ftx,
-        float fty,
-        float ftz,
-        float scale,
-        const float *__restrict__ input_poses,
-        float *__restrict__ output_poses
-    )
+    float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
+    trajectory_alpha_time_grads_f(t0s, t1s, qt, d, grad_alpha, &g_t0, &g_t1, &g_qt);
+    grad_time0[i * st0]      = g_t0;
+    grad_time1[i * st1]      = g_t1;
+    grad_query_time[i * sqt] = g_qt;
+}
+
+// Row i: SLERP rot0/rot1 at query_time (same α and OOB semantics as 2-pose point); result_quat (N,4) xyzw.
+__forceinline__ __device__ void trajectory_get_rotation_2poses_fwd_device(
+    int64_t i,
+    int64_t n,
+    int64_t st0,
+    int64_t st1,
+    int64_t sqt,
+    const float *__restrict__ time0,
+    const float *__restrict__ time1,
+    const float *__restrict__ query_time,
+    const float *__restrict__ rot0,
+    const float *__restrict__ rot1,
+    float *__restrict__ result_quat,
+    float *__restrict__ result_oob
+)
+{
+    const int64_t o4  = i * 4;
+    const float t0s   = time0[i * st0];
+    const float t1s   = time1[i * st1];
+    const float qt    = query_time[i * sqt];
+    const float t_min = fminf(t0s, t1s);
+    const float t_max = fmaxf(t0s, t1s);
+    const bool oob    = (qt < t_min) || (qt > t_max);
+    const float d     = t_max - t_min;
+    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+    float ox, oy, oz, ow;
+    if(t0s <= t1s)
     {
-        const int64_t o7 = i * 7;
-        const float itx = input_poses[o7 + 0], ity = input_poses[o7 + 1], itz = input_poses[o7 + 2];
-        const float iqx = input_poses[o7 + 3], iqy = input_poses[o7 + 4], iqz = input_poses[o7 + 5],
-                    iqw = input_poses[o7 + 6];
-        float nqx = 0, nqy = 0, nqz = 0, nqw = 0;
-        quat_multiply_impl<float>(frx, fry, frz, frw, iqx, iqy, iqz, iqw, &nqx, &nqy, &nqz, &nqw);
-        float rtx = 0, rty = 0, rtz = 0;
-        quat_rotate_vector_fwd_impl<float>(frx, fry, frz, frw, itx, ity, itz, &rtx, &rty, &rtz);
-        const float ntx      = scale * (rtx + ftx);
-        const float nty      = scale * (rty + fty);
-        const float ntz      = scale * (rtz + ftz);
-        output_poses[o7 + 0] = ntx;
-        output_poses[o7 + 1] = nty;
-        output_poses[o7 + 2] = ntz;
-        output_poses[o7 + 3] = nqx;
-        output_poses[o7 + 4] = nqy;
-        output_poses[o7 + 5] = nqz;
-        output_poses[o7 + 6] = nqw;
+        quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &ox, &oy, &oz, &ow);
     }
-} // namespace trajectory_cuda
+    else
+    {
+        quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &ox, &oy, &oz, &ow);
+    }
+    result_quat[o4 + 0] = ox;
+    result_quat[o4 + 1] = oy;
+    result_quat[o4 + 2] = oz;
+    result_quat[o4 + 3] = ow;
+    result_oob[i]       = oob ? 1.0f : 0.0f;
+}
+
+// VJP: grad_result_quat (N,4) → grad_rot0, grad_rot1; time grads via trajectory_alpha_time_grads_f on SLERP ∂L/∂α.
+__forceinline__ __device__ void trajectory_get_rotation_2poses_bwd_device(
+    int64_t i,
+    int64_t n,
+    int64_t st0,
+    int64_t st1,
+    int64_t sqt,
+    const float *__restrict__ time0,
+    const float *__restrict__ time1,
+    const float *__restrict__ query_time,
+    const float *__restrict__ rot0,
+    const float *__restrict__ rot1,
+    const float *__restrict__ grad_result_quat,
+    float *__restrict__ grad_rot0,
+    float *__restrict__ grad_rot1,
+    float *__restrict__ grad_time0,
+    float *__restrict__ grad_time1,
+    float *__restrict__ grad_query_time
+)
+{
+    const int64_t o4  = i * 4;
+    const float t0s   = time0[i * st0];
+    const float t1s   = time1[i * st1];
+    const float qt    = query_time[i * sqt];
+    const float t_min = fminf(t0s, t1s);
+    const float t_max = fmaxf(t0s, t1s);
+    const float d     = t_max - t_min;
+    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+
+    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+
+    float qix, qiy, qiz, qiw;
+    if(t0s <= t1s)
+    {
+        quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
+    }
+    else
+    {
+        quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
+    }
+
+    const float gx = grad_result_quat[o4 + 0];
+    const float gy = grad_result_quat[o4 + 1];
+    const float gz = grad_result_quat[o4 + 2];
+    const float gw = grad_result_quat[o4 + 3];
+
+    float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
+    if(t0s <= t1s)
+    {
+        quat_slerp_pair_bwd_with_time_grad<float>(
+            qx0,
+            qy0,
+            qz0,
+            qw0,
+            qx1,
+            qy1,
+            qz1,
+            qw1,
+            alpha,
+            qix,
+            qiy,
+            qiz,
+            qiw,
+            gx,
+            gy,
+            gz,
+            gw,
+            &gq1x,
+            &gq1y,
+            &gq1z,
+            &gq1w,
+            &gq2x,
+            &gq2y,
+            &gq2z,
+            &gq2w,
+            &ga_slerp
+        );
+        grad_rot0[o4 + 0] = gq1x;
+        grad_rot0[o4 + 1] = gq1y;
+        grad_rot0[o4 + 2] = gq1z;
+        grad_rot0[o4 + 3] = gq1w;
+        grad_rot1[o4 + 0] = gq2x;
+        grad_rot1[o4 + 1] = gq2y;
+        grad_rot1[o4 + 2] = gq2z;
+        grad_rot1[o4 + 3] = gq2w;
+    }
+    else
+    {
+        quat_slerp_pair_bwd_with_time_grad<float>(
+            qx1,
+            qy1,
+            qz1,
+            qw1,
+            qx0,
+            qy0,
+            qz0,
+            qw0,
+            alpha,
+            qix,
+            qiy,
+            qiz,
+            qiw,
+            gx,
+            gy,
+            gz,
+            gw,
+            &gq1x,
+            &gq1y,
+            &gq1z,
+            &gq1w,
+            &gq2x,
+            &gq2y,
+            &gq2z,
+            &gq2w,
+            &ga_slerp
+        );
+        grad_rot1[o4 + 0] = gq1x;
+        grad_rot1[o4 + 1] = gq1y;
+        grad_rot1[o4 + 2] = gq1z;
+        grad_rot1[o4 + 3] = gq1w;
+        grad_rot0[o4 + 0] = gq2x;
+        grad_rot0[o4 + 1] = gq2y;
+        grad_rot0[o4 + 2] = gq2z;
+        grad_rot0[o4 + 3] = gq2w;
+    }
+
+    float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
+    trajectory_alpha_time_grads_f(t0s, t1s, qt, d, ga_slerp, &g_t0, &g_t1, &g_qt);
+    grad_time0[i * st0]      = g_t0;
+    grad_time1[i * st1]      = g_t1;
+    grad_query_time[i * sqt] = g_qt;
+}
+
+// -----------------------------------------------------------------------------
+// Single-keyframe trajectory (float32): OOB = (query_time != keyframe time), transform still applied.
+// -----------------------------------------------------------------------------
+
+// Row i: result = R(rot_i) point_i + trans_i; result_oob[i]=1 if query_time[i*sqt] != time[i*st] (exact float compare).
+__forceinline__ __device__ void trajectory_transform_point_1pose_fwd_device(
+    int64_t i,
+    int64_t n,
+    int64_t st,
+    int64_t sqt,
+    const float *__restrict__ trans,
+    const float *__restrict__ rot,
+    const float *__restrict__ time,
+    const float *__restrict__ point,
+    const float *__restrict__ query_time,
+    float *__restrict__ result_point,
+    float *__restrict__ result_oob
+)
+{
+    const int64_t o3 = i * 3;
+    const int64_t o4 = i * 4;
+    const float tt   = time[i * st];
+    const float qt   = query_time[i * sqt];
+    const bool oob   = (qt != tt);
+
+    const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
+    const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+    const float tx = trans[o3 + 0], ty = trans[o3 + 1], tz = trans[o3 + 2];
+    float rx = 0, ry = 0, rz = 0;
+    quat_rotate_vector_fwd_impl<float>(qx, qy, qz, qw, px, py, pz, &rx, &ry, &rz);
+    result_point[o3 + 0] = rx + tx;
+    result_point[o3 + 1] = ry + ty;
+    result_point[o3 + 2] = rz + tz;
+    result_oob[i]        = oob ? 1.0f : 0.0f;
+}
+
+// VJP: grad_result_point → grad_trans, grad_rot (xyzw), grad_point; grad_time/grad_query_time not populated by device body (kernel may ignore).
+__forceinline__ __device__ void trajectory_transform_point_1pose_bwd_device(
+    int64_t i,
+    int64_t n,
+    const float *__restrict__ trans,
+    const float *__restrict__ rot,
+    const float *__restrict__ time,
+    const float *__restrict__ point,
+    const float *__restrict__ query_time,
+    const float *__restrict__ grad_result_point,
+    float *__restrict__ grad_trans,
+    float *__restrict__ grad_rot,
+    float *__restrict__ grad_time,
+    float *__restrict__ grad_point,
+    float *__restrict__ grad_query_time
+)
+{
+    const int64_t o3 = i * 3;
+    const int64_t o4 = i * 4;
+    const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
+    const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+
+    const float gtx = grad_result_point[o3 + 0];
+    const float gty = grad_result_point[o3 + 1];
+    const float gtz = grad_result_point[o3 + 2];
+
+    float gqix, gqiy, gqiz, gqiw;
+    float gpx, gpy, gpz;
+    quat_rotate_vector_bwd_impl<float>(
+        qx, qy, qz, qw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
+    );
+
+    grad_trans[o3 + 0] = gtx;
+    grad_trans[o3 + 1] = gty;
+    grad_trans[o3 + 2] = gtz;
+    grad_rot[o4 + 0]   = gqix;
+    grad_rot[o4 + 1]   = gqiy;
+    grad_rot[o4 + 2]   = gqiz;
+    grad_rot[o4 + 3]   = gqiw;
+    grad_point[o3 + 0] = gpx;
+    grad_point[o3 + 1] = gpy;
+    grad_point[o3 + 2] = gpz;
+}
+
+// Row i: 7-D pose (tx,ty,tz, qx,qy,qz,qw) → new_q = fr⊗iq, new_t = scale * (R(fr)*it + fxyz); frame quat fr is xyzw.
+__forceinline__ __device__ void frame_transform_poses_tquat_fwd_device(
+    int64_t i,
+    int64_t n,
+    float frx,
+    float fry,
+    float frz,
+    float frw,
+    float ftx,
+    float fty,
+    float ftz,
+    float scale,
+    const float *__restrict__ input_poses,
+    float *__restrict__ output_poses
+)
+{
+    const int64_t o7 = i * 7;
+    const float itx = input_poses[o7 + 0], ity = input_poses[o7 + 1], itz = input_poses[o7 + 2];
+    const float iqx = input_poses[o7 + 3], iqy = input_poses[o7 + 4], iqz = input_poses[o7 + 5],
+                iqw = input_poses[o7 + 6];
+    float nqx = 0, nqy = 0, nqz = 0, nqw = 0;
+    quat_multiply_impl<float>(frx, fry, frz, frw, iqx, iqy, iqz, iqw, &nqx, &nqy, &nqz, &nqw);
+    float rtx = 0, rty = 0, rtz = 0;
+    quat_rotate_vector_fwd_impl<float>(frx, fry, frz, frw, itx, ity, itz, &rtx, &rty, &rtz);
+    const float ntx      = scale * (rtx + ftx);
+    const float nty      = scale * (rty + fty);
+    const float ntz      = scale * (rtz + ftz);
+    output_poses[o7 + 0] = ntx;
+    output_poses[o7 + 1] = nty;
+    output_poses[o7 + 2] = ntz;
+    output_poses[o7 + 3] = nqx;
+    output_poses[o7 + 4] = nqy;
+    output_poses[o7 + 5] = nqz;
+    output_poses[o7 + 6] = nqw;
+}
 
 namespace packed_track_cuda
 {
@@ -1230,267 +1160,6 @@ __device__ __forceinline__ void se3_inverse_transform_point(
 )
 {
     quat_rotate_vector_fwd_impl<T>(-qx, -qy, -qz, qw, px - tx, py - ty, pz - tz, ox, oy, oz);
-}
-
-template<typename T>
-__device__ __forceinline__ void quat_slerp_pair_fwd(
-    T x1, T y1, T z1, T w1, T x2, T y2, T z2, T w2, T ti, T *ox, T *oy, T *oz, T *ow
-)
-{
-    const T dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const T s   = dot < T(0) ? T(-1) : T(1);
-    const T sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const T c_raw    = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const T c        = quat_slerp_clamp_dot<T>(c_raw);
-    const T small_th = quat_slerp_small_angle_dot_threshold<T>();
-
-    if(c > small_th)
-    {
-        const T om      = T(1) - ti;
-        const T rx      = om * x1 + ti * sx;
-        const T ry      = om * y1 + ti * sy;
-        const T rz      = om * z1 + ti * sz;
-        const T rw      = om * w1 + ti * sw;
-        const T norm_sq = rx * rx + ry * ry + rz * rz + rw * rw;
-        const T inv_n   = T(1) / sqrt(norm_sq);
-        *ox             = rx * inv_n;
-        *oy             = ry * inv_n;
-        *oz             = rz * inv_n;
-        *ow             = rw * inv_n;
-        return;
-    }
-
-    const T theta     = acos(c);
-    const T sin_theta = sin(theta);
-    const T w1s       = sin((T(1) - ti) * theta) / sin_theta;
-    const T w2s       = sin(ti * theta) / sin_theta;
-    *ox               = w1s * x1 + w2s * sx;
-    *oy               = w1s * y1 + w2s * sy;
-    *oz               = w1s * z1 + w2s * sz;
-    *ow               = w1s * w1 + w2s * sw;
-}
-
-// Shared VJP body; EmitGradT removes dL/dti work from no-time-grad callers.
-template<typename T, bool EmitGradT>
-__device__ __forceinline__ void quat_slerp_pair_bwd_impl(
-    T x1,
-    T y1,
-    T z1,
-    T w1,
-    T x2,
-    T y2,
-    T z2,
-    T w2,
-    T ti,
-    T rx,
-    T ry,
-    T rz,
-    T rw,
-    T gx,
-    T gy,
-    T gz,
-    T gw,
-    T *gq1x,
-    T *gq1y,
-    T *gq1z,
-    T *gq1w,
-    T *gq2x,
-    T *gq2y,
-    T *gq2z,
-    T *gq2w,
-    T *grad_t
-)
-{
-    const T dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const T s   = dot < T(0) ? T(-1) : T(1);
-    const T sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const T c_raw         = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const T c             = quat_slerp_clamp_dot<T>(c_raw);
-    const bool interior_c = (c_raw > T(-1)) && (c_raw < T(1));
-    const T c_mask        = interior_c ? T(1) : T(0);
-    const T small_th      = quat_slerp_small_angle_dot_threshold<T>();
-
-    if(c > small_th)
-    {
-        const T om      = T(1) - ti;
-        const T rrx     = om * x1 + ti * sx;
-        const T rry     = om * y1 + ti * sy;
-        const T rrz     = om * z1 + ti * sz;
-        const T rrw     = om * w1 + ti * sw;
-        const T norm_sq = rrx * rrx + rry * rry + rrz * rrz + rrw * rrw;
-        const T r_norm  = sqrt(norm_sq);
-        const T yx = rx, yy = ry, yz = rz, yw = rw;
-        const T ydotg = yx * gx + yy * gy + yz * gz + yw * gw;
-        const T scale = T(1) / r_norm;
-        const T grx   = (gx - yx * ydotg) * scale;
-        const T gry   = (gy - yy * ydotg) * scale;
-        const T grz   = (gz - yz * ydotg) * scale;
-        const T grw   = (gw - yw * ydotg) * scale;
-        *gq1x         = om * grx;
-        *gq1y         = om * gry;
-        *gq1z         = om * grz;
-        *gq1w         = om * grw;
-        *gq2x         = s * ti * grx;
-        *gq2y         = s * ti * gry;
-        *gq2z         = s * ti * grz;
-        *gq2w         = s * ti * grw;
-        if constexpr(EmitGradT)
-        {
-            const T dq2m_dq1x = sx - x1, dq2m_dq1y = sy - y1, dq2m_dq1z = sz - z1, dq2m_dq1w = sw - w1;
-            *grad_t = grx * dq2m_dq1x + gry * dq2m_dq1y + grz * dq2m_dq1z + grw * dq2m_dq1w;
-        }
-        return;
-    }
-
-    const T theta      = acos(c);
-    const T sin_theta  = sin(theta);
-    const T w1s        = sin((T(1) - ti) * theta) / sin_theta;
-    const T w2s        = sin(ti * theta) / sin_theta;
-    const T G1         = gx * x1 + gy * y1 + gz * z1 + gw * w1;
-    const T G2         = gx * sx + gy * sy + gz * sz + gw * sw;
-    const T den        = sin_theta * sin_theta;
-    const T dw1_dtheta = ((T(1) - ti) * cos((T(1) - ti) * theta) * sin_theta - sin((T(1) - ti) * theta) * c) / den;
-    const T dw2_dtheta = (ti * cos(ti * theta) * sin_theta - sin(ti * theta) * c) / den;
-    const T dw1_dc     = sin_theta > T(1e-20) ? (-dw1_dtheta / sin_theta) * c_mask : T(0);
-    const T dw2_dc     = sin_theta > T(1e-20) ? (-dw2_dtheta / sin_theta) * c_mask : T(0);
-    const T K          = G1 * dw1_dc + G2 * dw2_dc;
-    *gq1x              = w1s * gx + K * sx;
-    *gq1y              = w1s * gy + K * sy;
-    *gq1z              = w1s * gz + K * sz;
-    *gq1w              = w1s * gw + K * sw;
-    const T gq2ex      = w2s * gx + K * x1;
-    const T gq2ey      = w2s * gy + K * y1;
-    const T gq2ez      = w2s * gz + K * z1;
-    const T gq2ew      = w2s * gw + K * w1;
-    *gq2x              = s * gq2ex;
-    *gq2y              = s * gq2ey;
-    *gq2z              = s * gq2ez;
-    *gq2w              = s * gq2ew;
-    if constexpr(EmitGradT)
-    {
-        const T dw1_dt = -theta * cos((T(1) - ti) * theta) / sin_theta;
-        const T dw2_dt = theta * cos(ti * theta) / sin_theta;
-        *grad_t        = G1 * dw1_dt + G2 * dw2_dt;
-    }
-}
-
-template<typename T>
-__device__ __forceinline__ void quat_slerp_pair_bwd_no_time_grad(
-    T x1,
-    T y1,
-    T z1,
-    T w1,
-    T x2,
-    T y2,
-    T z2,
-    T w2,
-    T ti,
-    T rx,
-    T ry,
-    T rz,
-    T rw,
-    T gx,
-    T gy,
-    T gz,
-    T gw,
-    T *gq1x,
-    T *gq1y,
-    T *gq1z,
-    T *gq1w,
-    T *gq2x,
-    T *gq2y,
-    T *gq2z,
-    T *gq2w
-)
-{
-    quat_slerp_pair_bwd_impl<T, false>(
-        x1,
-        y1,
-        z1,
-        w1,
-        x2,
-        y2,
-        z2,
-        w2,
-        ti,
-        rx,
-        ry,
-        rz,
-        rw,
-        gx,
-        gy,
-        gz,
-        gw,
-        gq1x,
-        gq1y,
-        gq1z,
-        gq1w,
-        gq2x,
-        gq2y,
-        gq2z,
-        gq2w,
-        nullptr
-    );
-}
-
-template<typename T>
-__device__ __forceinline__ void quat_slerp_pair_bwd_with_time_grad(
-    T x1,
-    T y1,
-    T z1,
-    T w1,
-    T x2,
-    T y2,
-    T z2,
-    T w2,
-    T ti,
-    T rx,
-    T ry,
-    T rz,
-    T rw,
-    T gx,
-    T gy,
-    T gz,
-    T gw,
-    T *gq1x,
-    T *gq1y,
-    T *gq1z,
-    T *gq1w,
-    T *gq2x,
-    T *gq2y,
-    T *gq2z,
-    T *gq2w,
-    T *grad_t
-)
-{
-    quat_slerp_pair_bwd_impl<T, true>(
-        x1,
-        y1,
-        z1,
-        w1,
-        x2,
-        y2,
-        z2,
-        w2,
-        ti,
-        rx,
-        ry,
-        rz,
-        rw,
-        gx,
-        gy,
-        gz,
-        gw,
-        gq1x,
-        gq1y,
-        gq1z,
-        gq1w,
-        gq2x,
-        gq2y,
-        gq2z,
-        gq2w,
-        grad_t
-    );
 }
 
 // Batch row i: out = R(q)^T d (same conjugate trick as inverse point, without translation).

--- a/gsplat/geometry/kernels/cuda/csrc/pose.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/pose.cuh
@@ -27,6 +27,8 @@
 
 #include "quaternion.cuh"
 
+namespace gsplat_geometry
+{
 // -----------------------------------------------------------------------------
 // se3pose_from_matrix with normalize-safe quaternion recovery.
 // Shared quaternion primitives: quaternion.cuh (QuatNormEps, quat_normalize_safe_*_write, quat_to_matrix_fwd_write).
@@ -229,801 +231,796 @@ __device__ void shepperd_from_matrix_bwd(
     }
 }
 
+// SLERP q1 -> q2 at ti (xyzw, unit-quaternion inputs).
+template<typename T>
+__device__ __forceinline__ void quat_slerp_pair_fwd(
+    T x1, T y1, T z1, T w1, T x2, T y2, T z2, T w2, T ti, T *ox, T *oy, T *oz, T *ow
+);
+
+// VJP for quat_slerp_pair_fwd when interpolation time is non-differentiable.
+template<typename T>
+__device__ __forceinline__ void quat_slerp_pair_bwd_no_time_grad(
+    T x1,
+    T y1,
+    T z1,
+    T w1,
+    T x2,
+    T y2,
+    T z2,
+    T w2,
+    T ti,
+    T rx,
+    T ry,
+    T rz,
+    T rw,
+    T gx,
+    T gy,
+    T gz,
+    T gw,
+    T *gq1x,
+    T *gq1y,
+    T *gq1z,
+    T *gq1w,
+    T *gq2x,
+    T *gq2y,
+    T *gq2z,
+    T *gq2w
+);
+
+// VJP variant for differentiable interpolation time; grad_t must be non-null.
+template<typename T>
+__device__ __forceinline__ void quat_slerp_pair_bwd_with_time_grad(
+    T x1,
+    T y1,
+    T z1,
+    T w1,
+    T x2,
+    T y2,
+    T z2,
+    T w2,
+    T ti,
+    T rx,
+    T ry,
+    T rz,
+    T rw,
+    T gx,
+    T gy,
+    T gz,
+    T gw,
+    T *gq1x,
+    T *gq1y,
+    T *gq1z,
+    T *gq1w,
+    T *gq2x,
+    T *gq2y,
+    T *gq2z,
+    T *gq2w,
+    T *grad_t
+);
+
 namespace trajectory_cuda
 {
-// Float32 trajectory: uses quaternion.cuh templates (cross3, quat_rotate_vector_*, quat_multiply_impl, quat_slerp_clamp_dot).
-
-// SLERP q1→q2 at parameter ti∈[0,1]; xyzw; hemisphere flip; if dot>0.9995 use normalized lerp. Outputs *ox..*ow.
-__forceinline__ __device__ void quat_slerp_pair_fwd_f(
-    float x1,
-    float y1,
-    float z1,
-    float w1,
-    float x2,
-    float y2,
-    float z2,
-    float w2,
-    float ti,
-    float *ox,
-    float *oy,
-    float *oz,
-    float *ow
-)
-{
-    quat_slerp_pair_fwd<float>(x1, y1, z1, w1, x2, y2, z2, w2, ti, ox, oy, oz, ow);
-}
-
-// VJP for quat_slerp_pair_fwd_f: forward outputs (rx,ry,rz,rw) and upstream (gx..gw) → *gq1*, *gq2*, *grad_t.
-__forceinline__ __device__ void quat_slerp_pair_bwd_f(
-    float x1,
-    float y1,
-    float z1,
-    float w1,
-    float x2,
-    float y2,
-    float z2,
-    float w2,
-    float ti,
-    float rx,
-    float ry,
-    float rz,
-    float rw,
-    float gx,
-    float gy,
-    float gz,
-    float gw,
-    float *gq1x,
-    float *gq1y,
-    float *gq1z,
-    float *gq1w,
-    float *gq2x,
-    float *gq2y,
-    float *gq2z,
-    float *gq2w,
-    float *grad_t
-)
-{
-    quat_slerp_pair_bwd<float>(
-        x1,
-        y1,
-        z1,
-        w1,
-        x2,
-        y2,
-        z2,
-        w2,
-        ti,
-        rx,
-        ry,
-        rz,
-        rw,
-        gx,
-        gy,
-        gz,
-        gw,
-        gq1x,
-        gq1y,
-        gq1z,
-        gq1w,
-        gq2x,
-        gq2y,
-        gq2z,
-        gq2w,
-        grad_t
-    );
-}
-
-// Time-interpolation chain rule: grad_alpha = ∂L/∂α with α=(qt-t_min)/(t_max-t_min), d=t_max-t_min.
-// Outputs *g_t0,*g_t1,*g_qt for ∂L/∂time0, ∂L/∂time1, ∂L/∂query_time (handles t0>t1 swap).
-__forceinline__ __device__ void trajectory_alpha_time_grads_f(
-    float t0s, float t1s, float qt, float d, float grad_alpha, float *g_t0, float *g_t1, float *g_qt
-)
-{
-    if(d <= 0.0f)
+    // Time-interpolation chain rule: grad_alpha = ∂L/∂α with α=(qt-t_min)/(t_max-t_min), d=t_max-t_min.
+    // Outputs *g_t0,*g_t1,*g_qt for ∂L/∂time0, ∂L/∂time1, ∂L/∂query_time (handles t0>t1 swap).
+    __forceinline__ __device__ void trajectory_alpha_time_grads_f(
+        float t0s, float t1s, float qt, float d, float grad_alpha, float *g_t0, float *g_t1, float *g_qt
+    )
     {
-        *g_t0 = *g_t1 = *g_qt = 0.0f;
-        return;
-    }
-    const float inv_d = 1.0f / d;
-    *g_qt             = grad_alpha * inv_d;
-    if(t0s <= t1s)
-    {
-        const float d2 = d * d;
-        *g_t0          = grad_alpha * (qt - t1s) / d2;
-        *g_t1          = -grad_alpha * (qt - t0s) / d2;
-    }
-    else
-    {
-        const float d2 = d * d;
-        *g_t1          = grad_alpha * (qt - t0s) / d2;
-        *g_t0          = -grad_alpha * (qt - t1s) / d2;
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Float32 trajectory: two-keyframe SLERP + helpers; OOB flags when query time leaves the span.
-// -----------------------------------------------------------------------------
-
-// Row i: interpolate pose between keyframes 0/1 at query_time. trans* (N,3), rot* xyzw (N,4), time* indexed by strides st0/st1; query_time stride sqt.
-// result_point (N,3) = R(qi)(point) + ti; result_oob[i]∈{0,1} if qt outside [min(t0,t1), max(t0,t1)].
-__forceinline__ __device__ void trajectory_transform_point_2poses_fwd_device(
-    int64_t i,
-    int64_t n,
-    int64_t st0,
-    int64_t st1,
-    int64_t sqt,
-    const float *__restrict__ trans0,
-    const float *__restrict__ rot0,
-    const float *__restrict__ time0,
-    const float *__restrict__ trans1,
-    const float *__restrict__ rot1,
-    const float *__restrict__ time1,
-    const float *__restrict__ point,
-    const float *__restrict__ query_time,
-    float *__restrict__ result_point,
-    float *__restrict__ result_oob
-)
-{
-    const int64_t o3  = i * 3;
-    const int64_t o4  = i * 4;
-    const float t0s   = time0[i * st0];
-    const float t1s   = time1[i * st1];
-    const float qt    = query_time[i * sqt];
-    const float t_min = fminf(t0s, t1s);
-    const float t_max = fmaxf(t0s, t1s);
-    const bool oob    = (qt < t_min) || (qt > t_max);
-    const float d     = t_max - t_min;
-    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-
-    float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
-    float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
-    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-    float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-
-    float tix, tiy, tiz;
-    float qix, qiy, qiz, qiw;
-    if(t0s <= t1s)
-    {
-        const float om = 1.0f - alpha;
-        tix            = om * tx0 + alpha * tx1;
-        tiy            = om * ty0 + alpha * ty1;
-        tiz            = om * tz0 + alpha * tz1;
-        quat_slerp_pair_fwd_f(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
-    }
-    else
-    {
-        const float om = 1.0f - alpha;
-        tix            = om * tx1 + alpha * tx0;
-        tiy            = om * ty1 + alpha * ty0;
-        tiz            = om * tz1 + alpha * tz0;
-        quat_slerp_pair_fwd_f(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
-    }
-    float rx, ry, rz;
-    quat_rotate_vector_fwd_impl<float>(qix, qiy, qiz, qiw, px, py, pz, &rx, &ry, &rz);
-    result_point[o3 + 0] = rx + tix;
-    result_point[o3 + 1] = ry + tiy;
-    result_point[o3 + 2] = rz + tiz;
-    result_oob[i]        = oob ? 1.0f : 0.0f;
-}
-
-// VJP for 2-pose point transform: grad_result_point (N,3) → grads for trans0/1, rot0/1 (xyzw), time strides, point, query_time.
-__forceinline__ __device__ void trajectory_transform_point_2poses_bwd_device(
-    int64_t i,
-    int64_t n,
-    int64_t st0,
-    int64_t st1,
-    int64_t sqt,
-    const float *__restrict__ trans0,
-    const float *__restrict__ rot0,
-    const float *__restrict__ time0,
-    const float *__restrict__ trans1,
-    const float *__restrict__ rot1,
-    const float *__restrict__ time1,
-    const float *__restrict__ point,
-    const float *__restrict__ query_time,
-    const float *__restrict__ grad_result_point,
-    float *__restrict__ grad_trans0,
-    float *__restrict__ grad_rot0,
-    float *__restrict__ grad_time0,
-    float *__restrict__ grad_trans1,
-    float *__restrict__ grad_rot1,
-    float *__restrict__ grad_time1,
-    float *__restrict__ grad_point,
-    float *__restrict__ grad_query_time
-)
-{
-    const int64_t o3  = i * 3;
-    const int64_t o4  = i * 4;
-    const float t0s   = time0[i * st0];
-    const float t1s   = time1[i * st1];
-    const float qt    = query_time[i * sqt];
-    const float t_min = fminf(t0s, t1s);
-    const float t_max = fmaxf(t0s, t1s);
-    const float d     = t_max - t_min;
-    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-
-    float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
-    float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
-    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-    float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-
-    float qix, qiy, qiz, qiw;
-    if(t0s <= t1s)
-    {
-        quat_slerp_pair_fwd_f(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
-    }
-    else
-    {
-        quat_slerp_pair_fwd_f(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
+        if(d <= 0.0f)
+        {
+            *g_t0 = *g_t1 = *g_qt = 0.0f;
+            return;
+        }
+        const float inv_d = 1.0f / d;
+        *g_qt             = grad_alpha * inv_d;
+        if(t0s <= t1s)
+        {
+            const float d2 = d * d;
+            *g_t0          = grad_alpha * (qt - t1s) / d2;
+            *g_t1          = -grad_alpha * (qt - t0s) / d2;
+        }
+        else
+        {
+            const float d2 = d * d;
+            *g_t1          = grad_alpha * (qt - t0s) / d2;
+            *g_t0          = -grad_alpha * (qt - t1s) / d2;
+        }
     }
 
-    const float gtx = grad_result_point[o3 + 0];
-    const float gty = grad_result_point[o3 + 1];
-    const float gtz = grad_result_point[o3 + 2];
+    // -----------------------------------------------------------------------------
+    // Float32 trajectory: two-keyframe SLERP + helpers; OOB flags when query time leaves the span.
+    // -----------------------------------------------------------------------------
 
-    float gqix, gqiy, gqiz, gqiw;
-    float gpx, gpy, gpz;
-    quat_rotate_vector_bwd_impl<float>(
-        qix, qiy, qiz, qiw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
-    );
-
-    grad_point[o3 + 0] = gpx;
-    grad_point[o3 + 1] = gpy;
-    grad_point[o3 + 2] = gpz;
-
-    float grad_alpha = 0.0f;
-
-    if(t0s <= t1s)
+    // Row i: interpolate pose between keyframes 0/1 at query_time. trans* (N,3), rot* xyzw (N,4), time* indexed by strides st0/st1; query_time stride sqt.
+    // result_point (N,3) = R(qi)(point) + ti; result_oob[i]∈{0,1} if qt outside [min(t0,t1), max(t0,t1)].
+    __forceinline__ __device__ void trajectory_transform_point_2poses_fwd_device(
+        int64_t i,
+        int64_t n,
+        int64_t st0,
+        int64_t st1,
+        int64_t sqt,
+        const float *__restrict__ trans0,
+        const float *__restrict__ rot0,
+        const float *__restrict__ time0,
+        const float *__restrict__ trans1,
+        const float *__restrict__ rot1,
+        const float *__restrict__ time1,
+        const float *__restrict__ point,
+        const float *__restrict__ query_time,
+        float *__restrict__ result_point,
+        float *__restrict__ result_oob
+    )
     {
-        grad_trans0[o3 + 0]  = (1.0f - alpha) * gtx;
-        grad_trans0[o3 + 1]  = (1.0f - alpha) * gty;
-        grad_trans0[o3 + 2]  = (1.0f - alpha) * gtz;
-        grad_trans1[o3 + 0]  = alpha * gtx;
-        grad_trans1[o3 + 1]  = alpha * gty;
-        grad_trans1[o3 + 2]  = alpha * gtz;
-        grad_alpha          += gtx * (tx1 - tx0) + gty * (ty1 - ty0) + gtz * (tz1 - tz0);
+        const int64_t o3  = i * 3;
+        const int64_t o4  = i * 4;
+        const float t0s   = time0[i * st0];
+        const float t1s   = time1[i * st1];
+        const float qt    = query_time[i * sqt];
+        const float t_min = fminf(t0s, t1s);
+        const float t_max = fmaxf(t0s, t1s);
+        const bool oob    = (qt < t_min) || (qt > t_max);
+        const float d     = t_max - t_min;
+        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+
+        float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
+        float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
+        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+        float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+
+        float tix, tiy, tiz;
+        float qix, qiy, qiz, qiw;
+        if(t0s <= t1s)
+        {
+            const float om = 1.0f - alpha;
+            tix            = om * tx0 + alpha * tx1;
+            tiy            = om * ty0 + alpha * ty1;
+            tiz            = om * tz0 + alpha * tz1;
+            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
+        }
+        else
+        {
+            const float om = 1.0f - alpha;
+            tix            = om * tx1 + alpha * tx0;
+            tiy            = om * ty1 + alpha * ty0;
+            tiz            = om * tz1 + alpha * tz0;
+            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
+        }
+        float rx, ry, rz;
+        quat_rotate_vector_fwd_impl<float>(qix, qiy, qiz, qiw, px, py, pz, &rx, &ry, &rz);
+        result_point[o3 + 0] = rx + tix;
+        result_point[o3 + 1] = ry + tiy;
+        result_point[o3 + 2] = rz + tiz;
+        result_oob[i]        = oob ? 1.0f : 0.0f;
     }
-    else
-    {
-        grad_trans1[o3 + 0]  = (1.0f - alpha) * gtx;
-        grad_trans1[o3 + 1]  = (1.0f - alpha) * gty;
-        grad_trans1[o3 + 2]  = (1.0f - alpha) * gtz;
-        grad_trans0[o3 + 0]  = alpha * gtx;
-        grad_trans0[o3 + 1]  = alpha * gty;
-        grad_trans0[o3 + 2]  = alpha * gtz;
-        grad_alpha          += gtx * (tx0 - tx1) + gty * (ty0 - ty1) + gtz * (tz0 - tz1);
-    }
 
-    float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
-    if(t0s <= t1s)
+    // VJP for 2-pose point transform: grad_result_point (N,3) → grads for trans0/1, rot0/1 (xyzw), time strides, point, query_time.
+    __forceinline__ __device__ void trajectory_transform_point_2poses_bwd_device(
+        int64_t i,
+        int64_t n,
+        int64_t st0,
+        int64_t st1,
+        int64_t sqt,
+        const float *__restrict__ trans0,
+        const float *__restrict__ rot0,
+        const float *__restrict__ time0,
+        const float *__restrict__ trans1,
+        const float *__restrict__ rot1,
+        const float *__restrict__ time1,
+        const float *__restrict__ point,
+        const float *__restrict__ query_time,
+        const float *__restrict__ grad_result_point,
+        float *__restrict__ grad_trans0,
+        float *__restrict__ grad_rot0,
+        float *__restrict__ grad_time0,
+        float *__restrict__ grad_trans1,
+        float *__restrict__ grad_rot1,
+        float *__restrict__ grad_time1,
+        float *__restrict__ grad_point,
+        float *__restrict__ grad_query_time
+    )
     {
-        quat_slerp_pair_bwd_f(
-            qx0,
-            qy0,
-            qz0,
-            qw0,
-            qx1,
-            qy1,
-            qz1,
-            qw1,
-            alpha,
-            qix,
-            qiy,
-            qiz,
-            qiw,
-            gqix,
-            gqiy,
-            gqiz,
-            gqiw,
-            &gq1x,
-            &gq1y,
-            &gq1z,
-            &gq1w,
-            &gq2x,
-            &gq2y,
-            &gq2z,
-            &gq2w,
-            &ga_slerp
+        const int64_t o3  = i * 3;
+        const int64_t o4  = i * 4;
+        const float t0s   = time0[i * st0];
+        const float t1s   = time1[i * st1];
+        const float qt    = query_time[i * sqt];
+        const float t_min = fminf(t0s, t1s);
+        const float t_max = fmaxf(t0s, t1s);
+        const float d     = t_max - t_min;
+        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+
+        float tx0 = trans0[o3 + 0], ty0 = trans0[o3 + 1], tz0 = trans0[o3 + 2];
+        float tx1 = trans1[o3 + 0], ty1 = trans1[o3 + 1], tz1 = trans1[o3 + 2];
+        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+        float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+
+        float qix, qiy, qiz, qiw;
+        if(t0s <= t1s)
+        {
+            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
+        }
+        else
+        {
+            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
+        }
+
+        const float gtx = grad_result_point[o3 + 0];
+        const float gty = grad_result_point[o3 + 1];
+        const float gtz = grad_result_point[o3 + 2];
+
+        float gqix, gqiy, gqiz, gqiw;
+        float gpx, gpy, gpz;
+        quat_rotate_vector_bwd_impl<float>(
+            qix, qiy, qiz, qiw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
         );
-        grad_rot0[o4 + 0] = gq1x;
-        grad_rot0[o4 + 1] = gq1y;
-        grad_rot0[o4 + 2] = gq1z;
-        grad_rot0[o4 + 3] = gq1w;
-        grad_rot1[o4 + 0] = gq2x;
-        grad_rot1[o4 + 1] = gq2y;
-        grad_rot1[o4 + 2] = gq2z;
-        grad_rot1[o4 + 3] = gq2w;
+
+        grad_point[o3 + 0] = gpx;
+        grad_point[o3 + 1] = gpy;
+        grad_point[o3 + 2] = gpz;
+
+        float grad_alpha = 0.0f;
+
+        if(t0s <= t1s)
+        {
+            grad_trans0[o3 + 0]  = (1.0f - alpha) * gtx;
+            grad_trans0[o3 + 1]  = (1.0f - alpha) * gty;
+            grad_trans0[o3 + 2]  = (1.0f - alpha) * gtz;
+            grad_trans1[o3 + 0]  = alpha * gtx;
+            grad_trans1[o3 + 1]  = alpha * gty;
+            grad_trans1[o3 + 2]  = alpha * gtz;
+            grad_alpha          += gtx * (tx1 - tx0) + gty * (ty1 - ty0) + gtz * (tz1 - tz0);
+        }
+        else
+        {
+            grad_trans1[o3 + 0]  = (1.0f - alpha) * gtx;
+            grad_trans1[o3 + 1]  = (1.0f - alpha) * gty;
+            grad_trans1[o3 + 2]  = (1.0f - alpha) * gtz;
+            grad_trans0[o3 + 0]  = alpha * gtx;
+            grad_trans0[o3 + 1]  = alpha * gty;
+            grad_trans0[o3 + 2]  = alpha * gtz;
+            grad_alpha          += gtx * (tx0 - tx1) + gty * (ty0 - ty1) + gtz * (tz0 - tz1);
+        }
+
+        float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
+        if(t0s <= t1s)
+        {
+            quat_slerp_pair_bwd_with_time_grad<float>(
+                qx0,
+                qy0,
+                qz0,
+                qw0,
+                qx1,
+                qy1,
+                qz1,
+                qw1,
+                alpha,
+                qix,
+                qiy,
+                qiz,
+                qiw,
+                gqix,
+                gqiy,
+                gqiz,
+                gqiw,
+                &gq1x,
+                &gq1y,
+                &gq1z,
+                &gq1w,
+                &gq2x,
+                &gq2y,
+                &gq2z,
+                &gq2w,
+                &ga_slerp
+            );
+            grad_rot0[o4 + 0] = gq1x;
+            grad_rot0[o4 + 1] = gq1y;
+            grad_rot0[o4 + 2] = gq1z;
+            grad_rot0[o4 + 3] = gq1w;
+            grad_rot1[o4 + 0] = gq2x;
+            grad_rot1[o4 + 1] = gq2y;
+            grad_rot1[o4 + 2] = gq2z;
+            grad_rot1[o4 + 3] = gq2w;
+        }
+        else
+        {
+            quat_slerp_pair_bwd_with_time_grad<float>(
+                qx1,
+                qy1,
+                qz1,
+                qw1,
+                qx0,
+                qy0,
+                qz0,
+                qw0,
+                alpha,
+                qix,
+                qiy,
+                qiz,
+                qiw,
+                gqix,
+                gqiy,
+                gqiz,
+                gqiw,
+                &gq1x,
+                &gq1y,
+                &gq1z,
+                &gq1w,
+                &gq2x,
+                &gq2y,
+                &gq2z,
+                &gq2w,
+                &ga_slerp
+            );
+            grad_rot1[o4 + 0] = gq1x;
+            grad_rot1[o4 + 1] = gq1y;
+            grad_rot1[o4 + 2] = gq1z;
+            grad_rot1[o4 + 3] = gq1w;
+            grad_rot0[o4 + 0] = gq2x;
+            grad_rot0[o4 + 1] = gq2y;
+            grad_rot0[o4 + 2] = gq2z;
+            grad_rot0[o4 + 3] = gq2w;
+        }
+        grad_alpha += ga_slerp;
+
+        float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
+        trajectory_alpha_time_grads_f(t0s, t1s, qt, d, grad_alpha, &g_t0, &g_t1, &g_qt);
+        grad_time0[i * st0]      = g_t0;
+        grad_time1[i * st1]      = g_t1;
+        grad_query_time[i * sqt] = g_qt;
     }
-    else
+
+    // Row i: SLERP rot0/rot1 at query_time (same α and OOB semantics as 2-pose point); result_quat (N,4) xyzw.
+    __forceinline__ __device__ void trajectory_get_rotation_2poses_fwd_device(
+        int64_t i,
+        int64_t n,
+        int64_t st0,
+        int64_t st1,
+        int64_t sqt,
+        const float *__restrict__ time0,
+        const float *__restrict__ time1,
+        const float *__restrict__ query_time,
+        const float *__restrict__ rot0,
+        const float *__restrict__ rot1,
+        float *__restrict__ result_quat,
+        float *__restrict__ result_oob
+    )
     {
-        quat_slerp_pair_bwd_f(
-            qx1,
-            qy1,
-            qz1,
-            qw1,
-            qx0,
-            qy0,
-            qz0,
-            qw0,
-            alpha,
-            qix,
-            qiy,
-            qiz,
-            qiw,
-            gqix,
-            gqiy,
-            gqiz,
-            gqiw,
-            &gq1x,
-            &gq1y,
-            &gq1z,
-            &gq1w,
-            &gq2x,
-            &gq2y,
-            &gq2z,
-            &gq2w,
-            &ga_slerp
+        const int64_t o4  = i * 4;
+        const float t0s   = time0[i * st0];
+        const float t1s   = time1[i * st1];
+        const float qt    = query_time[i * sqt];
+        const float t_min = fminf(t0s, t1s);
+        const float t_max = fmaxf(t0s, t1s);
+        const bool oob    = (qt < t_min) || (qt > t_max);
+        const float d     = t_max - t_min;
+        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+        float ox, oy, oz, ow;
+        if(t0s <= t1s)
+        {
+            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &ox, &oy, &oz, &ow);
+        }
+        else
+        {
+            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &ox, &oy, &oz, &ow);
+        }
+        result_quat[o4 + 0] = ox;
+        result_quat[o4 + 1] = oy;
+        result_quat[o4 + 2] = oz;
+        result_quat[o4 + 3] = ow;
+        result_oob[i]       = oob ? 1.0f : 0.0f;
+    }
+
+    // VJP: grad_result_quat (N,4) → grad_rot0, grad_rot1; time grads via trajectory_alpha_time_grads_f on SLERP ∂L/∂α.
+    __forceinline__ __device__ void trajectory_get_rotation_2poses_bwd_device(
+        int64_t i,
+        int64_t n,
+        int64_t st0,
+        int64_t st1,
+        int64_t sqt,
+        const float *__restrict__ time0,
+        const float *__restrict__ time1,
+        const float *__restrict__ query_time,
+        const float *__restrict__ rot0,
+        const float *__restrict__ rot1,
+        const float *__restrict__ grad_result_quat,
+        float *__restrict__ grad_rot0,
+        float *__restrict__ grad_rot1,
+        float *__restrict__ grad_time0,
+        float *__restrict__ grad_time1,
+        float *__restrict__ grad_query_time
+    )
+    {
+        const int64_t o4  = i * 4;
+        const float t0s   = time0[i * st0];
+        const float t1s   = time1[i * st1];
+        const float qt    = query_time[i * sqt];
+        const float t_min = fminf(t0s, t1s);
+        const float t_max = fmaxf(t0s, t1s);
+        const float d     = t_max - t_min;
+        const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
+
+        float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
+        float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
+
+        float qix, qiy, qiz, qiw;
+        if(t0s <= t1s)
+        {
+            quat_slerp_pair_fwd<float>(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
+        }
+        else
+        {
+            quat_slerp_pair_fwd<float>(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
+        }
+
+        const float gx = grad_result_quat[o4 + 0];
+        const float gy = grad_result_quat[o4 + 1];
+        const float gz = grad_result_quat[o4 + 2];
+        const float gw = grad_result_quat[o4 + 3];
+
+        float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
+        if(t0s <= t1s)
+        {
+            quat_slerp_pair_bwd_with_time_grad<float>(
+                qx0,
+                qy0,
+                qz0,
+                qw0,
+                qx1,
+                qy1,
+                qz1,
+                qw1,
+                alpha,
+                qix,
+                qiy,
+                qiz,
+                qiw,
+                gx,
+                gy,
+                gz,
+                gw,
+                &gq1x,
+                &gq1y,
+                &gq1z,
+                &gq1w,
+                &gq2x,
+                &gq2y,
+                &gq2z,
+                &gq2w,
+                &ga_slerp
+            );
+            grad_rot0[o4 + 0] = gq1x;
+            grad_rot0[o4 + 1] = gq1y;
+            grad_rot0[o4 + 2] = gq1z;
+            grad_rot0[o4 + 3] = gq1w;
+            grad_rot1[o4 + 0] = gq2x;
+            grad_rot1[o4 + 1] = gq2y;
+            grad_rot1[o4 + 2] = gq2z;
+            grad_rot1[o4 + 3] = gq2w;
+        }
+        else
+        {
+            quat_slerp_pair_bwd_with_time_grad<float>(
+                qx1,
+                qy1,
+                qz1,
+                qw1,
+                qx0,
+                qy0,
+                qz0,
+                qw0,
+                alpha,
+                qix,
+                qiy,
+                qiz,
+                qiw,
+                gx,
+                gy,
+                gz,
+                gw,
+                &gq1x,
+                &gq1y,
+                &gq1z,
+                &gq1w,
+                &gq2x,
+                &gq2y,
+                &gq2z,
+                &gq2w,
+                &ga_slerp
+            );
+            grad_rot1[o4 + 0] = gq1x;
+            grad_rot1[o4 + 1] = gq1y;
+            grad_rot1[o4 + 2] = gq1z;
+            grad_rot1[o4 + 3] = gq1w;
+            grad_rot0[o4 + 0] = gq2x;
+            grad_rot0[o4 + 1] = gq2y;
+            grad_rot0[o4 + 2] = gq2z;
+            grad_rot0[o4 + 3] = gq2w;
+        }
+
+        float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
+        trajectory_alpha_time_grads_f(t0s, t1s, qt, d, ga_slerp, &g_t0, &g_t1, &g_qt);
+        grad_time0[i * st0]      = g_t0;
+        grad_time1[i * st1]      = g_t1;
+        grad_query_time[i * sqt] = g_qt;
+    }
+
+    // -----------------------------------------------------------------------------
+    // Single-keyframe trajectory (float32): OOB = (query_time != keyframe time), transform still applied.
+    // -----------------------------------------------------------------------------
+
+    // Row i: result = R(rot_i) point_i + trans_i; result_oob[i]=1 if query_time[i*sqt] != time[i*st] (exact float compare).
+    __forceinline__ __device__ void trajectory_transform_point_1pose_fwd_device(
+        int64_t i,
+        int64_t n,
+        int64_t st,
+        int64_t sqt,
+        const float *__restrict__ trans,
+        const float *__restrict__ rot,
+        const float *__restrict__ time,
+        const float *__restrict__ point,
+        const float *__restrict__ query_time,
+        float *__restrict__ result_point,
+        float *__restrict__ result_oob
+    )
+    {
+        const int64_t o3 = i * 3;
+        const int64_t o4 = i * 4;
+        const float tt   = time[i * st];
+        const float qt   = query_time[i * sqt];
+        const bool oob   = (qt != tt);
+
+        const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
+        const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+        const float tx = trans[o3 + 0], ty = trans[o3 + 1], tz = trans[o3 + 2];
+        float rx = 0, ry = 0, rz = 0;
+        quat_rotate_vector_fwd_impl<float>(qx, qy, qz, qw, px, py, pz, &rx, &ry, &rz);
+        result_point[o3 + 0] = rx + tx;
+        result_point[o3 + 1] = ry + ty;
+        result_point[o3 + 2] = rz + tz;
+        result_oob[i]        = oob ? 1.0f : 0.0f;
+    }
+
+    // VJP: grad_result_point → grad_trans, grad_rot (xyzw), grad_point; grad_time/grad_query_time not populated by device body (kernel may ignore).
+    __forceinline__ __device__ void trajectory_transform_point_1pose_bwd_device(
+        int64_t i,
+        int64_t n,
+        const float *__restrict__ trans,
+        const float *__restrict__ rot,
+        const float *__restrict__ time,
+        const float *__restrict__ point,
+        const float *__restrict__ query_time,
+        const float *__restrict__ grad_result_point,
+        float *__restrict__ grad_trans,
+        float *__restrict__ grad_rot,
+        float *__restrict__ grad_time,
+        float *__restrict__ grad_point,
+        float *__restrict__ grad_query_time
+    )
+    {
+        const int64_t o3 = i * 3;
+        const int64_t o4 = i * 4;
+        const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
+        const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
+
+        const float gtx = grad_result_point[o3 + 0];
+        const float gty = grad_result_point[o3 + 1];
+        const float gtz = grad_result_point[o3 + 2];
+
+        float gqix, gqiy, gqiz, gqiw;
+        float gpx, gpy, gpz;
+        quat_rotate_vector_bwd_impl<float>(
+            qx, qy, qz, qw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
         );
-        grad_rot1[o4 + 0] = gq1x;
-        grad_rot1[o4 + 1] = gq1y;
-        grad_rot1[o4 + 2] = gq1z;
-        grad_rot1[o4 + 3] = gq1w;
-        grad_rot0[o4 + 0] = gq2x;
-        grad_rot0[o4 + 1] = gq2y;
-        grad_rot0[o4 + 2] = gq2z;
-        grad_rot0[o4 + 3] = gq2w;
+
+        grad_trans[o3 + 0] = gtx;
+        grad_trans[o3 + 1] = gty;
+        grad_trans[o3 + 2] = gtz;
+        grad_rot[o4 + 0]   = gqix;
+        grad_rot[o4 + 1]   = gqiy;
+        grad_rot[o4 + 2]   = gqiz;
+        grad_rot[o4 + 3]   = gqiw;
+        grad_point[o3 + 0] = gpx;
+        grad_point[o3 + 1] = gpy;
+        grad_point[o3 + 2] = gpz;
     }
-    grad_alpha += ga_slerp;
 
-    float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
-    trajectory_alpha_time_grads_f(t0s, t1s, qt, d, grad_alpha, &g_t0, &g_t1, &g_qt);
-    grad_time0[i * st0]      = g_t0;
-    grad_time1[i * st1]      = g_t1;
-    grad_query_time[i * sqt] = g_qt;
-}
-
-// Row i: SLERP rot0/rot1 at query_time (same α and OOB semantics as 2-pose point); result_quat (N,4) xyzw.
-__forceinline__ __device__ void trajectory_get_rotation_2poses_fwd_device(
-    int64_t i,
-    int64_t n,
-    int64_t st0,
-    int64_t st1,
-    int64_t sqt,
-    const float *__restrict__ time0,
-    const float *__restrict__ time1,
-    const float *__restrict__ query_time,
-    const float *__restrict__ rot0,
-    const float *__restrict__ rot1,
-    float *__restrict__ result_quat,
-    float *__restrict__ result_oob
-)
-{
-    const int64_t o4  = i * 4;
-    const float t0s   = time0[i * st0];
-    const float t1s   = time1[i * st1];
-    const float qt    = query_time[i * sqt];
-    const float t_min = fminf(t0s, t1s);
-    const float t_max = fmaxf(t0s, t1s);
-    const bool oob    = (qt < t_min) || (qt > t_max);
-    const float d     = t_max - t_min;
-    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-    float ox, oy, oz, ow;
-    if(t0s <= t1s)
+    // Row i: 7-D pose (tx,ty,tz, qx,qy,qz,qw) → new_q = fr⊗iq, new_t = scale * (R(fr)*it + fxyz); frame quat fr is xyzw.
+    __forceinline__ __device__ void frame_transform_poses_tquat_fwd_device(
+        int64_t i,
+        int64_t n,
+        float frx,
+        float fry,
+        float frz,
+        float frw,
+        float ftx,
+        float fty,
+        float ftz,
+        float scale,
+        const float *__restrict__ input_poses,
+        float *__restrict__ output_poses
+    )
     {
-        quat_slerp_pair_fwd_f(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &ox, &oy, &oz, &ow);
+        const int64_t o7 = i * 7;
+        const float itx = input_poses[o7 + 0], ity = input_poses[o7 + 1], itz = input_poses[o7 + 2];
+        const float iqx = input_poses[o7 + 3], iqy = input_poses[o7 + 4], iqz = input_poses[o7 + 5],
+                    iqw = input_poses[o7 + 6];
+        float nqx = 0, nqy = 0, nqz = 0, nqw = 0;
+        quat_multiply_impl<float>(frx, fry, frz, frw, iqx, iqy, iqz, iqw, &nqx, &nqy, &nqz, &nqw);
+        float rtx = 0, rty = 0, rtz = 0;
+        quat_rotate_vector_fwd_impl<float>(frx, fry, frz, frw, itx, ity, itz, &rtx, &rty, &rtz);
+        const float ntx      = scale * (rtx + ftx);
+        const float nty      = scale * (rty + fty);
+        const float ntz      = scale * (rtz + ftz);
+        output_poses[o7 + 0] = ntx;
+        output_poses[o7 + 1] = nty;
+        output_poses[o7 + 2] = ntz;
+        output_poses[o7 + 3] = nqx;
+        output_poses[o7 + 4] = nqy;
+        output_poses[o7 + 5] = nqz;
+        output_poses[o7 + 6] = nqw;
     }
-    else
-    {
-        quat_slerp_pair_fwd_f(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &ox, &oy, &oz, &ow);
-    }
-    result_quat[o4 + 0] = ox;
-    result_quat[o4 + 1] = oy;
-    result_quat[o4 + 2] = oz;
-    result_quat[o4 + 3] = ow;
-    result_oob[i]       = oob ? 1.0f : 0.0f;
-}
-
-// VJP: grad_result_quat (N,4) → grad_rot0, grad_rot1; time grads via trajectory_alpha_time_grads_f on SLERP ∂L/∂α.
-__forceinline__ __device__ void trajectory_get_rotation_2poses_bwd_device(
-    int64_t i,
-    int64_t n,
-    int64_t st0,
-    int64_t st1,
-    int64_t sqt,
-    const float *__restrict__ time0,
-    const float *__restrict__ time1,
-    const float *__restrict__ query_time,
-    const float *__restrict__ rot0,
-    const float *__restrict__ rot1,
-    const float *__restrict__ grad_result_quat,
-    float *__restrict__ grad_rot0,
-    float *__restrict__ grad_rot1,
-    float *__restrict__ grad_time0,
-    float *__restrict__ grad_time1,
-    float *__restrict__ grad_query_time
-)
-{
-    const int64_t o4  = i * 4;
-    const float t0s   = time0[i * st0];
-    const float t1s   = time1[i * st1];
-    const float qt    = query_time[i * sqt];
-    const float t_min = fminf(t0s, t1s);
-    const float t_max = fmaxf(t0s, t1s);
-    const float d     = t_max - t_min;
-    const float alpha = d > 0.0f ? (qt - t_min) / d : 0.0f;
-
-    float qx0 = rot0[o4 + 0], qy0 = rot0[o4 + 1], qz0 = rot0[o4 + 2], qw0 = rot0[o4 + 3];
-    float qx1 = rot1[o4 + 0], qy1 = rot1[o4 + 1], qz1 = rot1[o4 + 2], qw1 = rot1[o4 + 3];
-
-    float qix, qiy, qiz, qiw;
-    if(t0s <= t1s)
-    {
-        quat_slerp_pair_fwd_f(qx0, qy0, qz0, qw0, qx1, qy1, qz1, qw1, alpha, &qix, &qiy, &qiz, &qiw);
-    }
-    else
-    {
-        quat_slerp_pair_fwd_f(qx1, qy1, qz1, qw1, qx0, qy0, qz0, qw0, alpha, &qix, &qiy, &qiz, &qiw);
-    }
-
-    const float gx = grad_result_quat[o4 + 0];
-    const float gy = grad_result_quat[o4 + 1];
-    const float gz = grad_result_quat[o4 + 2];
-    const float gw = grad_result_quat[o4 + 3];
-
-    float gq1x, gq1y, gq1z, gq1w, gq2x, gq2y, gq2z, gq2w, ga_slerp = 0.0f;
-    if(t0s <= t1s)
-    {
-        quat_slerp_pair_bwd_f(
-            qx0,
-            qy0,
-            qz0,
-            qw0,
-            qx1,
-            qy1,
-            qz1,
-            qw1,
-            alpha,
-            qix,
-            qiy,
-            qiz,
-            qiw,
-            gx,
-            gy,
-            gz,
-            gw,
-            &gq1x,
-            &gq1y,
-            &gq1z,
-            &gq1w,
-            &gq2x,
-            &gq2y,
-            &gq2z,
-            &gq2w,
-            &ga_slerp
-        );
-        grad_rot0[o4 + 0] = gq1x;
-        grad_rot0[o4 + 1] = gq1y;
-        grad_rot0[o4 + 2] = gq1z;
-        grad_rot0[o4 + 3] = gq1w;
-        grad_rot1[o4 + 0] = gq2x;
-        grad_rot1[o4 + 1] = gq2y;
-        grad_rot1[o4 + 2] = gq2z;
-        grad_rot1[o4 + 3] = gq2w;
-    }
-    else
-    {
-        quat_slerp_pair_bwd_f(
-            qx1,
-            qy1,
-            qz1,
-            qw1,
-            qx0,
-            qy0,
-            qz0,
-            qw0,
-            alpha,
-            qix,
-            qiy,
-            qiz,
-            qiw,
-            gx,
-            gy,
-            gz,
-            gw,
-            &gq1x,
-            &gq1y,
-            &gq1z,
-            &gq1w,
-            &gq2x,
-            &gq2y,
-            &gq2z,
-            &gq2w,
-            &ga_slerp
-        );
-        grad_rot1[o4 + 0] = gq1x;
-        grad_rot1[o4 + 1] = gq1y;
-        grad_rot1[o4 + 2] = gq1z;
-        grad_rot1[o4 + 3] = gq1w;
-        grad_rot0[o4 + 0] = gq2x;
-        grad_rot0[o4 + 1] = gq2y;
-        grad_rot0[o4 + 2] = gq2z;
-        grad_rot0[o4 + 3] = gq2w;
-    }
-
-    float g_t0 = 0.0f, g_t1 = 0.0f, g_qt = 0.0f;
-    trajectory_alpha_time_grads_f(t0s, t1s, qt, d, ga_slerp, &g_t0, &g_t1, &g_qt);
-    grad_time0[i * st0]      = g_t0;
-    grad_time1[i * st1]      = g_t1;
-    grad_query_time[i * sqt] = g_qt;
-}
-
-// -----------------------------------------------------------------------------
-// Single-keyframe trajectory (float32): OOB = (query_time != keyframe time), transform still applied.
-// -----------------------------------------------------------------------------
-
-// Row i: result = R(rot_i) point_i + trans_i; result_oob[i]=1 if query_time[i*sqt] != time[i*st] (exact float compare).
-__forceinline__ __device__ void trajectory_transform_point_1pose_fwd_device(
-    int64_t i,
-    int64_t n,
-    int64_t st,
-    int64_t sqt,
-    const float *__restrict__ trans,
-    const float *__restrict__ rot,
-    const float *__restrict__ time,
-    const float *__restrict__ point,
-    const float *__restrict__ query_time,
-    float *__restrict__ result_point,
-    float *__restrict__ result_oob
-)
-{
-    const int64_t o3 = i * 3;
-    const int64_t o4 = i * 4;
-    const float tt   = time[i * st];
-    const float qt   = query_time[i * sqt];
-    const bool oob   = (qt != tt);
-
-    const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
-    const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-    const float tx = trans[o3 + 0], ty = trans[o3 + 1], tz = trans[o3 + 2];
-    float rx = 0, ry = 0, rz = 0;
-    quat_rotate_vector_fwd_impl<float>(qx, qy, qz, qw, px, py, pz, &rx, &ry, &rz);
-    result_point[o3 + 0] = rx + tx;
-    result_point[o3 + 1] = ry + ty;
-    result_point[o3 + 2] = rz + tz;
-    result_oob[i]        = oob ? 1.0f : 0.0f;
-}
-
-// VJP: grad_result_point → grad_trans, grad_rot (xyzw), grad_point; grad_time/grad_query_time not populated by device body (kernel may ignore).
-__forceinline__ __device__ void trajectory_transform_point_1pose_bwd_device(
-    int64_t i,
-    int64_t n,
-    const float *__restrict__ trans,
-    const float *__restrict__ rot,
-    const float *__restrict__ time,
-    const float *__restrict__ point,
-    const float *__restrict__ query_time,
-    const float *__restrict__ grad_result_point,
-    float *__restrict__ grad_trans,
-    float *__restrict__ grad_rot,
-    float *__restrict__ grad_time,
-    float *__restrict__ grad_point,
-    float *__restrict__ grad_query_time
-)
-{
-    const int64_t o3 = i * 3;
-    const int64_t o4 = i * 4;
-    const float qx = rot[o4 + 0], qy = rot[o4 + 1], qz = rot[o4 + 2], qw = rot[o4 + 3];
-    const float px = point[o3 + 0], py = point[o3 + 1], pz = point[o3 + 2];
-
-    const float gtx = grad_result_point[o3 + 0];
-    const float gty = grad_result_point[o3 + 1];
-    const float gtz = grad_result_point[o3 + 2];
-
-    float gqix, gqiy, gqiz, gqiw;
-    float gpx, gpy, gpz;
-    quat_rotate_vector_bwd_impl<float>(
-        qx, qy, qz, qw, px, py, pz, gtx, gty, gtz, &gqix, &gqiy, &gqiz, &gqiw, &gpx, &gpy, &gpz
-    );
-
-    grad_trans[o3 + 0] = gtx;
-    grad_trans[o3 + 1] = gty;
-    grad_trans[o3 + 2] = gtz;
-    grad_rot[o4 + 0]   = gqix;
-    grad_rot[o4 + 1]   = gqiy;
-    grad_rot[o4 + 2]   = gqiz;
-    grad_rot[o4 + 3]   = gqiw;
-    grad_point[o3 + 0] = gpx;
-    grad_point[o3 + 1] = gpy;
-    grad_point[o3 + 2] = gpz;
-}
-
-// Row i: 7-D pose (tx,ty,tz, qx,qy,qz,qw) → new_q = fr⊗iq, new_t = scale * (R(fr)*it + fxyz); frame quat fr is xyzw.
-__forceinline__ __device__ void frame_transform_poses_tquat_fwd_device(
-    int64_t i,
-    int64_t n,
-    float frx,
-    float fry,
-    float frz,
-    float frw,
-    float ftx,
-    float fty,
-    float ftz,
-    float scale,
-    const float *__restrict__ input_poses,
-    float *__restrict__ output_poses
-)
-{
-    const int64_t o7 = i * 7;
-    const float itx = input_poses[o7 + 0], ity = input_poses[o7 + 1], itz = input_poses[o7 + 2];
-    const float iqx = input_poses[o7 + 3], iqy = input_poses[o7 + 4], iqz = input_poses[o7 + 5],
-                iqw = input_poses[o7 + 6];
-    float nqx = 0, nqy = 0, nqz = 0, nqw = 0;
-    quat_multiply_impl<float>(frx, fry, frz, frw, iqx, iqy, iqz, iqw, &nqx, &nqy, &nqz, &nqw);
-    float rtx = 0, rty = 0, rtz = 0;
-    quat_rotate_vector_fwd_impl<float>(frx, fry, frz, frw, itx, ity, itz, &rtx, &rty, &rtz);
-    const float ntx      = scale * (rtx + ftx);
-    const float nty      = scale * (rty + fty);
-    const float ntz      = scale * (rtz + ftz);
-    output_poses[o7 + 0] = ntx;
-    output_poses[o7 + 1] = nty;
-    output_poses[o7 + 2] = ntz;
-    output_poses[o7 + 3] = nqx;
-    output_poses[o7 + 4] = nqy;
-    output_poses[o7 + 5] = nqz;
-    output_poses[o7 + 6] = nqw;
-}
 } // namespace trajectory_cuda
 
 namespace packed_track_cuda
 {
-template<typename scalar_t>
-__forceinline__ __device__ void atomic_add(scalar_t *__restrict__ address, scalar_t value)
-{
-    atomicAdd(address, value);
-}
-
-template<typename time_t>
-__forceinline__ __device__ time_t clamp_time(time_t value, time_t first, time_t last)
-{
-    return value < first ? first : (value > last ? last : value);
-}
-
-template<typename time_t>
-__forceinline__ __device__ int64_t
-    lower_bound_local(const time_t *__restrict__ times, int64_t start, int64_t count, time_t query)
-{
-    int64_t lo = 0;
-    int64_t hi = count;
-    while(lo < hi)
+    template<typename scalar_t>
+    __forceinline__ __device__ void atomic_add(scalar_t *__restrict__ address, scalar_t value)
     {
-        const int64_t mid = lo + ((hi - lo) >> 1);
-        if(times[start + mid] < query)
+        atomicAdd(address, value);
+    }
+
+    template<typename time_t>
+    __forceinline__ __device__ time_t clamp_time(time_t value, time_t first, time_t last)
+    {
+        return value < first ? first : (value > last ? last : value);
+    }
+
+    template<typename time_t>
+    __forceinline__ __device__ int64_t
+        lower_bound_local(const time_t *__restrict__ times, int64_t start, int64_t count, time_t query)
+    {
+        int64_t lo = 0;
+        int64_t hi = count;
+        while(lo < hi)
         {
-            lo = mid + 1;
+            const int64_t mid = lo + ((hi - lo) >> 1);
+            if(times[start + mid] < query)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
         }
-        else
+        return lo;
+    }
+
+    template<typename scalar_t, typename time_t>
+    __forceinline__ __device__ scalar_t interpolation_alpha(time_t left, time_t right, time_t query, bool valid)
+    {
+        if(!valid)
         {
-            hi = mid;
+            return scalar_t(0);
+        }
+        return static_cast<scalar_t>((query - left) / (right - left));
+    }
+
+    template<typename scalar_t>
+    __forceinline__ __device__ scalar_t interpolation_alpha(int64_t left, int64_t right, int64_t query, bool valid)
+    {
+        if(!valid)
+        {
+            return scalar_t(0);
+        }
+        const bool numerator_fits = !((left > 0 && query < INT64_MIN + left) || (left < 0 && query > INT64_MAX + left));
+        const bool denominator_fits
+            = !((left > 0 && right < INT64_MIN + left) || (left < 0 && right > INT64_MAX + left));
+        const double numerator   = numerator_fits ? static_cast<double>(query - left)
+                                                  : static_cast<double>(query) - static_cast<double>(left);
+        const double denominator = denominator_fits ? static_cast<double>(right - left)
+                                                    : static_cast<double>(right) - static_cast<double>(left);
+        return denominator != 0.0 ? static_cast<scalar_t>(numerator / denominator) : scalar_t(0);
+    }
+
+    __forceinline__ __device__ bool valid_track_range(int64_t start, int64_t count, int64_t n_poses)
+    {
+        return start >= 0 && count > 0 && start <= n_poses && count <= n_poses - start;
+    }
+
+    template<typename scalar_t, typename time_t>
+    __forceinline__ __device__ void accumulate_interpolation_time_grads(
+        time_t left_time,
+        time_t right_time,
+        time_t clamped_query,
+        bool valid,
+        int64_t left,
+        int64_t right,
+        int64_t track,
+        scalar_t grad_alpha,
+        time_t *__restrict__ grad_pose_times,
+        time_t *__restrict__ grad_query_times
+    )
+    {
+        const time_t d = right_time - left_time;
+        if(valid && d != time_t(0))
+        {
+            const time_t grad_alpha_t = static_cast<time_t>(grad_alpha);
+            const time_t d2           = d * d;
+            atomic_add(grad_pose_times + left, grad_alpha_t * (clamped_query - right_time) / d2);
+            atomic_add(grad_pose_times + right, -grad_alpha_t * (clamped_query - left_time) / d2);
+            grad_query_times[track] = grad_alpha_t / d;
         }
     }
-    return lo;
-}
 
-template<typename scalar_t, typename time_t>
-__forceinline__ __device__ scalar_t interpolation_alpha(time_t left, time_t right, time_t query, bool valid)
-{
-    if(!valid)
+    template<typename scalar_t>
+    __forceinline__ __device__ void accumulate_interpolation_time_grads(
+        int64_t,
+        int64_t,
+        int64_t,
+        bool,
+        int64_t,
+        int64_t,
+        int64_t,
+        scalar_t,
+        int64_t *__restrict__,
+        int64_t *__restrict__
+    )
     {
-        return scalar_t(0);
-    }
-    return static_cast<scalar_t>((query - left) / (right - left));
-}
-
-template<typename scalar_t>
-__forceinline__ __device__ scalar_t interpolation_alpha(int64_t left, int64_t right, int64_t query, bool valid)
-{
-    if(!valid)
-    {
-        return scalar_t(0);
-    }
-    const bool numerator_fits   = !((left > 0 && query < INT64_MIN + left) || (left < 0 && query > INT64_MAX + left));
-    const bool denominator_fits = !((left > 0 && right < INT64_MIN + left) || (left < 0 && right > INT64_MAX + left));
-    const double numerator
-        = numerator_fits ? static_cast<double>(query - left) : static_cast<double>(query) - static_cast<double>(left);
-    const double denominator
-        = denominator_fits ? static_cast<double>(right - left) : static_cast<double>(right) - static_cast<double>(left);
-    return denominator != 0.0 ? static_cast<scalar_t>(numerator / denominator) : scalar_t(0);
-}
-
-__forceinline__ __device__ bool valid_track_range(int64_t start, int64_t count, int64_t n_poses)
-{
-    return start >= 0 && count > 0 && start <= n_poses && count <= n_poses - start;
-}
-
-template<typename scalar_t, typename time_t>
-__forceinline__ __device__ void accumulate_interpolation_time_grads(
-    time_t left_time,
-    time_t right_time,
-    time_t clamped_query,
-    bool valid,
-    int64_t left,
-    int64_t right,
-    int64_t track,
-    scalar_t grad_alpha,
-    time_t *__restrict__ grad_pose_times,
-    time_t *__restrict__ grad_query_times
-)
-{
-    const time_t d = right_time - left_time;
-    if(valid && d != time_t(0))
-    {
-        const time_t grad_alpha_t = static_cast<time_t>(grad_alpha);
-        const time_t d2           = d * d;
-        atomic_add(grad_pose_times + left, grad_alpha_t * (clamped_query - right_time) / d2);
-        atomic_add(grad_pose_times + right, -grad_alpha_t * (clamped_query - left_time) / d2);
-        grad_query_times[track] = grad_alpha_t / d;
-    }
-}
-
-template<typename scalar_t>
-__forceinline__ __device__ void accumulate_interpolation_time_grads(
-    int64_t, int64_t, int64_t, bool, int64_t, int64_t, int64_t, scalar_t, int64_t *__restrict__, int64_t *__restrict__
-)
-{
-}
-
-template<typename time_t>
-__forceinline__ __device__ void track_interval(
-    const time_t *__restrict__ times,
-    int64_t start,
-    int64_t count,
-    time_t query,
-    int64_t *left_index,
-    int64_t *right_index,
-    bool *same_pose,
-    bool *valid_interval,
-    time_t *clamped_query,
-    time_t *left_time,
-    time_t *right_time
-)
-{
-    const time_t first_time  = times[start];
-    const time_t last_time   = times[start + count - 1];
-    const time_t clamped     = clamp_time(query, first_time, last_time);
-    int64_t right_local      = lower_bound_local(times, start, count, clamped);
-    const int64_t last_local = count - 1;
-    if(query <= first_time)
-    {
-        right_local = 0;
-    }
-    else if(query > last_time)
-    {
-        right_local = last_local;
-    }
-    else if(right_local > last_local)
-    {
-        right_local = last_local;
     }
 
-    const int64_t right       = start + right_local;
-    const time_t rt           = times[right];
-    const bool exact_or_first = right_local == 0 || rt == clamped;
-    const int64_t left_local  = exact_or_first ? right_local : right_local - 1;
-    const int64_t left        = start + left_local;
-    const time_t lt           = times[left];
-    const bool same           = left == right;
-    *left_index               = left;
-    *right_index              = right;
-    *same_pose                = same;
-    *valid_interval           = !same && rt != lt;
-    *clamped_query            = clamped;
-    *left_time                = lt;
-    *right_time               = rt;
-}
+    template<typename time_t>
+    __forceinline__ __device__ void track_interval(
+        const time_t *__restrict__ times,
+        int64_t start,
+        int64_t count,
+        time_t query,
+        int64_t *left_index,
+        int64_t *right_index,
+        bool *same_pose,
+        bool *valid_interval,
+        time_t *clamped_query,
+        time_t *left_time,
+        time_t *right_time
+    )
+    {
+        const time_t first_time  = times[start];
+        const time_t last_time   = times[start + count - 1];
+        const time_t clamped     = clamp_time(query, first_time, last_time);
+        int64_t right_local      = lower_bound_local(times, start, count, clamped);
+        const int64_t last_local = count - 1;
+        if(query <= first_time)
+        {
+            right_local = 0;
+        }
+        else if(query > last_time)
+        {
+            right_local = last_local;
+        }
+        else if(right_local > last_local)
+        {
+            right_local = last_local;
+        }
+
+        const int64_t right       = start + right_local;
+        const time_t rt           = times[right];
+        const bool exact_or_first = right_local == 0 || rt == clamped;
+        const int64_t left_local  = exact_or_first ? right_local : right_local - 1;
+        const int64_t left        = start + left_local;
+        const time_t lt           = times[left];
+        const bool same           = left == right;
+        *left_index               = left;
+        *right_index              = right;
+        *same_pose                = same;
+        *valid_interval           = !same && rt != lt;
+        *clamped_query            = clamped;
+        *left_time                = lt;
+        *right_time               = rt;
+    }
 } // namespace packed_track_cuda
 
 // Batch row i: out = R(q_i) p_i + t_i. translation/point (N,3), rotation (N,4) xyzw, contiguous row-major.
@@ -1235,6 +1232,267 @@ __device__ __forceinline__ void se3_inverse_transform_point(
     quat_rotate_vector_fwd_impl<T>(-qx, -qy, -qz, qw, px - tx, py - ty, pz - tz, ox, oy, oz);
 }
 
+template<typename T>
+__device__ __forceinline__ void quat_slerp_pair_fwd(
+    T x1, T y1, T z1, T w1, T x2, T y2, T z2, T w2, T ti, T *ox, T *oy, T *oz, T *ow
+)
+{
+    const T dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
+    const T s   = dot < T(0) ? T(-1) : T(1);
+    const T sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
+    const T c_raw    = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
+    const T c        = quat_slerp_clamp_dot<T>(c_raw);
+    const T small_th = quat_slerp_small_angle_dot_threshold<T>();
+
+    if(c > small_th)
+    {
+        const T om      = T(1) - ti;
+        const T rx      = om * x1 + ti * sx;
+        const T ry      = om * y1 + ti * sy;
+        const T rz      = om * z1 + ti * sz;
+        const T rw      = om * w1 + ti * sw;
+        const T norm_sq = rx * rx + ry * ry + rz * rz + rw * rw;
+        const T inv_n   = T(1) / sqrt(norm_sq);
+        *ox             = rx * inv_n;
+        *oy             = ry * inv_n;
+        *oz             = rz * inv_n;
+        *ow             = rw * inv_n;
+        return;
+    }
+
+    const T theta     = acos(c);
+    const T sin_theta = sin(theta);
+    const T w1s       = sin((T(1) - ti) * theta) / sin_theta;
+    const T w2s       = sin(ti * theta) / sin_theta;
+    *ox               = w1s * x1 + w2s * sx;
+    *oy               = w1s * y1 + w2s * sy;
+    *oz               = w1s * z1 + w2s * sz;
+    *ow               = w1s * w1 + w2s * sw;
+}
+
+// Shared VJP body; EmitGradT removes dL/dti work from no-time-grad callers.
+template<typename T, bool EmitGradT>
+__device__ __forceinline__ void quat_slerp_pair_bwd_impl(
+    T x1,
+    T y1,
+    T z1,
+    T w1,
+    T x2,
+    T y2,
+    T z2,
+    T w2,
+    T ti,
+    T rx,
+    T ry,
+    T rz,
+    T rw,
+    T gx,
+    T gy,
+    T gz,
+    T gw,
+    T *gq1x,
+    T *gq1y,
+    T *gq1z,
+    T *gq1w,
+    T *gq2x,
+    T *gq2y,
+    T *gq2z,
+    T *gq2w,
+    T *grad_t
+)
+{
+    const T dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
+    const T s   = dot < T(0) ? T(-1) : T(1);
+    const T sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
+    const T c_raw         = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
+    const T c             = quat_slerp_clamp_dot<T>(c_raw);
+    const bool interior_c = (c_raw > T(-1)) && (c_raw < T(1));
+    const T c_mask        = interior_c ? T(1) : T(0);
+    const T small_th      = quat_slerp_small_angle_dot_threshold<T>();
+
+    if(c > small_th)
+    {
+        const T om      = T(1) - ti;
+        const T rrx     = om * x1 + ti * sx;
+        const T rry     = om * y1 + ti * sy;
+        const T rrz     = om * z1 + ti * sz;
+        const T rrw     = om * w1 + ti * sw;
+        const T norm_sq = rrx * rrx + rry * rry + rrz * rrz + rrw * rrw;
+        const T r_norm  = sqrt(norm_sq);
+        const T yx = rx, yy = ry, yz = rz, yw = rw;
+        const T ydotg = yx * gx + yy * gy + yz * gz + yw * gw;
+        const T scale = T(1) / r_norm;
+        const T grx   = (gx - yx * ydotg) * scale;
+        const T gry   = (gy - yy * ydotg) * scale;
+        const T grz   = (gz - yz * ydotg) * scale;
+        const T grw   = (gw - yw * ydotg) * scale;
+        *gq1x         = om * grx;
+        *gq1y         = om * gry;
+        *gq1z         = om * grz;
+        *gq1w         = om * grw;
+        *gq2x         = s * ti * grx;
+        *gq2y         = s * ti * gry;
+        *gq2z         = s * ti * grz;
+        *gq2w         = s * ti * grw;
+        if constexpr(EmitGradT)
+        {
+            const T dq2m_dq1x = sx - x1, dq2m_dq1y = sy - y1, dq2m_dq1z = sz - z1, dq2m_dq1w = sw - w1;
+            *grad_t = grx * dq2m_dq1x + gry * dq2m_dq1y + grz * dq2m_dq1z + grw * dq2m_dq1w;
+        }
+        return;
+    }
+
+    const T theta      = acos(c);
+    const T sin_theta  = sin(theta);
+    const T w1s        = sin((T(1) - ti) * theta) / sin_theta;
+    const T w2s        = sin(ti * theta) / sin_theta;
+    const T G1         = gx * x1 + gy * y1 + gz * z1 + gw * w1;
+    const T G2         = gx * sx + gy * sy + gz * sz + gw * sw;
+    const T den        = sin_theta * sin_theta;
+    const T dw1_dtheta = ((T(1) - ti) * cos((T(1) - ti) * theta) * sin_theta - sin((T(1) - ti) * theta) * c) / den;
+    const T dw2_dtheta = (ti * cos(ti * theta) * sin_theta - sin(ti * theta) * c) / den;
+    const T dw1_dc     = sin_theta > T(1e-20) ? (-dw1_dtheta / sin_theta) * c_mask : T(0);
+    const T dw2_dc     = sin_theta > T(1e-20) ? (-dw2_dtheta / sin_theta) * c_mask : T(0);
+    const T K          = G1 * dw1_dc + G2 * dw2_dc;
+    *gq1x              = w1s * gx + K * sx;
+    *gq1y              = w1s * gy + K * sy;
+    *gq1z              = w1s * gz + K * sz;
+    *gq1w              = w1s * gw + K * sw;
+    const T gq2ex      = w2s * gx + K * x1;
+    const T gq2ey      = w2s * gy + K * y1;
+    const T gq2ez      = w2s * gz + K * z1;
+    const T gq2ew      = w2s * gw + K * w1;
+    *gq2x              = s * gq2ex;
+    *gq2y              = s * gq2ey;
+    *gq2z              = s * gq2ez;
+    *gq2w              = s * gq2ew;
+    if constexpr(EmitGradT)
+    {
+        const T dw1_dt = -theta * cos((T(1) - ti) * theta) / sin_theta;
+        const T dw2_dt = theta * cos(ti * theta) / sin_theta;
+        *grad_t        = G1 * dw1_dt + G2 * dw2_dt;
+    }
+}
+
+template<typename T>
+__device__ __forceinline__ void quat_slerp_pair_bwd_no_time_grad(
+    T x1,
+    T y1,
+    T z1,
+    T w1,
+    T x2,
+    T y2,
+    T z2,
+    T w2,
+    T ti,
+    T rx,
+    T ry,
+    T rz,
+    T rw,
+    T gx,
+    T gy,
+    T gz,
+    T gw,
+    T *gq1x,
+    T *gq1y,
+    T *gq1z,
+    T *gq1w,
+    T *gq2x,
+    T *gq2y,
+    T *gq2z,
+    T *gq2w
+)
+{
+    quat_slerp_pair_bwd_impl<T, false>(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        ti,
+        rx,
+        ry,
+        rz,
+        rw,
+        gx,
+        gy,
+        gz,
+        gw,
+        gq1x,
+        gq1y,
+        gq1z,
+        gq1w,
+        gq2x,
+        gq2y,
+        gq2z,
+        gq2w,
+        nullptr
+    );
+}
+
+template<typename T>
+__device__ __forceinline__ void quat_slerp_pair_bwd_with_time_grad(
+    T x1,
+    T y1,
+    T z1,
+    T w1,
+    T x2,
+    T y2,
+    T z2,
+    T w2,
+    T ti,
+    T rx,
+    T ry,
+    T rz,
+    T rw,
+    T gx,
+    T gy,
+    T gz,
+    T gw,
+    T *gq1x,
+    T *gq1y,
+    T *gq1z,
+    T *gq1w,
+    T *gq2x,
+    T *gq2y,
+    T *gq2z,
+    T *gq2w,
+    T *grad_t
+)
+{
+    quat_slerp_pair_bwd_impl<T, true>(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        ti,
+        rx,
+        ry,
+        rz,
+        rw,
+        gx,
+        gy,
+        gz,
+        gw,
+        gq1x,
+        gq1y,
+        gq1z,
+        gq1w,
+        gq2x,
+        gq2y,
+        gq2z,
+        gq2w,
+        grad_t
+    );
+}
+
 // Batch row i: out = R(q)^T d (same conjugate trick as inverse point, without translation).
 template<typename scalar_t>
 __device__ void se3pose_inverse_transform_direction_fwd_device(
@@ -1423,3 +1681,4 @@ __device__ void se3pose_from_matrix_bwd_device(
     grad_m16[o + 9]  += gR[7];
     grad_m16[o + 10] += gR[8];
 }
+} // namespace gsplat_geometry

--- a/gsplat/geometry/kernels/cuda/csrc/quaternion.cu
+++ b/gsplat/geometry/kernels/cuda/csrc/quaternion.cu
@@ -113,7 +113,7 @@ void launch_quat_multiply_bwd(
 void quat_multiply_cuda(const at::Tensor &q1, const at::Tensor &q2, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        q1.scalar_type(), "quat_multiply_cuda", [&] { launch_quat_multiply_fwd<scalar_t>(q1, q2, out); }
+        q1.scalar_type(), "quat_multiply_cuda", ([&] { launch_quat_multiply_fwd<scalar_t>(q1, q2, out); })
     );
 }
 
@@ -127,7 +127,7 @@ void quat_multiply_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         q1.scalar_type(),
         "quat_multiply_bwd_cuda",
-        [&] { launch_quat_multiply_bwd<scalar_t>(q1, q2, grad_out, grad_q1, grad_q2); }
+        ([&] { launch_quat_multiply_bwd<scalar_t>(q1, q2, grad_out, grad_q1, grad_q2); })
     );
 }
 
@@ -225,7 +225,9 @@ void launch_quat_rotate_vector_bwd(
 void quat_rotate_vector_cuda(const at::Tensor &quat, const at::Tensor &vec, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        quat.scalar_type(), "quat_rotate_vector_cuda", [&] { launch_quat_rotate_vector_fwd<scalar_t>(quat, vec, out); }
+        quat.scalar_type(),
+        "quat_rotate_vector_cuda",
+        ([&] { launch_quat_rotate_vector_fwd<scalar_t>(quat, vec, out); })
     );
 }
 
@@ -243,7 +245,7 @@ void quat_rotate_vector_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         quat.scalar_type(),
         "quat_rotate_vector_bwd_cuda",
-        [&] { launch_quat_rotate_vector_bwd<scalar_t>(quat, vec, grad_out, grad_quat, grad_vec); }
+        ([&] { launch_quat_rotate_vector_bwd<scalar_t>(quat, vec, grad_out, grad_quat, grad_vec); })
     );
 }
 
@@ -321,7 +323,7 @@ void launch_quat_to_matrix_bwd(const at::Tensor &quat, const at::Tensor &grad_fl
 void quat_to_matrix_cuda(const at::Tensor &quat, at::Tensor &out_flat)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        quat.scalar_type(), "quat_to_matrix_cuda", [&] { launch_quat_to_matrix_fwd<scalar_t>(quat, out_flat); }
+        quat.scalar_type(), "quat_to_matrix_cuda", ([&] { launch_quat_to_matrix_fwd<scalar_t>(quat, out_flat); })
     );
 }
 
@@ -333,7 +335,7 @@ void quat_to_matrix_bwd_cuda(const at::Tensor &quat, const at::Tensor &grad_matr
     AT_DISPATCH_FLOATING_TYPES(
         quat.scalar_type(),
         "quat_to_matrix_bwd_cuda",
-        [&] { launch_quat_to_matrix_bwd<scalar_t>(quat, grad_matrix_flat, grad_quat); }
+        ([&] { launch_quat_to_matrix_bwd<scalar_t>(quat, grad_matrix_flat, grad_quat); })
     );
 }
 
@@ -415,7 +417,7 @@ void launch_quat_normalize_safe_bwd(const at::Tensor &quat, const at::Tensor &gr
 void quat_normalize_safe_cuda(const at::Tensor &quat, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        quat.scalar_type(), "quat_normalize_safe_cuda", [&] { launch_quat_normalize_safe_fwd<scalar_t>(quat, out); }
+        quat.scalar_type(), "quat_normalize_safe_cuda", ([&] { launch_quat_normalize_safe_fwd<scalar_t>(quat, out); })
     );
 }
 
@@ -427,7 +429,7 @@ void quat_normalize_safe_bwd_cuda(const at::Tensor &quat, const at::Tensor &grad
     AT_DISPATCH_FLOATING_TYPES(
         quat.scalar_type(),
         "quat_normalize_safe_bwd_cuda",
-        [&] { launch_quat_normalize_safe_bwd<scalar_t>(quat, grad_out, grad_quat); }
+        ([&] { launch_quat_normalize_safe_bwd<scalar_t>(quat, grad_out, grad_quat); })
     );
 }
 
@@ -505,7 +507,7 @@ void launch_quat_conjugate_bwd(const at::Tensor &grad_out, at::Tensor &grad_quat
 void quat_conjugate_cuda(const at::Tensor &quat, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        quat.scalar_type(), "quat_conjugate_cuda", [&] { launch_quat_conjugate_fwd<scalar_t>(quat, out); }
+        quat.scalar_type(), "quat_conjugate_cuda", ([&] { launch_quat_conjugate_fwd<scalar_t>(quat, out); })
     );
 }
 
@@ -515,7 +517,9 @@ void quat_conjugate_cuda(const at::Tensor &quat, at::Tensor &out)
 void quat_conjugate_bwd_cuda(const at::Tensor &quat, const at::Tensor &grad_out, at::Tensor &grad_quat)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        quat.scalar_type(), "quat_conjugate_bwd_cuda", [&] { launch_quat_conjugate_bwd<scalar_t>(grad_out, grad_quat); }
+        quat.scalar_type(),
+        "quat_conjugate_bwd_cuda",
+        ([&] { launch_quat_conjugate_bwd<scalar_t>(grad_out, grad_quat); })
     );
 }
 
@@ -616,7 +620,7 @@ void quat_from_axis_angle_cuda(const at::Tensor &axis, const at::Tensor &angle, 
     AT_DISPATCH_FLOATING_TYPES(
         axis.scalar_type(),
         "quat_from_axis_angle_cuda",
-        [&] { launch_quat_from_axis_angle_fwd<scalar_t>(axis, angle, quat); }
+        ([&] { launch_quat_from_axis_angle_fwd<scalar_t>(axis, angle, quat); })
     );
 }
 
@@ -634,7 +638,7 @@ void quat_from_axis_angle_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         axis.scalar_type(),
         "quat_from_axis_angle_bwd_cuda",
-        [&] { launch_quat_from_axis_angle_bwd<scalar_t>(axis, angle, grad_quat, grad_axis, grad_angle); }
+        ([&] { launch_quat_from_axis_angle_bwd<scalar_t>(axis, angle, grad_quat, grad_axis, grad_angle); })
     );
 }
 
@@ -740,7 +744,7 @@ void launch_quat_lerp_bwd(
 void quat_lerp_cuda(const at::Tensor &q1, const at::Tensor &q2, double t, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        q1.scalar_type(), "quat_lerp_cuda", [&] { launch_quat_lerp_fwd<scalar_t>(q1, q2, t, out); }
+        q1.scalar_type(), "quat_lerp_cuda", ([&] { launch_quat_lerp_fwd<scalar_t>(q1, q2, t, out); })
     );
 }
 
@@ -760,7 +764,7 @@ void quat_lerp_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         q1.scalar_type(),
         "quat_lerp_bwd_cuda",
-        [&] { launch_quat_lerp_bwd<scalar_t>(q1, q2, result, grad_out, t, grad_q1, grad_q2); }
+        ([&] { launch_quat_lerp_bwd<scalar_t>(q1, q2, result, grad_out, t, grad_q1, grad_q2); })
     );
 }
 
@@ -864,10 +868,16 @@ void launch_quat_slerp_batched_bwd(
 // Public CUDA entrypoint for batched SLERP.
 // Inputs: q1 (N,4), q2 (N,4), and per-row interpolation parameters t.
 // Output: out (N,4) with one SLERP result per row.
+// Host accessor for the SLERP small-angle dot threshold, bound to Python in ext.cpp.
+double slerp_small_angle_dot_threshold()
+{
+    return gsplat_geometry::kSlerpSmallAngleDotThreshold;
+}
+
 void quat_slerp_batched_cuda(const at::Tensor &q1, const at::Tensor &q2, const at::Tensor &t, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        q1.scalar_type(), "quat_slerp_batched_cuda", [&] { launch_quat_slerp_batched_fwd<scalar_t>(q1, q2, t, out); }
+        q1.scalar_type(), "quat_slerp_batched_cuda", ([&] { launch_quat_slerp_batched_fwd<scalar_t>(q1, q2, t, out); })
     );
 }
 
@@ -888,7 +898,7 @@ void quat_slerp_batched_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         q1.scalar_type(),
         "quat_slerp_batched_bwd_cuda",
-        [&] { launch_quat_slerp_batched_bwd<scalar_t>(q1, q2, t, result, grad_out, grad_q1, grad_q2, grad_t); }
+        ([&] { launch_quat_slerp_batched_bwd<scalar_t>(q1, q2, t, result, grad_out, grad_q1, grad_q2, grad_t); })
     );
 }
 
@@ -977,7 +987,9 @@ void launch_quat_angular_distance_bwd(
 void quat_angular_distance_cuda(const at::Tensor &q1, const at::Tensor &q2, at::Tensor &out)
 {
     AT_DISPATCH_FLOATING_TYPES(
-        q1.scalar_type(), "quat_angular_distance_cuda", [&] { launch_quat_angular_distance_fwd<scalar_t>(q1, q2, out); }
+        q1.scalar_type(),
+        "quat_angular_distance_cuda",
+        ([&] { launch_quat_angular_distance_fwd<scalar_t>(q1, q2, out); })
     );
 }
 
@@ -991,7 +1003,7 @@ void quat_angular_distance_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         q1.scalar_type(),
         "quat_angular_distance_bwd_cuda",
-        [&] { launch_quat_angular_distance_bwd<scalar_t>(q1, q2, grad_dist, grad_q1, grad_q2); }
+        ([&] { launch_quat_angular_distance_bwd<scalar_t>(q1, q2, grad_dist, grad_q1, grad_q2); })
     );
 }
 
@@ -1105,7 +1117,7 @@ void quat_manifold_interp_cuda(const at::Tensor &q1, const at::Tensor &q2, const
     AT_DISPATCH_FLOATING_TYPES(
         q1.scalar_type(),
         "quat_manifold_interp_cuda",
-        [&] { launch_quat_manifold_interp_fwd<scalar_t>(q1, q2, t, out); }
+        ([&] { launch_quat_manifold_interp_fwd<scalar_t>(q1, q2, t, out); })
     );
 }
 
@@ -1125,6 +1137,6 @@ void quat_manifold_interp_bwd_cuda(
     AT_DISPATCH_FLOATING_TYPES(
         q1.scalar_type(),
         "quat_manifold_interp_bwd_cuda",
-        [&] { launch_quat_manifold_interp_bwd<scalar_t>(q1, q2, t, grad_out, grad_q1, grad_q2, grad_t); }
+        ([&] { launch_quat_manifold_interp_bwd<scalar_t>(q1, q2, t, grad_out, grad_q1, grad_q2, grad_t); })
     );
 }

--- a/gsplat/geometry/kernels/cuda/csrc/quaternion.cu
+++ b/gsplat/geometry/kernels/cuda/csrc/quaternion.cu
@@ -38,7 +38,7 @@ __global__ void quat_multiply_fwd_kernel(
     {
         return;
     }
-    quat_multiply_fwd_device(i, n, q1, q2, out);
+    gsplat_geometry::quat_multiply_fwd_device(i, n, q1, q2, out);
 }
 
 // Grid-stride: VJP for Hamilton product; grad_out layout matches q1/q2 (4 per row).
@@ -57,7 +57,7 @@ __global__ void quat_multiply_bwd_kernel(
     {
         return;
     }
-    quat_multiply_bwd_device(i, n, q1, q2, grad_out, grad_q1, grad_q2);
+    gsplat_geometry::quat_multiply_bwd_device(i, n, q1, q2, grad_out, grad_q1, grad_q2);
 }
 
 // Launch batched Hamilton products on the current CUDA stream.
@@ -146,7 +146,7 @@ __global__ void quat_rotate_vector_fwd_kernel(
     {
         return;
     }
-    quat_rotate_vector_fwd_device(i, n, quat, vec, out);
+    gsplat_geometry::quat_rotate_vector_fwd_device(i, n, quat, vec, out);
 }
 
 // Grid-stride: grad_out (N,3) → grad_quat (N,4), grad_vec (N,3) per row.
@@ -165,7 +165,7 @@ __global__ void quat_rotate_vector_bwd_kernel(
     {
         return;
     }
-    quat_rotate_vector_bwd_device(i, n, quat, vec, grad_out, grad_quat, grad_vec);
+    gsplat_geometry::quat_rotate_vector_bwd_device(i, n, quat, vec, grad_out, grad_quat, grad_vec);
 }
 
 // Launch quaternion-vector rotation on the current CUDA stream.
@@ -256,7 +256,7 @@ __global__ void quat_to_matrix_fwd_kernel(int64_t n, const scalar_t *__restrict_
     {
         return;
     }
-    quat_to_matrix_fwd_device(i, n, quat, out_flat);
+    gsplat_geometry::quat_to_matrix_fwd_device(i, n, quat, out_flat);
 }
 
 // Grid-stride: grad_flat (N*9) ∂L/∂R row-major → grad_quat (N,4).
@@ -273,7 +273,7 @@ __global__ void quat_to_matrix_bwd_kernel(
     {
         return;
     }
-    quat_to_matrix_bwd_device(i, n, quat, grad_flat, grad_quat);
+    gsplat_geometry::quat_to_matrix_bwd_device(i, n, quat, grad_flat, grad_quat);
 }
 
 // Launch quaternion -> matrix conversion on the current CUDA stream.
@@ -350,7 +350,7 @@ __global__ void quat_normalize_safe_fwd_kernel(int64_t n, const scalar_t *__rest
     {
         return;
     }
-    quat_normalize_safe_fwd_device(i, n, quat, out);
+    gsplat_geometry::quat_normalize_safe_fwd_device(i, n, quat, out);
 }
 
 // Grid-stride: VJP through safe normalize (grad_out → grad_quat).
@@ -367,7 +367,7 @@ __global__ void quat_normalize_safe_bwd_kernel(
     {
         return;
     }
-    quat_normalize_safe_bwd_device(i, n, quat, grad_out, grad_quat);
+    gsplat_geometry::quat_normalize_safe_bwd_device(i, n, quat, grad_out, grad_quat);
 }
 
 // Launch safe quaternion normalization on the current CUDA stream.
@@ -444,7 +444,7 @@ __global__ void quat_conjugate_fwd_kernel(int64_t n, const scalar_t *__restrict_
     {
         return;
     }
-    quat_conjugate_fwd_device(i, n, quat, out);
+    gsplat_geometry::quat_conjugate_fwd_device(i, n, quat, out);
 }
 
 // Grid-stride: VJP for conjugate; grad_out layout matches quaternion.
@@ -458,7 +458,7 @@ __global__ void quat_conjugate_bwd_kernel(
     {
         return;
     }
-    quat_conjugate_bwd_device(i, n, grad_out, grad_quat);
+    gsplat_geometry::quat_conjugate_bwd_device(i, n, grad_out, grad_quat);
 }
 
 // Launch quaternion conjugation on the current CUDA stream.
@@ -535,7 +535,7 @@ __global__ void quat_from_axis_angle_fwd_kernel(
     {
         return;
     }
-    quat_from_axis_angle_fwd_device(i, n, axis, angle, quat);
+    gsplat_geometry::quat_from_axis_angle_fwd_device(i, n, axis, angle, quat);
 }
 
 // Grid-stride: grad_quat (N,4) → grad_axis (N,3), grad_angle (N).
@@ -554,7 +554,7 @@ __global__ void quat_from_axis_angle_bwd_kernel(
     {
         return;
     }
-    quat_from_axis_angle_bwd_device(i, n, axis, angle, grad_quat, grad_axis, grad_angle);
+    gsplat_geometry::quat_from_axis_angle_bwd_device(i, n, axis, angle, grad_quat, grad_axis, grad_angle);
 }
 
 // Launch axis-angle -> quaternion conversion on the current CUDA stream.
@@ -653,7 +653,7 @@ __global__ void quat_lerp_fwd_kernel(
     {
         return;
     }
-    quat_lerp_fwd_device(i, n, t, q1, q2, out);
+    gsplat_geometry::quat_lerp_fwd_device(i, n, t, q1, q2, out);
 }
 
 // Grid-stride: VJP for LERP; requires forward `result` buffer (N,4).
@@ -674,7 +674,7 @@ __global__ void quat_lerp_bwd_kernel(
     {
         return;
     }
-    quat_lerp_bwd_device(i, n, t, q1, q2, result, grad_out, grad_q1, grad_q2);
+    gsplat_geometry::quat_lerp_bwd_device(i, n, t, q1, q2, result, grad_out, grad_q1, grad_q2);
 }
 
 // Launch normalized quaternion LERP on the current CUDA stream.
@@ -779,7 +779,7 @@ __global__ void quat_slerp_batched_fwd_kernel(
     {
         return;
     }
-    quat_slerp_batched_fwd_device(i, n, q1, q2, t, out);
+    gsplat_geometry::quat_slerp_batched_fwd_device(i, n, q1, q2, t, out);
 }
 
 // Grid-stride: VJP batched SLERP; writes grad_t[i] per row; needs forward `result`.
@@ -801,7 +801,7 @@ __global__ void quat_slerp_batched_bwd_kernel(
     {
         return;
     }
-    quat_slerp_batched_bwd_device(i, n, q1, q2, t, result, grad_out, grad_q1, grad_q2, grad_t);
+    gsplat_geometry::quat_slerp_batched_bwd_device(i, n, q1, q2, t, result, grad_out, grad_q1, grad_q2, grad_t);
 }
 
 // Launch batched SLERP on the current CUDA stream.
@@ -903,7 +903,7 @@ __global__ void quat_angular_distance_fwd_kernel(
     {
         return;
     }
-    quat_angular_distance_fwd_device(i, n, q1, q2, dist_out);
+    gsplat_geometry::quat_angular_distance_fwd_device(i, n, q1, q2, dist_out);
 }
 
 // Grid-stride: grad_dist (N,) → grad_q1, grad_q2 (N,4).
@@ -922,7 +922,7 @@ __global__ void quat_angular_distance_bwd_kernel(
     {
         return;
     }
-    quat_angular_distance_bwd_device(i, n, q1, q2, grad_dist, grad_q1, grad_q2);
+    gsplat_geometry::quat_angular_distance_bwd_device(i, n, q1, q2, grad_dist, grad_q1, grad_q2);
 }
 
 // Launch angular distance evaluation on the current CUDA stream.
@@ -1017,7 +1017,7 @@ __global__ void quat_manifold_interp_fwd_kernel(
     {
         return;
     }
-    quat_manifold_interp_fwd_device(i, n, t, q1, q2, out);
+    gsplat_geometry::quat_manifold_interp_fwd_device(i, n, t, q1, q2, out);
 }
 
 // Grid-stride: VJP manifold interp; grad_out (N,4) → grad_q1, grad_q2, grad_t.
@@ -1038,7 +1038,7 @@ __global__ void quat_manifold_interp_bwd_kernel(
     {
         return;
     }
-    quat_manifold_interp_bwd_device(i, n, t, q1, q2, grad_out, grad_q1, grad_q2, grad_t);
+    gsplat_geometry::quat_manifold_interp_bwd_device(i, n, t, q1, q2, grad_out, grad_q1, grad_q2, grad_t);
 }
 
 // Launch manifold quaternion interpolation on the current CUDA stream.

--- a/gsplat/geometry/kernels/cuda/csrc/quaternion.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/quaternion.cuh
@@ -317,7 +317,7 @@ __forceinline__ __device__ void quat_normalize_safe_bwd_write(
 
 // -----------------------------------------------------------------------------
 // quat_slerp_batched with hemisphere handling and lerp fallback.
-// Hemisphere flip, clamp(dot), small-angle lerp fallback (dot > 0.9995), per-row t (N,1).
+// Hemisphere flip, clamp(dot), small-angle lerp fallback (dot above the threshold), per-row t (N,1).
 // -----------------------------------------------------------------------------
 
 // Clamp dot product to [-1, 1] before acos in SLERP (avoids NaNs from slight overshoot).
@@ -335,11 +335,14 @@ __forceinline__ __device__ scalar_t quat_slerp_clamp_dot(scalar_t x)
     return x;
 }
 
-// Dot threshold above which SLERP uses normalized linear blend instead of sin/acos path (~0.9995).
+// Dot threshold above which SLERP uses normalized linear blend instead of sin/acos path.
+// Host+device constant; also exposed to Python via the extension (see ext.cpp).
+inline constexpr double kSlerpSmallAngleDotThreshold = 0.9995;
+
 template<typename scalar_t>
 __forceinline__ __device__ scalar_t quat_slerp_small_angle_dot_threshold()
 {
-    return scalar_t(0.9995);
+    return scalar_t(kSlerpSmallAngleDotThreshold);
 }
 
 // Scalar SLERP(q1, q2, t) in xyzw order. Used by batched quaternion, trajectory,
@@ -394,10 +397,9 @@ __forceinline__ __device__ void quat_slerp_pair_fwd(
     *ow                      = w1s * w1 + w2s * sw;
 }
 
-// VJP for quat_slerp_pair_fwd. `rx..rw` are the forward outputs and
-// `gx..gw` is upstream dL/dout.
-template<typename scalar_t>
-__forceinline__ __device__ void quat_slerp_pair_bwd(
+// Shared VJP body; EmitGradT removes dL/dti work from no-time-grad callers.
+template<typename scalar_t, bool EmitGradT>
+__forceinline__ __device__ void quat_slerp_pair_bwd_impl(
     scalar_t x1,
     scalar_t y1,
     scalar_t z1,
@@ -459,7 +461,10 @@ __forceinline__ __device__ void quat_slerp_pair_bwd(
         *gq2z = s * ti * grz;
         *gq2w = s * ti * grw;
 
-        *grad_t = grx * (sx - x1) + gry * (sy - y1) + grz * (sz - z1) + grw * (sw - w1);
+        if constexpr(EmitGradT)
+        {
+            *grad_t = grx * (sx - x1) + gry * (sy - y1) + grz * (sz - z1) + grw * (sw - w1);
+        }
         return;
     }
 
@@ -492,9 +497,131 @@ __forceinline__ __device__ void quat_slerp_pair_bwd(
     *gq2z                = s * gq2ez;
     *gq2w                = s * gq2ew;
 
-    const scalar_t dw1_dt = -theta * cos((scalar_t(1) - ti) * theta) / sin_theta;
-    const scalar_t dw2_dt = theta * cos(ti * theta) / sin_theta;
-    *grad_t               = G1 * dw1_dt + G2 * dw2_dt;
+    if constexpr(EmitGradT)
+    {
+        const scalar_t dw1_dt = -theta * cos((scalar_t(1) - ti) * theta) / sin_theta;
+        const scalar_t dw2_dt = theta * cos(ti * theta) / sin_theta;
+        *grad_t               = G1 * dw1_dt + G2 * dw2_dt;
+    }
+}
+
+template<typename scalar_t>
+__forceinline__ __device__ void quat_slerp_pair_bwd_no_time_grad(
+    scalar_t x1,
+    scalar_t y1,
+    scalar_t z1,
+    scalar_t w1,
+    scalar_t x2,
+    scalar_t y2,
+    scalar_t z2,
+    scalar_t w2,
+    scalar_t ti,
+    scalar_t rx,
+    scalar_t ry,
+    scalar_t rz,
+    scalar_t rw,
+    scalar_t gx,
+    scalar_t gy,
+    scalar_t gz,
+    scalar_t gw,
+    scalar_t *gq1x,
+    scalar_t *gq1y,
+    scalar_t *gq1z,
+    scalar_t *gq1w,
+    scalar_t *gq2x,
+    scalar_t *gq2y,
+    scalar_t *gq2z,
+    scalar_t *gq2w
+)
+{
+    quat_slerp_pair_bwd_impl<scalar_t, false>(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        ti,
+        rx,
+        ry,
+        rz,
+        rw,
+        gx,
+        gy,
+        gz,
+        gw,
+        gq1x,
+        gq1y,
+        gq1z,
+        gq1w,
+        gq2x,
+        gq2y,
+        gq2z,
+        gq2w,
+        nullptr
+    );
+}
+
+template<typename scalar_t>
+__forceinline__ __device__ void quat_slerp_pair_bwd_with_time_grad(
+    scalar_t x1,
+    scalar_t y1,
+    scalar_t z1,
+    scalar_t w1,
+    scalar_t x2,
+    scalar_t y2,
+    scalar_t z2,
+    scalar_t w2,
+    scalar_t ti,
+    scalar_t rx,
+    scalar_t ry,
+    scalar_t rz,
+    scalar_t rw,
+    scalar_t gx,
+    scalar_t gy,
+    scalar_t gz,
+    scalar_t gw,
+    scalar_t *gq1x,
+    scalar_t *gq1y,
+    scalar_t *gq1z,
+    scalar_t *gq1w,
+    scalar_t *gq2x,
+    scalar_t *gq2y,
+    scalar_t *gq2z,
+    scalar_t *gq2w,
+    scalar_t *grad_t
+)
+{
+    quat_slerp_pair_bwd_impl<scalar_t, true>(
+        x1,
+        y1,
+        z1,
+        w1,
+        x2,
+        y2,
+        z2,
+        w2,
+        ti,
+        rx,
+        ry,
+        rz,
+        rw,
+        gx,
+        gy,
+        gz,
+        gw,
+        gq1x,
+        gq1y,
+        gq1z,
+        gq1w,
+        gq2x,
+        gq2y,
+        gq2z,
+        gq2w,
+        grad_t
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -1235,7 +1362,7 @@ __device__ void quat_slerp_batched_bwd_device(
     const scalar_t x1 = q1[o + 0], y1 = q1[o + 1], z1 = q1[o + 2], w1 = q1[o + 3];
     const scalar_t x2 = q2[o + 0], y2 = q2[o + 1], z2 = q2[o + 2], w2 = q2[o + 3];
     const scalar_t gx = grad_out[o + 0], gy = grad_out[o + 1], gz = grad_out[o + 2], gw = grad_out[o + 3];
-    quat_slerp_pair_bwd(
+    quat_slerp_pair_bwd_with_time_grad(
         x1,
         y1,
         z1,

--- a/gsplat/geometry/kernels/cuda/csrc/quaternion.cuh
+++ b/gsplat/geometry/kernels/cuda/csrc/quaternion.cuh
@@ -26,6 +26,8 @@
 
 #include <cuda_runtime.h>
 
+namespace gsplat_geometry
+{
 // 3D cross product a × b.
 // Inputs: components of a and b. Outputs: *ox,*oy,*oz = result (same scalar type as inputs).
 template<typename scalar_t>
@@ -1493,3 +1495,4 @@ __device__ void quat_manifold_interp_bwd_device(
     grad_q2[o + 2] = static_cast<scalar_t>(gq2z);
     grad_q2[o + 3] = static_cast<scalar_t>(gq2w);
 }
+} // namespace gsplat_geometry

--- a/gsplat/geometry/kernels/cuda/ext.cpp
+++ b/gsplat/geometry/kernels/cuda/ext.cpp
@@ -17,6 +17,8 @@
 
 #include <torch/extension.h>
 
+double slerp_small_angle_dot_threshold();
+
 void quat_normalize_safe_cuda(const at::Tensor &quat, at::Tensor &out);
 void quat_normalize_safe_bwd_cuda(const at::Tensor &quat, const at::Tensor &grad_out, at::Tensor &grad_quat);
 
@@ -1736,6 +1738,7 @@ torch::Tensor frame_transform_poses_tquat(
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
+    m.attr("SLERP_SMALL_ANGLE_DOT_THRESHOLD") = slerp_small_angle_dot_threshold();
     m.def("quat_normalize_safe", &quat_normalize_safe, "Normalize quaternion xyzw with near-zero guard, CUDA");
     m.def("quat_normalize_safe_bwd", &quat_normalize_safe_bwd, "Backward for quat_normalize_safe, CUDA");
     m.def("quat_multiply", &quat_multiply, "Hamilton product q1*q2, xyzw, CUDA");

--- a/gsplat/geometry/kernels/quaternion_ops.py
+++ b/gsplat/geometry/kernels/quaternion_ops.py
@@ -31,6 +31,10 @@ from torch import Tensor
 
 from . import _backend
 
+SLERP_SMALL_ANGLE_DOT_THRESHOLD = float(
+    _backend._GEOMETRY_CUDA.SLERP_SMALL_ANGLE_DOT_THRESHOLD
+)
+
 
 def _expect_tensor(name: str, x: object) -> Tensor:
     if not isinstance(x, Tensor):
@@ -177,7 +181,7 @@ def _quat_slerp_batched_forward_reference(q1: Tensor, q2: Tensor, t: Tensor) -> 
     q2e = torch.where(d < 0, -q2, q2)
     c_raw = (q1 * q2e).sum(dim=-1, keepdim=True)
     c = c_raw.clamp(min=-1.0, max=1.0)
-    use_lerp = c > 0.9995
+    use_lerp = c > SLERP_SMALL_ANGLE_DOT_THRESHOLD
     om = 1.0 - t
     r = om * q1 + t * q2e
     y_lerp = r / r.norm(dim=-1, keepdim=True)

--- a/gsplat/sensors/design-kernels.md
+++ b/gsplat/sensors/design-kernels.md
@@ -290,7 +290,11 @@ by the functional layer for downstream tools that still want a `(N, 4, 4)`
 representation.
 
 Pose interpolation runs on device using geometry-owned SLERP helpers in
-`gsplat/geometry/kernels/cuda/csrc/pose.cuh`.
+`gsplat/geometry/kernels/cuda/csrc/quaternion.cuh`. Sensor backward kernels call the
+`quat_slerp_pair_bwd_no_time_grad` variant because the per-frame interpolation
+time is a fixed (non-differentiable) timestamp; the `with_time_grad` variant,
+which also emits the time gradient, is used only by `gsplat/geometry`'s
+trajectory backward path where query time is differentiable.
 
 ## File-level reference
 
@@ -314,7 +318,7 @@ Pose interpolation runs on device using geometry-owned SLERP helpers in
 | `kernels/cuda/ext.cpp` | TorchScript class registrations, camera per-pair `m.def` bindings, LiDAR op bindings, and `PYBIND11_MODULE` re-export of `ShutterType` / `SpinningDirection`. |
 | `csrc/camera_params.h` | Projection kernel-parameter PODs + 36 forward + 36 backward `_launch` prototypes + rolling-shutter and Newton-iteration bounds. Forward-declared `cudaStream_t`. |
 | `csrc/external_distortion_params.h` | `NoExternalDistortion_KernelParameters` (empty) + `BivariateWindshieldDistortion_KernelParameters`. |
-| `csrc/camera_kernel.cuh` | `OpenCVPinholeParams`, `ProjectionEval`, `DistortionResult`, `DistortionParamGrads`; OpenCV pinhole device math + rolling-shutter time helper. SLERP is delegated to `gsplat/geometry/kernels/cuda/csrc/pose.cuh`. |
+| `csrc/camera_kernel.cuh` | `OpenCVPinholeParams`, `ProjectionEval`, `DistortionResult`, `DistortionParamGrads`; OpenCV pinhole device math + rolling-shutter time helper. SLERP is delegated to `gsplat/geometry/kernels/cuda/csrc/quaternion.cuh`. |
 | `csrc/ftheta_kernel.cuh` / `.cu` / `_backward.cu` | FTheta device math, forward kernels, and backward kernels. |
 | `csrc/fisheye_kernel.cuh` / `.cu` / `_backward.cu` | OpenCV fisheye device math, forward kernels, and backward kernels. |
 | `csrc/external_distortion_kernel.cuh` | `BivariateWindshieldParams` + `NoExternalDistortion_Parameters` no-op tag + header-only bivariate distortion math (no companion `.cu`). |

--- a/gsplat/sensors/design-kernels.md
+++ b/gsplat/sensors/design-kernels.md
@@ -289,9 +289,8 @@ The convention helpers `wxyz_to_xyzw` / `xyzw_to_wxyz` live in
 by the functional layer for downstream tools that still want a `(N, 4, 4)`
 representation.
 
-Pose interpolation (slerp + lerp) is performed on the device by the kernels
-themselves, not in Python — see `trajectory_cuda::quat_slerp_pair_fwd_f` /
-`quat_slerp_pair_bwd_f` in `gsplat/geometry/kernels/cuda/csrc/pose.cuh`.
+Pose interpolation runs on device using geometry-owned SLERP helpers in
+`gsplat/geometry/kernels/cuda/csrc/pose.cuh`.
 
 ## File-level reference
 

--- a/gsplat/sensors/kernels/cameras/ops.py
+++ b/gsplat/sensors/kernels/cameras/ops.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
+from gsplat.geometry.kernels.quaternion_ops import SLERP_SMALL_ANGLE_DOT_THRESHOLD
+
 from .. import _backend
 
 _backend._SENSORS_CUDA  # noqa: B018  # ensures torch.ops gsplat_sensors registrations exist
@@ -4295,7 +4297,8 @@ def _quat_slerp_wxyz(q0: Tensor, q1: Tensor, alpha: Tensor) -> Tensor:
     """Differentiable quaternion SLERP in wxyz convention.
 
     Falls back to normalized linear interpolation (NLERP) when the two
-    quaternions are nearly identical (dot > 0.9995) to avoid acos singularities.
+    quaternions are nearly identical (dot above the small-angle threshold) to
+    avoid acos singularities.
 
     Args:
         q0: (*, 4) start quaternions in wxyz order.
@@ -4308,7 +4311,7 @@ def _quat_slerp_wxyz(q0: Tensor, q1: Tensor, alpha: Tensor) -> Tensor:
     q1 = torch.nn.functional.normalize(q1, dim=-1)
     q1 = torch.where((q0 * q1).sum(dim=-1, keepdim=True) < 0, -q1, q1)
     dot = (q0 * q1).sum(dim=-1, keepdim=True)
-    close = dot > 0.9995
+    close = dot > SLERP_SMALL_ANGLE_DOT_THRESHOLD
     # torch.where computes both branches before selecting, so torch.acos must
     # have a finite derivative on the slerp branch even when q0 == q1
     # (otherwise the unselected branch's NaN gradient pollutes q0 / q1.grad).

--- a/gsplat/sensors/kernels/cuda/csrc/camera_kernel.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/camera_kernel.cu
@@ -251,7 +251,7 @@ __global__ void project_world_points_mean_pose_forward_kernel(
         float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
         block_pose_t  = lerp3(trans0, trans1, 0.5f);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &qx, &qy, &qz, &qw
         );
         block_pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -374,7 +374,7 @@ __global__ void project_world_points_shutter_pose_forward_kernel(
         pose_t = lerp3(trans0, trans1, alpha);
         {
             float qx, qy, qz, qw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
             );
             pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -558,7 +558,7 @@ __global__ void image_points_to_world_rays_shutter_pose_forward_kernel(
     float4 rot0       = read_quat_xyzw_from_wxyz(start_rotation, 0);
     float4 rot1       = read_quat_xyzw_from_wxyz(end_rotation, 0);
     float qx, qy, qz, qw;
-    trajectory_cuda::quat_slerp_pair_fwd_f(
+    gsplat_geometry::quat_slerp_pair_fwd<float>(
         rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, relative_time, &qx, &qy, &qz, &qw
     );
     float4 pose_r_xyzw      = make_float4(qx, qy, qz, qw);
@@ -753,7 +753,7 @@ __global__ void project_world_points_mean_pose_opencv_pinhole_bivariate_windshie
         float4 rot1            = read_quat_xyzw_from_wxyz(end_rotation, 0);
         block_pose_t           = lerp3(trans0, trans1, 0.5f);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &qx, &qy, &qz, &qw
         );
         block_pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -878,7 +878,7 @@ __global__ void project_world_points_shutter_pose_opencv_pinhole_bivariate_winds
         pose_t = lerp3(trans0, trans1, alpha);
         {
             float qx, qy, qz, qw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
             );
             pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -1078,7 +1078,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_pinhole_bivariate
     float4 rot0   = read_quat_xyzw_from_wxyz(start_rotation, 0);
     float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
     float qx, qy, qz, qw;
-    trajectory_cuda::quat_slerp_pair_fwd_f(
+    gsplat_geometry::quat_slerp_pair_fwd<float>(
         rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, relative_time, &qx, &qy, &qz, &qw
     );
     float4 pose_r_xyzw = make_float4(qx, qy, qz, qw);

--- a/gsplat/sensors/kernels/cuda/csrc/camera_kernel.cuh
+++ b/gsplat/sensors/kernels/cuda/csrc/camera_kernel.cuh
@@ -206,14 +206,13 @@ __device__ __forceinline__ float4 xyzw_to_wxyz(float4 q)
 // helpers keep sensorlib callsites float3/float4-shaped while delegating the
 // actual quaternion math to libs/geometry/kernels/cuda/csrc/quaternion.cuh.
 
-// Rotates v by q (xyzw order). Wraps quat_rotate_vector_fwd_impl<float>
-// from libs/geometry; inputs and outputs stay in float3/float4 shapes.
+// Rotates v by xyzw q while preserving sensor float3/float4 call shapes.
 __device__ __forceinline__ float3 quat_rotate_xyzw_geom(float4 q, float3 v)
 {
     float ox = 0.0f;
     float oy = 0.0f;
     float oz = 0.0f;
-    quat_rotate_vector_fwd_impl<float>(q.x, q.y, q.z, q.w, v.x, v.y, v.z, &ox, &oy, &oz);
+    gsplat_geometry::quat_rotate_vector_fwd_impl<float>(q.x, q.y, q.z, q.w, v.x, v.y, v.z, &ox, &oy, &oz);
     return make_float3(ox, oy, oz);
 }
 
@@ -224,12 +223,11 @@ __device__ __forceinline__ float3 quat_inverse_rotate_xyzw_geom(float4 q, float3
     return quat_rotate_xyzw_geom(make_float4(-q.x, -q.y, -q.z, q.w), v);
 }
 
-// Fills r0/r1/r2 with the rows of the rotation matrix for q (xyzw order).
-// Wraps quat_to_matrix_fwd_write<float> from libs/geometry.
+// Fills row vectors for q's rotation matrix without exposing flat geometry buffers.
 __device__ __forceinline__ void quat_to_matrix_xyzw_geom(float4 q, float3 &r0, float3 &r1, float3 &r2)
 {
     float r[9];
-    quat_to_matrix_fwd_write<float>(q.x, q.y, q.z, q.w, r);
+    gsplat_geometry::quat_to_matrix_fwd_write<float>(q.x, q.y, q.z, q.w, r);
     r0 = make_float3(r[0], r[1], r[2]);
     r1 = make_float3(r[3], r[4], r[5]);
     r2 = make_float3(r[6], r[7], r[8]);
@@ -250,7 +248,7 @@ __device__ __forceinline__ float4 normalize_quat_geom(float4 q)
     float oy = 0.0f;
     float oz = 0.0f;
     float ow = 0.0f;
-    quat_normalize_safe_fwd_write<float>(q.x, q.y, q.z, q.w, &ox, &oy, &oz, &ow);
+    gsplat_geometry::quat_normalize_safe_fwd_write<float>(q.x, q.y, q.z, q.w, &ox, &oy, &oz, &ow);
     return make_float4(ox, oy, oz, ow);
 }
 
@@ -266,7 +264,7 @@ __device__ __forceinline__ void quat_rotate_bwd_xyzw_geom(float4 q, float3 v, fl
     float gvx = 0.0f;
     float gvy = 0.0f;
     float gvz = 0.0f;
-    quat_rotate_vector_bwd_impl<float>(
+    gsplat_geometry::quat_rotate_vector_bwd_impl<float>(
         q.x, q.y, q.z, q.w, v.x, v.y, v.z, d_v_out.x, d_v_out.y, d_v_out.z, &gqx, &gqy, &gqz, &gqw, &gvx, &gvy, &gvz
     );
     d_q.x += gqx;
@@ -289,7 +287,7 @@ __device__ __forceinline__ void quat_inverse_rotate_bwd_xyzw_geom(
     float gvx = 0.0f;
     float gvy = 0.0f;
     float gvz = 0.0f;
-    quat_rotate_vector_bwd_impl<float>(
+    gsplat_geometry::quat_rotate_vector_bwd_impl<float>(
         -q.x, -q.y, -q.z, q.w, v.x, v.y, v.z, d_v_out.x, d_v_out.y, d_v_out.z, &gqx, &gqy, &gqz, &gqw, &gvx, &gvy, &gvz
     );
     // Conjugate chain rule: imaginary parts negate, real part unchanged.

--- a/gsplat/sensors/kernels/cuda/csrc/camera_kernel_backward.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/camera_kernel_backward.cu
@@ -556,7 +556,7 @@ __global__ void project_world_points_mean_pose_backward_kernel(
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &rx, &ry, &rz, &rw
             );
             float4 rot     = make_float4(rx, ry, rz, rw);
@@ -567,8 +567,8 @@ __global__ void project_world_points_mean_pose_backward_kernel(
             float3 d_trans = scale3(d_p_rel, -1.0f);
             d_trans0       = scale3(d_trans, 0.5f);
             d_trans1       = scale3(d_trans, 0.5f);
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -593,8 +593,7 @@ __global__ void project_world_points_mean_pose_backward_kernel(
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0 = make_float4(gq0x, gq0y, gq0z, gq0w);
             d_rot1 = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -684,7 +683,7 @@ __global__ void project_world_points_shutter_pose_backward_kernel(
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
             );
             float4 rot     = make_float4(rx, ry, rz, rw);
@@ -695,8 +694,8 @@ __global__ void project_world_points_shutter_pose_backward_kernel(
             float3 d_trans = scale3(d_p_rel, -1.0f);
             d_trans0       = scale3(d_trans, 1.0f - alpha);
             d_trans1       = scale3(d_trans, alpha);
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -721,8 +720,7 @@ __global__ void project_world_points_shutter_pose_backward_kernel(
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0 = make_float4(gq0x, gq0y, gq0z, gq0w);
             d_rot1 = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -880,7 +878,7 @@ __global__ void image_points_to_world_rays_shutter_pose_backward_kernel(
         float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
         float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
         float rx, ry, rz, rw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
         );
         float4 rot          = make_float4(rx, ry, rz, rw);
@@ -888,8 +886,8 @@ __global__ void image_points_to_world_rays_shutter_pose_backward_kernel(
         float3 d_camera_ray = make_float3(0.0f, 0.0f, 0.0f);
         float3 camera_ray   = normalize3(make_float3(scratch[off + 0], scratch[off + 1], 1.0f));
         quat_rotate_bwd_xyzw_geom(rot, camera_ray, d_dir, d_rot, d_camera_ray);
-        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-        trajectory_cuda::quat_slerp_pair_bwd_f(
+        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+        gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
             rot0.x,
             rot0.y,
             rot0.z,
@@ -914,8 +912,7 @@ __global__ void image_points_to_world_rays_shutter_pose_backward_kernel(
             &gq1x,
             &gq1y,
             &gq1z,
-            &gq1w,
-            &ga_unused
+            &gq1w
         );
         d_rot0 = make_float4(gq0x, gq0y, gq0z, gq0w);
         d_rot1 = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1169,7 +1166,7 @@ __global__ void project_world_points_mean_pose_opencv_pinhole_bivariate_windshie
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &rx, &ry, &rz, &rw
             );
             float4 rot     = make_float4(rx, ry, rz, rw);
@@ -1180,8 +1177,8 @@ __global__ void project_world_points_mean_pose_opencv_pinhole_bivariate_windshie
             float3 d_trans = scale3(d_p_rel, -1.0f);
             d_trans0       = scale3(d_trans, 0.5f);
             d_trans1       = scale3(d_trans, 0.5f);
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -1206,8 +1203,7 @@ __global__ void project_world_points_mean_pose_opencv_pinhole_bivariate_windshie
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0 = make_float4(gq0x, gq0y, gq0z, gq0w);
             d_rot1 = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1306,7 +1302,7 @@ __global__ void project_world_points_shutter_pose_opencv_pinhole_bivariate_winds
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
             );
             float4 rot     = make_float4(rx, ry, rz, rw);
@@ -1317,8 +1313,8 @@ __global__ void project_world_points_shutter_pose_opencv_pinhole_bivariate_winds
             float3 d_trans = scale3(d_p_rel, -1.0f);
             d_trans0       = scale3(d_trans, 1.0f - alpha);
             d_trans1       = scale3(d_trans, alpha);
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -1343,8 +1339,7 @@ __global__ void project_world_points_shutter_pose_opencv_pinhole_bivariate_winds
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0 = make_float4(gq0x, gq0y, gq0z, gq0w);
             d_rot1 = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1518,7 +1513,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_pinhole_bivariate
         float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
         float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
         float rx, ry, rz, rw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
         );
         float4 rot                 = make_float4(rx, ry, rz, rw);
@@ -1527,8 +1522,8 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_pinhole_bivariate
         float3 camera_ray_pre_norm = make_float3(scratch[off + 5], scratch[off + 6], scratch[off + 7]);
         float3 camera_ray          = normalize3(camera_ray_pre_norm);
         quat_rotate_bwd_xyzw_geom(rot, camera_ray, d_dir, d_rot, d_camera_ray);
-        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-        trajectory_cuda::quat_slerp_pair_bwd_f(
+        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+        gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
             rot0.x,
             rot0.y,
             rot0.z,
@@ -1553,8 +1548,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_pinhole_bivariate
             &gq1x,
             &gq1y,
             &gq1z,
-            &gq1w,
-            &ga_unused
+            &gq1w
         );
         d_rot0 = make_float4(gq0x, gq0y, gq0z, gq0w);
         d_rot1 = make_float4(gq1x, gq1y, gq1z, gq1w);

--- a/gsplat/sensors/kernels/cuda/csrc/fisheye_kernel.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/fisheye_kernel.cu
@@ -190,7 +190,7 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_no_external_forwar
         float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
         block_pose_t  = lerp3(trans0, trans1, 0.5f);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &qx, &qy, &qz, &qw
         );
         block_pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -408,7 +408,7 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_bivariate_windshie
         float4 rot1            = read_quat_xyzw_from_wxyz(end_rotation, 0);
         block_pose_t           = lerp3(trans0, trans1, 0.5f);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &qx, &qy, &qz, &qw
         );
         block_pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -602,7 +602,7 @@ __global__ void
         alpha  = relative_time;
         pose_t = lerp3(trans0, trans1, alpha);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
         );
         pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -730,7 +730,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_no_extern
     float4 rot0   = read_quat_xyzw_from_wxyz(start_rotation, 0);
     float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
     float qx, qy, qz, qw;
-    trajectory_cuda::quat_slerp_pair_fwd_f(
+    gsplat_geometry::quat_slerp_pair_fwd<float>(
         rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
     );
     float4 pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -835,7 +835,7 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_bivariate_winds
         alpha  = relative_time;
         pose_t = lerp3(trans0, trans1, alpha);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
         );
         pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -964,7 +964,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_bivariate
     float4 rot0   = read_quat_xyzw_from_wxyz(start_rotation, 0);
     float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
     float qx, qy, qz, qw;
-    trajectory_cuda::quat_slerp_pair_fwd_f(
+    gsplat_geometry::quat_slerp_pair_fwd<float>(
         rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
     );
     float4 pose_r_xyzw = make_float4(qx, qy, qz, qw);

--- a/gsplat/sensors/kernels/cuda/csrc/fisheye_kernel_backward.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/fisheye_kernel_backward.cu
@@ -320,7 +320,7 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_no_external_backwa
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &rx, &ry, &rz, &rw
             );
             float4 rot_mid_xyzw   = make_float4(rx, ry, rz, rw);
@@ -340,8 +340,8 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_no_external_backwa
             d_trans1.y      += 0.5f * d_mean_t.y;
             d_trans1.z      += 0.5f * d_mean_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -366,8 +366,7 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_no_external_backwa
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0.x += gq0x;
             d_rot0.y += gq0y;
@@ -700,7 +699,7 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_bivariate_windshie
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &rx, &ry, &rz, &rw
             );
             float4 rot_mid_xyzw   = make_float4(rx, ry, rz, rw);
@@ -720,8 +719,8 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_bivariate_windshie
             d_trans1.y      += 0.5f * d_mean_t.y;
             d_trans1.z      += 0.5f * d_mean_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -746,8 +745,7 @@ __global__ void project_world_points_mean_pose_opencv_fisheye_bivariate_windshie
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0.x += gq0x;
             d_rot0.y += gq0y;
@@ -1037,7 +1035,7 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_no_external_bac
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
             );
             float4 rot_alpha_xyzw = make_float4(rx, ry, rz, rw);
@@ -1057,8 +1055,8 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_no_external_bac
             d_trans1.y      += alpha * d_pose_t.y;
             d_trans1.z      += alpha * d_pose_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -1083,8 +1081,7 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_no_external_bac
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0.x += gq0x;
             d_rot0.y += gq0y;
@@ -1176,7 +1173,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_no_extern
         float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
         float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
         float rx, ry, rz, rw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
         );
         float4 rot_alpha_xyzw = make_float4(rx, ry, rz, rw);
@@ -1200,8 +1197,8 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_no_extern
             grad_image_points[idx * 2 + 1] = d_img.y;
         }
 
-        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-        trajectory_cuda::quat_slerp_pair_bwd_f(
+        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+        gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
             rot0.x,
             rot0.y,
             rot0.z,
@@ -1226,8 +1223,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_no_extern
             &gq1x,
             &gq1y,
             &gq1z,
-            &gq1w,
-            &ga_unused
+            &gq1w
         );
         d_rot0.x += gq0x;
         d_rot0.y += gq0y;
@@ -1314,7 +1310,7 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_bivariate_winds
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
             );
             float4 rot_alpha_xyzw = make_float4(rx, ry, rz, rw);
@@ -1334,8 +1330,8 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_bivariate_winds
             d_trans1.y      += alpha * d_pose_t.y;
             d_trans1.z      += alpha * d_pose_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -1360,8 +1356,7 @@ __global__ void project_world_points_shutter_pose_opencv_fisheye_bivariate_winds
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             d_rot0.x += gq0x;
             d_rot0.y += gq0y;
@@ -1462,7 +1457,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_bivariate
         float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
         float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
         float rx, ry, rz, rw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
         );
         float4 rot_alpha_xyzw = make_float4(rx, ry, rz, rw);
@@ -1489,8 +1484,8 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_bivariate
             grad_image_points[idx * 2 + 1] = d_img.y;
         }
 
-        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-        trajectory_cuda::quat_slerp_pair_bwd_f(
+        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+        gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
             rot0.x,
             rot0.y,
             rot0.z,
@@ -1515,8 +1510,7 @@ __global__ void image_points_to_world_rays_shutter_pose_opencv_fisheye_bivariate
             &gq1x,
             &gq1y,
             &gq1z,
-            &gq1w,
-            &ga_unused
+            &gq1w
         );
         d_rot0.x += gq0x;
         d_rot0.y += gq0y;

--- a/gsplat/sensors/kernels/cuda/csrc/fisheye_kernel_backward.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/fisheye_kernel_backward.cu
@@ -269,7 +269,7 @@ __device__ __forceinline__ void fisheye_load_meanpose_14(
 //
 // Feeds the UNNORMALIZED cam_pt straight into fisheye_project_ray_bwd (atan2
 // path, NO normalize3_bwd), then through
-// quat_inverse_rotate_bwd_xyzw_geom (mean rotation) and quat_slerp_pair_bwd to
+// quat_inverse_rotate_bwd_xyzw_geom (mean rotation) and quat_slerp_pair_bwd_no_time_grad to
 // world-point + start/end pose grads. The single mean rotation gradient is
 // stored in wxyz output order.
 // =============================================================================

--- a/gsplat/sensors/kernels/cuda/csrc/ftheta_kernel.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/ftheta_kernel.cu
@@ -270,7 +270,7 @@ __global__ void project_world_points_mean_pose_ftheta_no_external_forward_kernel
         float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
         block_pose_t  = lerp3(trans0, trans1, 0.5f);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &qx, &qy, &qz, &qw
         );
         block_pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -375,7 +375,7 @@ __global__ void project_world_points_mean_pose_ftheta_bivariate_windshield_forwa
         float4 rot1            = read_quat_xyzw_from_wxyz(end_rotation, 0);
         block_pose_t           = lerp3(trans0, trans1, 0.5f);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &qx, &qy, &qz, &qw
         );
         block_pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -606,7 +606,7 @@ __global__ void project_world_points_shutter_pose_ftheta_no_external_forward_ker
         alpha  = relative_time;
         pose_t = lerp3(trans0, trans1, alpha);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
         );
         pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -745,7 +745,7 @@ __global__ void project_world_points_shutter_pose_ftheta_bivariate_windshield_fo
         alpha  = relative_time;
         pose_t = lerp3(trans0, trans1, alpha);
         float qx, qy, qz, qw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &qx, &qy, &qz, &qw
         );
         pose_r_xyzw = make_float4(qx, qy, qz, qw);
@@ -861,7 +861,7 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_no_external_forwa
     float4 rot0             = read_quat_xyzw_from_wxyz(start_rotation, 0);
     float4 rot1             = read_quat_xyzw_from_wxyz(end_rotation, 0);
     float qx, qy, qz, qw;
-    trajectory_cuda::quat_slerp_pair_fwd_f(
+    gsplat_geometry::quat_slerp_pair_fwd<float>(
         rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, relative_time, &qx, &qy, &qz, &qw
     );
     float4 pose_r_xyzw      = make_float4(qx, qy, qz, qw);
@@ -936,7 +936,7 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_bivariate_windshi
     float4 rot0   = read_quat_xyzw_from_wxyz(start_rotation, 0);
     float4 rot1   = read_quat_xyzw_from_wxyz(end_rotation, 0);
     float qx, qy, qz, qw;
-    trajectory_cuda::quat_slerp_pair_fwd_f(
+    gsplat_geometry::quat_slerp_pair_fwd<float>(
         rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, relative_time, &qx, &qy, &qz, &qw
     );
     float4 pose_r_xyzw      = make_float4(qx, qy, qz, qw);

--- a/gsplat/sensors/kernels/cuda/csrc/ftheta_kernel_backward.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/ftheta_kernel_backward.cu
@@ -415,8 +415,7 @@ __device__ __forceinline__ void ftheta_load_meanpose_10(
 //
 // Backward: project world points -> image points with mean shutter pose
 // (slerp alpha = 0.5, no external distortion). Chains d_image_point through
-// ftheta_project_ray_bwd, quat_inverse_rotate_bwd (mean rotation), and
-// quat_slerp_pair_bwd to world-point + start/end pose grads.
+// ftheta_project_ray_bwd and pose VJPs; interpolation time is fixed by the sensor.
 // =============================================================================
 
 __global__ void project_world_points_mean_pose_ftheta_no_external_backward_kernel(
@@ -468,7 +467,7 @@ __global__ void project_world_points_mean_pose_ftheta_no_external_backward_kerne
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &rx, &ry, &rz, &rw
             );
             float4 rot_mid_xyzw   = make_float4(rx, ry, rz, rw);
@@ -489,8 +488,8 @@ __global__ void project_world_points_mean_pose_ftheta_no_external_backward_kerne
             d_trans1.y      += 0.5f * d_mean_t.y;
             d_trans1.z      += 0.5f * d_mean_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -515,8 +514,7 @@ __global__ void project_world_points_mean_pose_ftheta_no_external_backward_kerne
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             float4 d_r0  = make_float4(gq0x, gq0y, gq0z, gq0w);
             float4 d_r1  = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -652,7 +650,7 @@ __global__ void project_world_points_mean_pose_ftheta_bivariate_windshield_backw
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, 0.5f, &rx, &ry, &rz, &rw
             );
             float4 rot_mid_xyzw   = make_float4(rx, ry, rz, rw);
@@ -672,8 +670,8 @@ __global__ void project_world_points_mean_pose_ftheta_bivariate_windshield_backw
             d_trans1.y      += 0.5f * d_mean_t.y;
             d_trans1.z      += 0.5f * d_mean_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -698,8 +696,7 @@ __global__ void project_world_points_mean_pose_ftheta_bivariate_windshield_backw
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             float4 d_r0  = make_float4(gq0x, gq0y, gq0z, gq0w);
             float4 d_r1  = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1021,7 +1018,7 @@ __global__ void project_world_points_shutter_pose_ftheta_no_external_backward_ke
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
             );
             float4 rot_alpha_xyzw = make_float4(rx, ry, rz, rw);
@@ -1041,8 +1038,8 @@ __global__ void project_world_points_shutter_pose_ftheta_no_external_backward_ke
             d_trans1.y      += alpha * d_pose_t.y;
             d_trans1.z      += alpha * d_pose_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -1067,8 +1064,7 @@ __global__ void project_world_points_shutter_pose_ftheta_no_external_backward_ke
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             float4 d_r0  = make_float4(gq0x, gq0y, gq0z, gq0w);
             float4 d_r1  = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1211,7 +1207,7 @@ __global__ void project_world_points_shutter_pose_ftheta_bivariate_windshield_ba
             float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
             float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
             float rx, ry, rz, rw;
-            trajectory_cuda::quat_slerp_pair_fwd_f(
+            gsplat_geometry::quat_slerp_pair_fwd<float>(
                 rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
             );
             float4 rot_alpha_xyzw = make_float4(rx, ry, rz, rw);
@@ -1231,8 +1227,8 @@ __global__ void project_world_points_shutter_pose_ftheta_bivariate_windshield_ba
             d_trans1.y      += alpha * d_pose_t.y;
             d_trans1.z      += alpha * d_pose_t.z;
 
-            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-            trajectory_cuda::quat_slerp_pair_bwd_f(
+            float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
                 rot0.x,
                 rot0.y,
                 rot0.z,
@@ -1257,8 +1253,7 @@ __global__ void project_world_points_shutter_pose_ftheta_bivariate_windshield_ba
                 &gq1x,
                 &gq1y,
                 &gq1z,
-                &gq1w,
-                &ga_unused
+                &gq1w
             );
             float4 d_r0  = make_float4(gq0x, gq0y, gq0z, gq0w);
             float4 d_r1  = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1332,10 +1327,8 @@ __global__ void project_world_points_shutter_pose_ftheta_bivariate_windshield_ba
 // D7 backward -- image_points_to_world_rays_shutter_pose_ftheta_no_external
 //
 // Backward: FTheta backproject image points -> world rays with rolling-shutter
-// pose (no external distortion). d_origin splits (1-alpha)/(alpha) to
-// start/end translation; d_direction chains through quat_rotate_bwd and
-// quat_slerp_pair_bwd into start/end rotation, then through
-// ftheta_backproject_image_point_bwd to d_image_point + intrinsic grads.
+// pose (no external distortion). Pose interpolation is not time-differentiable
+// here; gradients flow only to world point, endpoint poses, and intrinsics.
 // =============================================================================
 
 __global__ void image_points_to_world_rays_shutter_pose_ftheta_no_external_backward_kernel(
@@ -1391,7 +1384,7 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_no_external_backw
         float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
         float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
         float rx, ry, rz, rw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
         );
         float4 pose_r_xyzw = make_float4(rx, ry, rz, rw);
@@ -1404,8 +1397,8 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_no_external_backw
         float3 d_camera_ray = make_float3(0.0f, 0.0f, 0.0f);
         quat_rotate_bwd_xyzw_geom(pose_r_xyzw, camera_ray, d_direction, d_pose_r, d_camera_ray);
 
-        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-        trajectory_cuda::quat_slerp_pair_bwd_f(
+        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+        gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
             rot0.x,
             rot0.y,
             rot0.z,
@@ -1430,8 +1423,7 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_no_external_backw
             &gq1x,
             &gq1y,
             &gq1z,
-            &gq1w,
-            &ga_unused
+            &gq1w
         );
         float4 d_r0  = make_float4(gq0x, gq0y, gq0z, gq0w);
         float4 d_r1  = make_float4(gq1x, gq1y, gq1z, gq1w);
@@ -1565,7 +1557,7 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_bivariate_windshi
         float4 rot0 = read_quat_xyzw_from_wxyz(start_rotation, 0);
         float4 rot1 = read_quat_xyzw_from_wxyz(end_rotation, 0);
         float rx, ry, rz, rw;
-        trajectory_cuda::quat_slerp_pair_fwd_f(
+        gsplat_geometry::quat_slerp_pair_fwd<float>(
             rot0.x, rot0.y, rot0.z, rot0.w, rot1.x, rot1.y, rot1.z, rot1.w, alpha, &rx, &ry, &rz, &rw
         );
         float4 pose_r_xyzw  = make_float4(rx, ry, rz, rw);
@@ -1574,8 +1566,8 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_bivariate_windshi
         float3 d_camera_ray = make_float3(0.0f, 0.0f, 0.0f);
         quat_rotate_bwd_xyzw_geom(pose_r_xyzw, camera_ray, d_direction, d_pose_r, d_camera_ray);
 
-        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w, ga_unused;
-        trajectory_cuda::quat_slerp_pair_bwd_f(
+        float gq0x, gq0y, gq0z, gq0w, gq1x, gq1y, gq1z, gq1w;
+        gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<float>(
             rot0.x,
             rot0.y,
             rot0.z,
@@ -1600,8 +1592,7 @@ __global__ void image_points_to_world_rays_shutter_pose_ftheta_bivariate_windshi
             &gq1x,
             &gq1y,
             &gq1z,
-            &gq1w,
-            &ga_unused
+            &gq1w
         );
         float4 d_r0  = make_float4(gq0x, gq0y, gq0z, gq0w);
         float4 d_r1  = make_float4(gq1x, gq1y, gq1z, gq1w);

--- a/gsplat/sensors/kernels/cuda/csrc/lidar_kernel.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/lidar_kernel.cu
@@ -33,7 +33,6 @@
 using gsplat_sensors::kLidarThreads;
 using gsplat_sensors::normalize_angle;
 using gsplat_sensors::pi_const;
-using gsplat_sensors::slerp_pair_fwd;
 
 namespace
 {
@@ -163,7 +162,7 @@ __global__ void sensor_rays_to_sensor_angles_kernel(
     T z = sensor_rays[idx * 3 + 2];
     T elevation;
     T azimuth;
-    cartesian_to_spherical<T>(x, y, z, elevation, azimuth);
+    gsplat_geometry::cartesian_to_spherical<T>(x, y, z, elevation, azimuth);
     sensor_angles[idx * 2 + 0] = elevation;
     sensor_angles[idx * 2 + 1] = azimuth;
 }
@@ -183,7 +182,7 @@ __global__ void sensor_angles_to_sensor_rays_kernel(
     T rx;
     T ry;
     T rz;
-    spherical_to_cartesian<T>(elevation, azimuth, rx, ry, rz);
+    gsplat_geometry::spherical_to_cartesian<T>(elevation, azimuth, rx, ry, rz);
     sensor_rays[idx * 3 + 0] = rx;
     sensor_rays[idx * 3 + 1] = ry;
     sensor_rays[idx * 3 + 2] = rz;
@@ -308,12 +307,12 @@ __global__ void generate_spinning_lidar_rays_kernel(
     T trans_z  = om * t0z + alpha * t1z;
 
     T qix, qiy, qiz, qiw;
-    slerp_pair_fwd<T>(q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw);
+    gsplat_geometry::quat_slerp_pair_fwd<T>(q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw);
 
     T sx, sy, sz;
-    spherical_to_cartesian<T>(elevation, azimuth, sx, sy, sz);
+    gsplat_geometry::spherical_to_cartesian<T>(elevation, azimuth, sx, sy, sz);
     T wx, wy, wz;
-    quat_rotate_vector_fwd_impl<T>(qix, qiy, qiz, qiw, sx, sy, sz, &wx, &wy, &wz);
+    gsplat_geometry::quat_rotate_vector_fwd_impl<T>(qix, qiy, qiz, qiw, sx, sy, sz, &wx, &wy, &wz);
 
     if(!valid)
     {
@@ -423,7 +422,7 @@ __global__ void __launch_bounds__(kLidarThreads, 5) inverse_project_spinning_lid
         T trans_y  = om * t0y + alpha * t1y;
         T trans_z  = om * t0z + alpha * t1z;
         T qix, qiy, qiz, qiw;
-        slerp_pair_fwd<T>(q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw);
+        gsplat_geometry::quat_slerp_pair_fwd<T>(q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw);
 
         final_alpha   = alpha;
         final_trans_x = trans_x;
@@ -435,14 +434,16 @@ __global__ void __launch_bounds__(kLidarThreads, 5) inverse_project_spinning_lid
         final_qw      = qiw;
 
         T sx, sy, sz;
-        se3_inverse_transform_point<T>(qix, qiy, qiz, qiw, trans_x, trans_y, trans_z, px, py, pz, &sx, &sy, &sz);
+        gsplat_geometry::se3_inverse_transform_point<T>(
+            qix, qiy, qiz, qiw, trans_x, trans_y, trans_z, px, py, pz, &sx, &sy, &sz
+        );
         const T inv_n  = T(1) / sqrt(fmax(sx * sx + sy * sy + sz * sz, gsplat_sensors::normalize_normsq_floor<T>()));
         sx            *= inv_n;
         sy            *= inv_n;
         sz            *= inv_n;
 
         T elevation, azimuth;
-        cartesian_to_spherical<T>(sx, sy, sz, elevation, azimuth);
+        gsplat_geometry::cartesian_to_spherical<T>(sx, sy, sz, elevation, azimuth);
 
         if(!is_in_fov<T>(
                elevation,

--- a/gsplat/sensors/kernels/cuda/csrc/lidar_kernel.cuh
+++ b/gsplat/sensors/kernels/cuda/csrc/lidar_kernel.cuh
@@ -20,13 +20,9 @@
 // Tier-2 nvcc-only header.  Pulls in the Tier-1 POD parameter pack
 // (lidar_params.h), which also defines the SpinningDirection enum.
 //
-// Defines the device-side math the LiDAR kernels share: the SLERP
-// forward/backward (VJP) used by the rolling shutter, and the FOV /
-// nearest-row / nearest-column inverse-projection helpers.  The geometry
-// helpers (resolved via build.py extra_include_paths) supply the quaternion
-// rotate/conjugate math (quaternion.cuh), the scalar SE3 inverse transform
-// (pose.cuh), and the spherical<->cartesian angle conversions
-// (coordinate_conversions.cuh).
+// Defines LiDAR-specific device math: FOV checks, nearest-row/column lookup,
+// and inverse-projection helpers. Shared rotation, pose interpolation, and
+// ray/angle helpers come from geometry CUDA headers.
 
 #pragma once
 
@@ -103,53 +99,5 @@ template<>
 constexpr __device__ __forceinline__ double normalize_normsq_floor<double>()
 {
     return 1.0e-40;
-}
-
-// ===========================================================================
-// Two-pose SLERP (dtype-templated, scalar in/out, xyzw)
-// ===========================================================================
-//
-// The geometry pose.cuh `quat_slerp_pair_fwd_f/bwd_f` helpers are float-only,
-// so fp64 gradcheck cannot route through them.  These are the scalar form of
-// the dtype-templated `quat_slerp_batched_fwd_device/bwd_device` math
-// (quaternion.cuh) — hemisphere flip, clamp(dot), nlerp small-angle fallback —
-// transcribed to single-quaternion args so the LiDAR ray generator stays
-// float/double polymorphic without re-deriving the SLERP VJP.
-
-// SLERP q1->q2 at ti, xyzw, hemisphere flip, nlerp fallback when dot>0.9995.
-template<typename T>
-__device__ __forceinline__ void slerp_pair_fwd(
-    T x1, T y1, T z1, T w1, T x2, T y2, T z2, T w2, T ti, T *ox, T *oy, T *oz, T *ow
-)
-{
-    const T dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const T s   = dot < T(0) ? T(-1) : T(1);
-    const T sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const T c_raw = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const T c     = quat_slerp_clamp_dot<T>(c_raw);
-
-    if(c > quat_slerp_small_angle_dot_threshold<T>())
-    {
-        const T om    = T(1) - ti;
-        const T rx    = om * x1 + ti * sx;
-        const T ry    = om * y1 + ti * sy;
-        const T rz    = om * z1 + ti * sz;
-        const T rw    = om * w1 + ti * sw;
-        const T inv_n = T(1) / sqrt(rx * rx + ry * ry + rz * rz + rw * rw);
-        *ox           = rx * inv_n;
-        *oy           = ry * inv_n;
-        *oz           = rz * inv_n;
-        *ow           = rw * inv_n;
-        return;
-    }
-
-    const T theta     = acos(c);
-    const T sin_theta = sin(theta);
-    const T w1s       = sin((T(1) - ti) * theta) / sin_theta;
-    const T w2s       = sin(ti * theta) / sin_theta;
-    *ox               = w1s * x1 + w2s * sx;
-    *oy               = w1s * y1 + w2s * sy;
-    *oz               = w1s * z1 + w2s * sz;
-    *ow               = w1s * w1 + w2s * sw;
 }
 } // namespace gsplat_sensors

--- a/gsplat/sensors/kernels/cuda/csrc/lidar_kernel_backward.cu
+++ b/gsplat/sensors/kernels/cuda/csrc/lidar_kernel_backward.cu
@@ -26,7 +26,6 @@
 #include <c10/cuda/CUDAException.h>
 
 using gsplat_sensors::kLidarThreads;
-using gsplat_sensors::slerp_pair_fwd;
 
 namespace
 {
@@ -51,94 +50,6 @@ template<>
 constexpr __device__ __forceinline__ double det_guard_eps<double>()
 {
     return 1.0e-12;
-}
-
-// VJP for slerp_pair_fwd: forward outputs (rx,ry,rz,rw) and upstream
-// (gx..gw) -> gq1*, gq2* (xyzw).  ti is non-differentiable here (derived from
-// the column index), so the slerp time grad is computed and discarded by the
-// caller; this helper does not emit it.
-template<typename T>
-__device__ __forceinline__ void slerp_pair_bwd(
-    T x1,
-    T y1,
-    T z1,
-    T w1,
-    T x2,
-    T y2,
-    T z2,
-    T w2,
-    T ti,
-    T rx,
-    T ry,
-    T rz,
-    T rw,
-    T gx,
-    T gy,
-    T gz,
-    T gw,
-    T *gq1x,
-    T *gq1y,
-    T *gq1z,
-    T *gq1w,
-    T *gq2x,
-    T *gq2y,
-    T *gq2z,
-    T *gq2w
-)
-{
-    const T dot = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
-    const T s   = dot < T(0) ? T(-1) : T(1);
-    const T sx = s * x2, sy = s * y2, sz = s * z2, sw = s * w2;
-    const T c_raw         = x1 * sx + y1 * sy + z1 * sz + w1 * sw;
-    const T c             = quat_slerp_clamp_dot<T>(c_raw);
-    const bool interior_c = (c_raw > T(-1)) && (c_raw < T(1));
-    const T c_mask        = interior_c ? T(1) : T(0);
-
-    if(c > quat_slerp_small_angle_dot_threshold<T>())
-    {
-        const T om     = T(1) - ti;
-        const T rrx    = om * x1 + ti * sx;
-        const T rry    = om * y1 + ti * sy;
-        const T rrz    = om * z1 + ti * sz;
-        const T rrw    = om * w1 + ti * sw;
-        const T r_norm = sqrt(rrx * rrx + rry * rry + rrz * rrz + rrw * rrw);
-        const T ydotg  = rx * gx + ry * gy + rz * gz + rw * gw;
-        const T scale  = T(1) / r_norm;
-        const T grx    = (gx - rx * ydotg) * scale;
-        const T gry    = (gy - ry * ydotg) * scale;
-        const T grz    = (gz - rz * ydotg) * scale;
-        const T grw    = (gw - rw * ydotg) * scale;
-        *gq1x          = om * grx;
-        *gq1y          = om * gry;
-        *gq1z          = om * grz;
-        *gq1w          = om * grw;
-        *gq2x          = s * ti * grx;
-        *gq2y          = s * ti * gry;
-        *gq2z          = s * ti * grz;
-        *gq2w          = s * ti * grw;
-        return;
-    }
-
-    const T theta      = acos(c);
-    const T sin_theta  = sin(theta);
-    const T w1s        = sin((T(1) - ti) * theta) / sin_theta;
-    const T w2s        = sin(ti * theta) / sin_theta;
-    const T G1         = gx * x1 + gy * y1 + gz * z1 + gw * w1;
-    const T G2         = gx * sx + gy * sy + gz * sz + gw * sw;
-    const T den        = sin_theta * sin_theta;
-    const T dw1_dtheta = ((T(1) - ti) * cos((T(1) - ti) * theta) * sin_theta - sin((T(1) - ti) * theta) * c) / den;
-    const T dw2_dtheta = (ti * cos(ti * theta) * sin_theta - sin(ti * theta) * c) / den;
-    const T dw1_dc     = sin_theta > T(1e-20) ? (-dw1_dtheta / sin_theta) * c_mask : T(0);
-    const T dw2_dc     = sin_theta > T(1e-20) ? (-dw2_dtheta / sin_theta) * c_mask : T(0);
-    const T K          = G1 * dw1_dc + G2 * dw2_dc;
-    *gq1x              = w1s * gx + K * sx;
-    *gq1y              = w1s * gy + K * sy;
-    *gq1z              = w1s * gz + K * sz;
-    *gq1w              = w1s * gw + K * sw;
-    *gq2x              = s * (w2s * gx + K * x1);
-    *gq2y              = s * (w2s * gy + K * y1);
-    *gq2z              = s * (w2s * gz + K * z1);
-    *gq2w              = s * (w2s * gw + K * w1);
 }
 
 // Fused block reduction for the 14 control-pose grad components
@@ -256,8 +167,8 @@ __global__ void sensor_angles_to_sensor_rays_backward_kernel(
     T elevation = sensor_angles[idx * 2 + 0];
     T azimuth   = sensor_angles[idx * 2 + 1];
     T ce, se, ca, sa;
-    sincos_t<T>(elevation, se, ce);
-    sincos_t<T>(azimuth, sa, ca);
+    gsplat_geometry::sincos_t<T>(elevation, se, ce);
+    gsplat_geometry::sincos_t<T>(azimuth, sa, ca);
 
     T gx = grad_sensor_rays[idx * 3 + 0];
     T gy = grad_sensor_rays[idx * 3 + 1];
@@ -388,7 +299,7 @@ __global__ void elements_to_sensor_angles_backward_kernel(
 //                                                       + grad_sensor_ray
 //   grad_sensor_ray -> spherical_to_cartesian VJP -> grad_elev, grad_az
 //                       (scattered per (row, col) into the 3 angle tables)
-//   grad_q_interp -> slerp_pair VJP -> grad_q0/q1 (xyzw, hemisphere folded in)
+//   grad_q_interp -> SLERP VJP -> grad_q0/q1 (xyzw, hemisphere folded in)
 //   grad_world_rays[0:3] (origin) -> lerp3 -> grad_t0 = (1-a) g, grad_t1 = a g.
 // Control-pose grads are shared across all threads, so each component is
 // block-reduced then atomicAdded once per block.  The slerp time grad is
@@ -461,9 +372,11 @@ __global__ void __launch_bounds__(kLidarThreads, 5) generate_spinning_lidar_rays
                     q1w = control_rotations[4];
 
             T qix, qiy, qiz, qiw;
-            slerp_pair_fwd<T>(q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw);
+            gsplat_geometry::quat_slerp_pair_fwd<T>(
+                q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw
+            );
             T srx, sry, srz;
-            spherical_to_cartesian<T>(elevation, azimuth, srx, sry, srz);
+            gsplat_geometry::spherical_to_cartesian<T>(elevation, azimuth, srx, sry, srz);
 
             const T g_ox = grad_world_rays[idx * 6 + 0];
             const T g_oy = grad_world_rays[idx * 6 + 1];
@@ -475,7 +388,7 @@ __global__ void __launch_bounds__(kLidarThreads, 5) generate_spinning_lidar_rays
             // world_dir = R(q_interp) sensor_ray.
             T gq_ix, gq_iy, gq_iz, gq_iw;
             T g_srx, g_sry, g_srz;
-            quat_rotate_vector_bwd_impl<T>(
+            gsplat_geometry::quat_rotate_vector_bwd_impl<T>(
                 qix,
                 qiy,
                 qiz,
@@ -516,7 +429,7 @@ __global__ void __launch_bounds__(kLidarThreads, 5) generate_spinning_lidar_rays
             }
 
             // q_interp = slerp(q0, q1, alpha).
-            slerp_pair_bwd<T>(
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<T>(
                 q0x,
                 q0y,
                 q0z,
@@ -643,11 +556,15 @@ __global__ void __launch_bounds__(kLidarThreads, 5) inverse_project_spinning_lid
             const T trans_y = om * t0y + alpha * t1y;
             const T trans_z = om * t0z + alpha * t1z;
             T qix, qiy, qiz, qiw;
-            slerp_pair_fwd<T>(q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw);
+            gsplat_geometry::quat_slerp_pair_fwd<T>(
+                q0x, q0y, q0z, q0w, q1x, q1y, q1z, q1w, alpha, &qix, &qiy, &qiz, &qiw
+            );
 
             // s = R(q)^T (p - t), then ray = s / |s|.
             T sx, sy, sz;
-            se3_inverse_transform_point<T>(qix, qiy, qiz, qiw, trans_x, trans_y, trans_z, px, py, pz, &sx, &sy, &sz);
+            gsplat_geometry::se3_inverse_transform_point<T>(
+                qix, qiy, qiz, qiw, trans_x, trans_y, trans_z, px, py, pz, &sx, &sy, &sz
+            );
             const T s2         = fmax(sx * sx + sy * sy + sz * sz, gsplat_sensors::normalize_normsq_floor<T>());
             const T s_norm     = sqrt(s2);
             const T inv_s_norm = T(1) / s_norm;
@@ -683,7 +600,7 @@ __global__ void __launch_bounds__(kLidarThreads, 5) inverse_project_spinning_lid
             // s = rotate(q_conj, v), v = p - t.  q_conj = (-qx,-qy,-qz,qw).
             const T vx = px - trans_x, vy = py - trans_y, vz = pz - trans_z;
             T g_cqx, g_cqy, g_cqz, g_cqw, g_vx, g_vy, g_vz;
-            quat_rotate_vector_bwd_impl<T>(
+            gsplat_geometry::quat_rotate_vector_bwd_impl<T>(
                 -qix, -qiy, -qiz, qiw, vx, vy, vz, g_sx, g_sy, g_sz, &g_cqx, &g_cqy, &g_cqz, &g_cqw, &g_vx, &g_vy, &g_vz
             );
             // Undo the conjugate sign on the rotation grad.
@@ -704,7 +621,7 @@ __global__ void __launch_bounds__(kLidarThreads, 5) inverse_project_spinning_lid
             g_t1z = alpha * g_tz;
 
             // q = slerp(q0, q1, alpha).
-            slerp_pair_bwd<T>(
+            gsplat_geometry::quat_slerp_pair_bwd_no_time_grad<T>(
                 q0x,
                 q0y,
                 q0z,

--- a/tests/geometry/functional/test_quaternion.py
+++ b/tests/geometry/functional/test_quaternion.py
@@ -26,6 +26,7 @@ import torch
 
 from gsplat._helper import assert_grad_reference_close
 import gsplat.geometry.functional as quat
+from gsplat.geometry.kernels.quaternion_ops import SLERP_SMALL_ANGLE_DOT_THRESHOLD
 
 
 if not torch.cuda.is_available():
@@ -573,7 +574,7 @@ class TestQuaternionOperations(unittest.TestCase):
         q2e = torch.where(d < 0, -q2, q2)
         c_raw = (q1 * q2e).sum(dim=-1, keepdim=True)
         c = c_raw.clamp(min=-1.0, max=1.0)
-        use_lerp = c > 0.9995
+        use_lerp = c > SLERP_SMALL_ANGLE_DOT_THRESHOLD
         om = 1.0 - t
         r = om * q1 + t * q2e
         y_lerp = r / r.norm(dim=-1, keepdim=True)

--- a/tests/sensors/kernels/lidars/test_ops.py
+++ b/tests/sensors/kernels/lidars/test_ops.py
@@ -42,6 +42,7 @@ import pytest
 import torch
 
 from gsplat._helper import expect_grad_reference_close, expect_group
+from gsplat.geometry.kernels.quaternion_ops import SLERP_SMALL_ANGLE_DOT_THRESHOLD
 from gsplat.sensors.kernels.common import DynamicPose, Pose
 from gsplat.sensors.kernels.lidars.ops import (
     _GenerateSpinningLidarRays,
@@ -218,13 +219,13 @@ def _assert_slerp_branch_predicate(control_rotations, branch):
     hemisphere_dot = abs(dot)
     if branch == "hemisphere_flip":
         assert dot < 0.0
-        assert hemisphere_dot <= 0.9995
+        assert hemisphere_dot <= SLERP_SMALL_ANGLE_DOT_THRESHOLD
     elif branch == "full_theta":
         assert dot >= 0.0
-        assert hemisphere_dot <= 0.9995
+        assert hemisphere_dot <= SLERP_SMALL_ANGLE_DOT_THRESHOLD
     elif branch in ("nlerp", "coincident_identity"):
         assert dot >= 0.0
-        assert hemisphere_dot > 0.9995
+        assert hemisphere_dot > SLERP_SMALL_ANGLE_DOT_THRESHOLD
     else:
         raise ValueError(f"unknown SLERP branch case: {branch}")
 
@@ -235,7 +236,7 @@ def _slerp_wxyz_torch(q0, q1, alpha):
     sign = torch.where(dot < 0, q0.new_tensor(-1.0), q0.new_tensor(1.0))
     q1e = sign * q1
     c = (q0 * q1e).sum().clamp(-1.0, 1.0)
-    if bool(c > 0.9995):
+    if bool(c > SLERP_SMALL_ANGLE_DOT_THRESHOLD):
         out = (1 - alpha) * q0 + alpha * q1e
         return out / out.norm()
     theta = torch.acos(c)
@@ -893,7 +894,7 @@ def test_inverse_fp64_gradcheck_world_points_and_poses(sensor_device):
         s = torch.where(dot < 0, -1.0, 1.0)
         sx, sy, sz, sw = s * x1, s * y1, s * z1, s * w1
         c = (x0 * sx + y0 * sy + z0 * sz + w0 * sw).clamp(-1.0, 1.0)
-        if float(c) > 0.9995:
+        if float(c) > SLERP_SMALL_ANGLE_DOT_THRESHOLD:
             om = 1 - alpha
             rx, ry, rz, rw = (
                 om * x0 + alpha * sx,

--- a/tests/sensors/kernels/lidars/test_ops.py
+++ b/tests/sensors/kernels/lidars/test_ops.py
@@ -175,6 +175,85 @@ def _quat_rotation_matrix(qwxyz, device):
             ],
         ],
         device=device,
+        dtype=qwxyz.dtype,
+    )
+
+
+def _slerp_branch_control_rotations(branch, device, dtype):
+    """Return two wxyz unit quaternions that exercise a specific SLERP branch."""
+    q0 = torch.tensor([1.0, 0.0, 0.0, 0.0], device=device, dtype=dtype)
+    if branch == "nlerp":
+        half_angle = 0.01
+        q1 = torch.tensor(
+            [math.cos(half_angle), 0.0, 0.0, math.sin(half_angle)],
+            device=device,
+            dtype=dtype,
+        )
+    elif branch == "full_theta":
+        half_angle = math.pi / 4.0
+        q1 = torch.tensor(
+            [math.cos(half_angle), 0.0, 0.0, math.sin(half_angle)],
+            device=device,
+            dtype=dtype,
+        )
+    elif branch == "hemisphere_flip":
+        half_angle = math.pi / 4.0
+        q1 = -torch.tensor(
+            [math.cos(half_angle), 0.0, 0.0, math.sin(half_angle)],
+            device=device,
+            dtype=dtype,
+        )
+    elif branch == "coincident_identity":
+        # q0 == q1 exercises the small-angle path where sin(theta) would be zero.
+        # Unit quaternions cannot hit the clamp-only path separately.
+        q1 = q0.clone()
+    else:
+        raise ValueError(f"unknown SLERP branch case: {branch}")
+    return torch.stack([q0, q1 / q1.norm()])
+
+
+def _assert_slerp_branch_predicate(control_rotations, branch):
+    """Guard that branch-targeted quaternions still hit the intended SLERP path."""
+    dot = float((control_rotations[0] * control_rotations[1]).sum().item())
+    hemisphere_dot = abs(dot)
+    if branch == "hemisphere_flip":
+        assert dot < 0.0
+        assert hemisphere_dot <= 0.9995
+    elif branch == "full_theta":
+        assert dot >= 0.0
+        assert hemisphere_dot <= 0.9995
+    elif branch in ("nlerp", "coincident_identity"):
+        assert dot >= 0.0
+        assert hemisphere_dot > 0.9995
+    else:
+        raise ValueError(f"unknown SLERP branch case: {branch}")
+
+
+def _slerp_wxyz_torch(q0, q1, alpha):
+    """Torch reference matching the CUDA xyzw SLERP math, exposed as wxyz."""
+    dot = (q0 * q1).sum()
+    sign = torch.where(dot < 0, q0.new_tensor(-1.0), q0.new_tensor(1.0))
+    q1e = sign * q1
+    c = (q0 * q1e).sum().clamp(-1.0, 1.0)
+    if bool(c > 0.9995):
+        out = (1 - alpha) * q0 + alpha * q1e
+        return out / out.norm()
+    theta = torch.acos(c)
+    sin_theta = torch.sin(theta)
+    w0 = torch.sin((1 - alpha) * theta) / sin_theta
+    w1 = torch.sin(alpha * theta) / sin_theta
+    return w0 * q0 + w1 * q1e
+
+
+def _rotate_x_axis_wxyz(q):
+    """Reference direction for zero-elevation, zero-azimuth generated rays."""
+    qw, qx, qy, qz = q.unbind()
+    return torch.stack(
+        [
+            1 - 2 * (qy * qy + qz * qz),
+            2 * (qx * qy + qz * qw),
+            2 * (qx * qz - qy * qw),
+        ]
     )
 
 
@@ -434,6 +513,48 @@ def test_generate_timestamps_monotonic_with_column(lidar_projection_from_json):
     assert bool((diffs > 0).any())
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize(
+    "branch", ["nlerp", "full_theta", "hemisphere_flip", "coincident_identity"]
+)
+def test_generate_slerp_branches_match_torch_reference(sensor_device, dtype, branch):
+    """Lock CUDA SLERP branch outputs to the Torch reference across dtypes."""
+    re = torch.zeros(1, device=sensor_device, dtype=dtype)
+    ca = torch.zeros(3, device=sensor_device, dtype=dtype)
+    ro = torch.zeros(0, device=sensor_device, dtype=dtype)
+    proj = RowOffsetStructuredSpinningLidarProjection(
+        re.float(), ca.float(), ro.float(), 0.0, 0.0, -3.14159, 6.28318, 0, False
+    )
+    elements = torch.tensor(
+        [[0, 0], [0, 1], [0, 2]], device=sensor_device, dtype=torch.int32
+    )
+    control_translations = torch.zeros(2, 3, device=sensor_device, dtype=dtype)
+    control_rotations = _slerp_branch_control_rotations(branch, sensor_device, dtype)
+    _assert_slerp_branch_predicate(control_rotations, branch)
+
+    world_rays, _, poses_translation, poses_rotation = _GenerateSpinningLidarRays.apply(
+        elements, re, ca, ro, control_translations, control_rotations, proj, 0, 1000
+    )
+
+    alphas = torch.tensor([0.0, 0.5, 1.0], device=sensor_device, dtype=dtype)
+    expected_rotations = torch.stack(
+        [
+            _slerp_wxyz_torch(control_rotations[0], control_rotations[1], alpha)
+            for alpha in alphas
+        ]
+    )
+    expected_dirs = torch.stack([_rotate_x_axis_wxyz(q) for q in expected_rotations])
+    atol = 1e-5 if dtype == torch.float32 else 1e-8
+    assert torch.allclose(
+        world_rays[:, :3], torch.zeros_like(world_rays[:, :3]), atol=atol
+    )
+    assert torch.allclose(world_rays[:, 3:], expected_dirs, atol=atol)
+    assert torch.allclose(
+        poses_translation, torch.zeros_like(poses_translation), atol=atol
+    )
+    assert torch.allclose(poses_rotation, expected_rotations, atol=atol)
+
+
 # ===========================================================================
 # Op3: inverse_project_spinning_lidar
 # ===========================================================================
@@ -524,7 +645,7 @@ def test_inverse_rejects_out_of_range_max_iterations(
 
 
 # ===========================================================================
-# fp64 gradcheck (opt-in via -m gradcheck)
+# fp64 gradcheck. Runs in the default suite; use `-m gradcheck` to select only these.
 # ===========================================================================
 
 
@@ -627,6 +748,39 @@ def test_generate_fp64_gradcheck(sensor_device):
         return _GenerateSpinningLidarRays.apply(
             elements, a, b, c, t, r, proj, 0, 100000
         )[0]
+
+    assert torch.autograd.gradcheck(
+        fn, (re_g, ca_g, ro_g, ct_g, cr_g), **GRADCHECK_KWARGS
+    )
+
+
+@pytest.mark.gradcheck
+@pytest.mark.parametrize("branch", ["nlerp", "full_theta", "hemisphere_flip"])
+def test_generate_slerp_branch_fp64_gradcheck(sensor_device, branch):
+    """Guard gradient stability in each CUDA SLERP branch."""
+    re = torch.tensor([0.0], device=sensor_device, dtype=torch.float64)
+    ca = torch.tensor([-0.2, 0.0, 0.2], device=sensor_device, dtype=torch.float64)
+    ro = torch.tensor([0.0], device=sensor_device, dtype=torch.float64)
+    proj = RowOffsetStructuredSpinningLidarProjection(
+        re.float(), ca.float(), ro.float(), 0.0, 0.0, -3.14159, 6.28318, 0, True
+    )
+    elements = torch.tensor([[0, 1]], device=sensor_device, dtype=torch.int32)
+    control_translations = torch.zeros(2, 3, device=sensor_device, dtype=torch.float64)
+    control_rotations = _slerp_branch_control_rotations(
+        branch, sensor_device, torch.float64
+    )
+    _assert_slerp_branch_predicate(control_rotations, branch)
+
+    re_g = re.clone().requires_grad_(True)
+    ca_g = ca.clone().requires_grad_(True)
+    ro_g = ro.clone().requires_grad_(True)
+    ct_g = control_translations.clone().requires_grad_(True)
+    cr_g = control_rotations.clone().requires_grad_(True)
+
+    def fn(a, b, c, t, r):
+        return _GenerateSpinningLidarRays.apply(elements, a, b, c, t, r, proj, 0, 1000)[
+            0
+        ]
 
     assert torch.autograd.gradcheck(
         fn, (re_g, ca_g, ro_g, ct_g, cr_g), **GRADCHECK_KWARGS

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6150,6 +6150,28 @@ def test_sh(sh_degree: int, batch_dims: Tuple[int, ...], packed: bool, D: int):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_sh_backward_accepts_strided_output_grad():
+    """SH backward should accept channel-slice gradients from downstream cats."""
+    from gsplat.cuda._wrapper import spherical_harmonics
+
+    torch.manual_seed(42)
+
+    N, K, D = 128, (3 + 1) ** 2, 3
+    dirs = torch.randn(2, N, 3, device=device, requires_grad=True)
+    coeffs = torch.randn(N, K, D, device=device, requires_grad=True)
+
+    colors = spherical_harmonics(3, dirs, coeffs)
+    grad_storage = torch.randn(2, N, D * 2, device=device)
+    v_colors = grad_storage[..., :D]
+    assert not v_colors.is_contiguous()
+
+    v_coeffs, v_dirs = torch.autograd.grad(colors, (coeffs, dirs), v_colors)
+
+    assert torch.isfinite(v_coeffs).all()
+    assert torch.isfinite(v_dirs).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 def test_sh_zero_channels():
     """Test that an error is thrown when D = 0 (i.e. empty per-Gaussian feature)"""
     from gsplat.cuda._wrapper import spherical_harmonics


### PR DESCRIPTION
## Stage 10 - sensor SLERP consolidation + autograd cleanup + compile-time trim

- `refactor(sensors): consolidate SLERP geometry helpers` + `fix(sensors): update fisheye SLERP call sites` + `refactor(sensors): address SLERP consolidation review feedback`.
- `Remove overly defensive dense/contiguous normalization for autograd outputs`.
- `Improve compile times by removing unused UseHitDistance template param`.

**Tests:** full dev:10 suite - 2654 passed, 0 failed.

Stacked on stage 09.