### PR TITLE
[NV] Dense 3DGS forward one-thread-per-pixel + contributing-launcher dedup

### DIFF
--- a/gsplat/cuda/csrc/RasterizeContributingGaussianIds.cu
+++ b/gsplat/cuda/csrc/RasterizeContributingGaussianIds.cu
@@ -23,8 +23,7 @@
 #    include <c10/cuda/CUDAStream.h>
 
 #    include "Rasterization.h"
-#    include "RasterizeContributingCommon.cuh"
-#    include "RasterizeContributingCommonSparse.cuh"
+#    include "RasterizeContributingLaunch.cuh"
 
 namespace gsplat
 {
@@ -91,6 +90,11 @@ struct ContributingIdsAccumulator
     }
 
     __device__ __forceinline__ void finalize(const uint32_t, const uint32_t, const int32_t) { }
+
+    int64_t extra_shmem_bytes(const uint32_t) const
+    {
+        return 0;
+    }
 };
 
 void launch_rasterize_contributing_gaussian_ids_kernel(
@@ -112,67 +116,29 @@ void launch_rasterize_contributing_gaussian_ids_kernel(
 )
 {
     const bool packed = means2d.dim() == 2;
-
-    const uint32_t N        = packed ? 0 : means2d.size(-2); // number of gaussians
-    const uint32_t I        = contributing_ids.numel() / (image_height * image_width * max_num_contributing);
-    const uint32_t grid_h   = tile_offsets.size(-2);
-    const uint32_t grid_w   = tile_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
-    const dim3 grid         = {I, grid_h, grid_w};
-
-    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
-    {
-        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
-        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
-        using Accumulator                    = ContributingIdsAccumulator<PIXELS_PER_THREAD>;
-        const int64_t shmem_size             = rasterize_contributing_common_shmem_size<CTA_SIZE>();
-
-        if(cudaFuncSetAttribute(
-               rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
-               cudaFuncAttributeMaxDynamicSharedMemorySize,
-               shmem_size
-           )
-           != cudaSuccess)
+    const uint32_t N  = packed ? 0 : means2d.size(-2); // number of gaussians
+    const uint32_t I  = contributing_ids.numel() / (image_height * image_width * max_num_contributing);
+    launch_contributing_dense(
+        means2d,
+        conics,
+        opacities,
+        I,
+        image_width,
+        image_height,
+        tile_size,
+        tile_offsets,
+        flatten_ids,
+        [&]<uint32_t PIXELS_PER_THREAD>()
         {
-            AT_ERROR(
-                "Failed to set maximum shared memory size (requested ", shmem_size, " bytes), try lowering tile_size."
-            );
+            return ContributingIdsAccumulator<PIXELS_PER_THREAD>{
+                N,
+                packed,
+                max_num_contributing,
+                contributing_ids.data_ptr<int32_t>(),
+                contributing_weights.data_ptr<float>(),
+            };
         }
-
-        Accumulator accum{
-            N,
-            packed,
-            max_num_contributing,
-            contributing_ids.data_ptr<int32_t>(),
-            contributing_weights.data_ptr<float>(),
-        };
-
-        rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
-            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                n_isects,
-                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
-                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
-                opacities.const_data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_offsets.const_data_ptr<int32_t>(),
-                flatten_ids.const_data_ptr<int32_t>(),
-                accum
-            );
-    };
-
-    if(tile_size == 16)
-    {
-        launch_variant.template operator()<16, 64>();
-    }
-    else if(tile_size == 4)
-    {
-        launch_variant.template operator()<4, 16>();
-    }
-    else
-    {
-        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
-    }
+    );
 }
 
 // Sparse counterpart: reuses ContributingIdsAccumulator with the sparse
@@ -202,75 +168,34 @@ void launch_rasterize_contributing_gaussian_ids_sparse_kernel(
     at::Tensor contributing_weights
 )
 {
-    const uint32_t AT = active_tiles.size(0);
-    if(AT == 0)
-    {
-        return;
-    }
-    const bool packed    = means2d.dim() == 2;
-    const uint32_t N     = packed ? 0 : means2d.size(-2);
-    const uint32_t words = tile_pixel_mask.size(1);
-    const dim3 grid      = {AT, 1, 1};
-
-    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
-    {
-        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
-        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
-        using Accumulator                    = ContributingIdsAccumulator<PIXELS_PER_THREAD>;
-        const int64_t shmem_size             = rasterize_contributing_common_shmem_size<CTA_SIZE>();
-
-        if(cudaFuncSetAttribute(
-               rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
-               cudaFuncAttributeMaxDynamicSharedMemorySize,
-               shmem_size
-           )
-           != cudaSuccess)
+    const bool packed = means2d.dim() == 2;
+    const uint32_t N  = packed ? 0 : means2d.size(-2);
+    launch_contributing_sparse(
+        means2d,
+        conics,
+        opacities,
+        image_width,
+        image_height,
+        tile_size,
+        tile_width,
+        tile_height,
+        active_tiles,
+        tile_offsets,
+        flatten_ids,
+        tile_pixel_mask,
+        tile_pixel_cumsum,
+        pixel_map,
+        [&]<uint32_t PIXELS_PER_THREAD>()
         {
-            AT_ERROR(
-                "Failed to set maximum shared memory size (requested ", shmem_size, " bytes), try lowering tile_size."
-            );
+            return ContributingIdsAccumulator<PIXELS_PER_THREAD>{
+                N,
+                packed,
+                max_num_contributing,
+                contributing_ids.data_ptr<int32_t>(),
+                contributing_weights.data_ptr<float>(),
+            };
         }
-
-        Accumulator accum{
-            N,
-            packed,
-            max_num_contributing,
-            contributing_ids.data_ptr<int32_t>(),
-            contributing_weights.data_ptr<float>(),
-        };
-
-        rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
-            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
-                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
-                opacities.const_data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_width,
-                tile_height,
-                active_tiles.const_data_ptr<int32_t>(),
-                tile_offsets.const_data_ptr<int32_t>(),
-                flatten_ids.const_data_ptr<int32_t>(),
-                reinterpret_cast<const uint64_t *>(tile_pixel_mask.const_data_ptr<int64_t>()),
-                tile_pixel_cumsum.const_data_ptr<int64_t>(),
-                pixel_map.const_data_ptr<int64_t>(),
-                words,
-                accum
-            );
-    };
-
-    if(tile_size == 16)
-    {
-        launch_variant.template operator()<16, 256>();
-    }
-    else if(tile_size == 4)
-    {
-        launch_variant.template operator()<4, 16>();
-    }
-    else
-    {
-        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
-    }
+    );
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/RasterizeContributingLaunch.cuh
+++ b/gsplat/cuda/csrc/RasterizeContributingLaunch.cuh
@@ -1,0 +1,197 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include "Common.h"
+#include "RasterizeContributingCommon.cuh"
+#include "RasterizeContributingCommonSparse.cuh"
+
+// Host-side launch boilerplate shared by the contributing-gaussian ops
+// (num-contributing, contributing-ids, top-contributing). Every op runs the
+// same traversal kernel (`rasterize_contributing_common_kernel` or its sparse
+// counterpart): the op-specific outputs live entirely in an Accumulator, so the
+// kernels are launched with an identical argument list apart from that
+// Accumulator. These helpers own the grid/shared-memory setup, the dynamic
+// shared-memory opt-in, and the tile_size -> (TILE_SIZE, CTA_SIZE) dispatch;
+// each op supplies only a `make_accum` factory.
+//
+// `make_accum` is a C++20 templated lambda
+// `[&]<uint32_t PIXELS_PER_THREAD>() { return SomeAccumulator<...>{...}; }`;
+// it is invoked once the dispatch has fixed PIXELS_PER_THREAD. Each Accumulator
+// reports any dynamic shared memory it needs beyond the batch staging buffers
+// via `extra_shmem_bytes(num_pixels_per_cta)`.
+
+namespace gsplat
+{
+template<class MakeAccum>
+void launch_contributing_dense(
+    const at::Tensor means2d,
+    const at::Tensor conics,
+    const at::Tensor opacities,
+    const uint32_t I,
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    const at::Tensor tile_offsets,
+    const at::Tensor flatten_ids,
+    MakeAccum make_accum
+)
+{
+    const uint32_t grid_h   = tile_offsets.size(-2);
+    const uint32_t grid_w   = tile_offsets.size(-1);
+    const uint32_t n_isects = flatten_ids.size(0);
+    const dim3 grid         = {I, grid_h, grid_w};
+
+    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
+    {
+        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
+        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
+        auto accum                           = make_accum.template operator()<PIXELS_PER_THREAD>();
+        using Accumulator                    = decltype(accum);
+        const int64_t shmem_size             = rasterize_contributing_common_shmem_size<CTA_SIZE>()
+                                             + accum.extra_shmem_bytes(CTA_SIZE * PIXELS_PER_THREAD);
+
+        if(cudaFuncSetAttribute(
+               rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
+               cudaFuncAttributeMaxDynamicSharedMemorySize,
+               shmem_size
+           )
+           != cudaSuccess)
+        {
+            AT_ERROR(
+                "Failed to set maximum shared memory size (requested ",
+                shmem_size,
+                " bytes), try lowering tile_size or num_depth_samples."
+            );
+        }
+
+        rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
+            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
+                n_isects,
+                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
+                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
+                opacities.const_data_ptr<float>(),
+                image_width,
+                image_height,
+                tile_offsets.const_data_ptr<int32_t>(),
+                flatten_ids.const_data_ptr<int32_t>(),
+                accum
+            );
+    };
+
+    if(tile_size == 16)
+    {
+        launch_variant.template operator()<16, 64>();
+    }
+    else if(tile_size == 4)
+    {
+        launch_variant.template operator()<4, 16>();
+    }
+    else
+    {
+        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
+    }
+}
+
+template<class MakeAccum>
+void launch_contributing_sparse(
+    const at::Tensor means2d,
+    const at::Tensor conics,
+    const at::Tensor opacities,
+    const uint32_t image_width,
+    const uint32_t image_height,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const at::Tensor active_tiles,
+    const at::Tensor tile_offsets,
+    const at::Tensor flatten_ids,
+    const at::Tensor tile_pixel_mask,
+    const at::Tensor tile_pixel_cumsum,
+    const at::Tensor pixel_map,
+    MakeAccum make_accum
+)
+{
+    const uint32_t AT = active_tiles.size(0);
+    if(AT == 0)
+    {
+        return;
+    }
+    const uint32_t words = tile_pixel_mask.size(1);
+    const dim3 grid      = {AT, 1, 1};
+
+    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
+    {
+        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
+        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
+        auto accum                           = make_accum.template operator()<PIXELS_PER_THREAD>();
+        using Accumulator                    = decltype(accum);
+        const int64_t shmem_size             = rasterize_contributing_common_shmem_size<CTA_SIZE>()
+                                             + accum.extra_shmem_bytes(CTA_SIZE * PIXELS_PER_THREAD);
+
+        if(cudaFuncSetAttribute(
+               rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
+               cudaFuncAttributeMaxDynamicSharedMemorySize,
+               shmem_size
+           )
+           != cudaSuccess)
+        {
+            AT_ERROR(
+                "Failed to set maximum shared memory size (requested ",
+                shmem_size,
+                " bytes), try lowering tile_size or num_depth_samples."
+            );
+        }
+
+        rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
+            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
+                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
+                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
+                opacities.const_data_ptr<float>(),
+                image_width,
+                image_height,
+                tile_width,
+                tile_height,
+                active_tiles.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int32_t>(),
+                flatten_ids.const_data_ptr<int32_t>(),
+                reinterpret_cast<const uint64_t *>(tile_pixel_mask.const_data_ptr<int64_t>()),
+                tile_pixel_cumsum.const_data_ptr<int64_t>(),
+                pixel_map.const_data_ptr<int64_t>(),
+                words,
+                accum
+            );
+    };
+
+    if(tile_size == 16)
+    {
+        launch_variant.template operator()<16, 256>();
+    }
+    else if(tile_size == 4)
+    {
+        launch_variant.template operator()<4, 16>();
+    }
+    else
+    {
+        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
+    }
+}
+} // namespace gsplat

--- a/gsplat/cuda/csrc/RasterizeNumContributingGaussians.cu
+++ b/gsplat/cuda/csrc/RasterizeNumContributingGaussians.cu
@@ -23,8 +23,7 @@
 #    include <c10/cuda/CUDAStream.h>
 
 #    include "Rasterization.h"
-#    include "RasterizeContributingCommon.cuh"
-#    include "RasterizeContributingCommonSparse.cuh"
+#    include "RasterizeContributingLaunch.cuh"
 
 namespace gsplat
 {
@@ -80,6 +79,11 @@ struct NumContributingAccumulator
         num_contributing[pix_id] = counts[p];
         alphas[pix_id]           = 1.0f - T[p];
     }
+
+    int64_t extra_shmem_bytes(const uint32_t) const
+    {
+        return 0;
+    }
 };
 
 void launch_rasterize_num_contributing_gaussians_kernel(
@@ -99,62 +103,25 @@ void launch_rasterize_num_contributing_gaussians_kernel(
     at::Tensor alphas
 )
 {
-    const uint32_t I        = num_contributing.numel() / (image_height * image_width);
-    const uint32_t grid_h   = tile_offsets.size(-2);
-    const uint32_t grid_w   = tile_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
-    const dim3 grid         = {I, grid_h, grid_w};
-
-    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
-    {
-        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
-        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
-        using Accumulator                    = NumContributingAccumulator<PIXELS_PER_THREAD>;
-        const int64_t shmem_size             = rasterize_contributing_common_shmem_size<CTA_SIZE>();
-
-        if(cudaFuncSetAttribute(
-               rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
-               cudaFuncAttributeMaxDynamicSharedMemorySize,
-               shmem_size
-           )
-           != cudaSuccess)
+    const uint32_t I = num_contributing.numel() / (image_height * image_width);
+    launch_contributing_dense(
+        means2d,
+        conics,
+        opacities,
+        I,
+        image_width,
+        image_height,
+        tile_size,
+        tile_offsets,
+        flatten_ids,
+        [&]<uint32_t PIXELS_PER_THREAD>()
         {
-            AT_ERROR(
-                "Failed to set maximum shared memory size (requested ", shmem_size, " bytes), try lowering tile_size."
-            );
+            return NumContributingAccumulator<PIXELS_PER_THREAD>{
+                num_contributing.data_ptr<int32_t>(),
+                alphas.data_ptr<float>(),
+            };
         }
-
-        Accumulator accum{
-            num_contributing.data_ptr<int32_t>(),
-            alphas.data_ptr<float>(),
-        };
-
-        rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
-            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                n_isects,
-                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
-                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
-                opacities.const_data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_offsets.const_data_ptr<int32_t>(),
-                flatten_ids.const_data_ptr<int32_t>(),
-                accum
-            );
-    };
-
-    if(tile_size == 16)
-    {
-        launch_variant.template operator()<16, 64>();
-    }
-    else if(tile_size == 4)
-    {
-        launch_variant.template operator()<4, 16>();
-    }
-    else
-    {
-        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
-    }
+    );
 }
 
 // Sparse counterpart: reuses NumContributingAccumulator with the sparse
@@ -183,70 +150,29 @@ void launch_rasterize_num_contributing_gaussians_sparse_kernel(
     at::Tensor alphas
 )
 {
-    const uint32_t AT = active_tiles.size(0);
-    if(AT == 0)
-    {
-        return;
-    }
-    const uint32_t words = tile_pixel_mask.size(1);
-    const dim3 grid      = {AT, 1, 1};
-
-    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
-    {
-        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
-        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
-        using Accumulator                    = NumContributingAccumulator<PIXELS_PER_THREAD>;
-        const int64_t shmem_size             = rasterize_contributing_common_shmem_size<CTA_SIZE>();
-
-        if(cudaFuncSetAttribute(
-               rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
-               cudaFuncAttributeMaxDynamicSharedMemorySize,
-               shmem_size
-           )
-           != cudaSuccess)
+    launch_contributing_sparse(
+        means2d,
+        conics,
+        opacities,
+        image_width,
+        image_height,
+        tile_size,
+        tile_width,
+        tile_height,
+        active_tiles,
+        tile_offsets,
+        flatten_ids,
+        tile_pixel_mask,
+        tile_pixel_cumsum,
+        pixel_map,
+        [&]<uint32_t PIXELS_PER_THREAD>()
         {
-            AT_ERROR(
-                "Failed to set maximum shared memory size (requested ", shmem_size, " bytes), try lowering tile_size."
-            );
+            return NumContributingAccumulator<PIXELS_PER_THREAD>{
+                num_contributing.data_ptr<int32_t>(),
+                alphas.data_ptr<float>(),
+            };
         }
-
-        Accumulator accum{
-            num_contributing.data_ptr<int32_t>(),
-            alphas.data_ptr<float>(),
-        };
-
-        rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
-            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
-                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
-                opacities.const_data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_width,
-                tile_height,
-                active_tiles.const_data_ptr<int32_t>(),
-                tile_offsets.const_data_ptr<int32_t>(),
-                flatten_ids.const_data_ptr<int32_t>(),
-                reinterpret_cast<const uint64_t *>(tile_pixel_mask.const_data_ptr<int64_t>()),
-                tile_pixel_cumsum.const_data_ptr<int64_t>(),
-                pixel_map.const_data_ptr<int64_t>(),
-                words,
-                accum
-            );
-    };
-
-    if(tile_size == 16)
-    {
-        launch_variant.template operator()<16, 256>();
-    }
-    else if(tile_size == 4)
-    {
-        launch_variant.template operator()<4, 16>();
-    }
-    else
-    {
-        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
-    }
+    );
 }
 } // namespace gsplat
 

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
@@ -393,9 +393,14 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
         // When we also convert the 3DGS backward rasterizer pass, it will require much
         // less shared memory since we're iterating with PPT=4 and will therefore be able
         // to remove tile_size=4 both here and in test_basic.py.
+        // One thread per pixel (CTA=256, PIXELS_PER_THREAD=1) at tile_size=16.
+        // CTA=64 (PPT=4) keeps a pix_out[PPT][CDIM] accumulator per thread, whose
+        // register footprint scales with 4*CDIM and spills to local memory at high
+        // channel counts (~10x slower forward at CDIM=128). PPT=1 makes register
+        // pressure scale with CDIM alone; it is parity at CDIM=3 (see issue #8).
         if(tile_size == 16)
         {
-            launch_variant.template operator()<16, 64>();
+            launch_variant.template operator()<16, 256>();
         }
         else if(tile_size == 4)
         {
@@ -512,9 +517,14 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernels(
             }
         };
 
+        // One thread per pixel (CTA=256, PIXELS_PER_THREAD=1) at tile_size=16.
+        // CTA=64 (PPT=4) keeps a pix_out[PPT][CDIM] accumulator per thread, whose
+        // register footprint scales with 4*CDIM and spills to local memory at high
+        // channel counts (~10x slower forward at CDIM=128). PPT=1 makes register
+        // pressure scale with CDIM alone; it is parity at CDIM=3 (see issue #8).
         if(tile_size == 16)
         {
-            launch_variant.template operator()<16, 64>();
+            launch_variant.template operator()<16, 256>();
         }
         else if(tile_size == 4)
         {

--- a/gsplat/cuda/csrc/RasterizeTopContributingGaussianIds.cu
+++ b/gsplat/cuda/csrc/RasterizeTopContributingGaussianIds.cu
@@ -23,8 +23,7 @@
 #    include <c10/cuda/CUDAStream.h>
 
 #    include "Rasterization.h"
-#    include "RasterizeContributingCommon.cuh"
-#    include "RasterizeContributingCommonSparse.cuh"
+#    include "RasterizeContributingLaunch.cuh"
 
 namespace gsplat
 {
@@ -165,6 +164,15 @@ struct TopContributingIdsAccumulator
             top_weights[out_base + k] = sample_weights[sample_base + k];
         }
     }
+
+    // Per-pixel top-K sample scratch (ids + weights + depths), laid out by
+    // init_shared above; the common batch staging buffers are sized separately.
+    int64_t extra_shmem_bytes(const uint32_t num_pixels_per_cta) const
+    {
+        return static_cast<int64_t>(num_pixels_per_cta)
+             * num_depth_samples
+             * (sizeof(int32_t) + sizeof(float) + sizeof(uint32_t));
+    }
 };
 
 void launch_rasterize_top_contributing_gaussian_ids_kernel(
@@ -186,72 +194,29 @@ void launch_rasterize_top_contributing_gaussian_ids_kernel(
 )
 {
     const bool packed = means2d.dim() == 2;
-
-    const uint32_t N        = packed ? 0 : means2d.size(-2); // number of gaussians
-    const uint32_t I        = top_ids.numel() / (image_height * image_width * num_depth_samples);
-    const uint32_t grid_h   = tile_offsets.size(-2);
-    const uint32_t grid_w   = tile_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
-    const dim3 grid         = {I, grid_h, grid_w};
-
-    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
-    {
-        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
-        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
-        using Accumulator                    = TopContributingIdsAccumulator<PIXELS_PER_THREAD>;
-        const uint32_t num_pixels_per_cta    = CTA_SIZE * PIXELS_PER_THREAD;
-        const int64_t shmem_size
-            = rasterize_contributing_common_shmem_size<CTA_SIZE>()
-            + num_pixels_per_cta * num_depth_samples * (sizeof(int32_t) + sizeof(float) + sizeof(uint32_t));
-
-        if(cudaFuncSetAttribute(
-               rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
-               cudaFuncAttributeMaxDynamicSharedMemorySize,
-               shmem_size
-           )
-           != cudaSuccess)
+    const uint32_t N  = packed ? 0 : means2d.size(-2); // number of gaussians
+    const uint32_t I  = top_ids.numel() / (image_height * image_width * num_depth_samples);
+    launch_contributing_dense(
+        means2d,
+        conics,
+        opacities,
+        I,
+        image_width,
+        image_height,
+        tile_size,
+        tile_offsets,
+        flatten_ids,
+        [&]<uint32_t PIXELS_PER_THREAD>()
         {
-            AT_ERROR(
-                "Failed to set maximum shared memory size (requested ",
-                shmem_size,
-                " bytes), try lowering tile_size or num_depth_samples."
-            );
+            return TopContributingIdsAccumulator<PIXELS_PER_THREAD>{
+                N,
+                packed,
+                num_depth_samples,
+                top_ids.data_ptr<int32_t>(),
+                top_weights.data_ptr<float>(),
+            };
         }
-
-        Accumulator accum{
-            N,
-            packed,
-            num_depth_samples,
-            top_ids.data_ptr<int32_t>(),
-            top_weights.data_ptr<float>(),
-        };
-
-        rasterize_contributing_common_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
-            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                n_isects,
-                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
-                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
-                opacities.const_data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_offsets.const_data_ptr<int32_t>(),
-                flatten_ids.const_data_ptr<int32_t>(),
-                accum
-            );
-    };
-
-    if(tile_size == 16)
-    {
-        launch_variant.template operator()<16, 64>();
-    }
-    else if(tile_size == 4)
-    {
-        launch_variant.template operator()<4, 16>();
-    }
-    else
-    {
-        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
-    }
+    );
 }
 
 // Sparse counterpart: reuses TopContributingIdsAccumulator with the sparse
@@ -281,80 +246,34 @@ void launch_rasterize_top_contributing_gaussian_ids_sparse_kernel(
     at::Tensor top_weights
 )
 {
-    const uint32_t AT = active_tiles.size(0);
-    if(AT == 0)
-    {
-        return;
-    }
-    const bool packed    = means2d.dim() == 2;
-    const uint32_t N     = packed ? 0 : means2d.size(-2);
-    const uint32_t words = tile_pixel_mask.size(1);
-    const dim3 grid      = {AT, 1, 1};
-
-    auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
-    {
-        const dim3 threads                   = dim3{CTA_SIZE, 1, 1};
-        constexpr uint32_t PIXELS_PER_THREAD = TILE_SIZE * TILE_SIZE / CTA_SIZE;
-        using Accumulator                    = TopContributingIdsAccumulator<PIXELS_PER_THREAD>;
-        const uint32_t num_pixels_per_cta    = CTA_SIZE * PIXELS_PER_THREAD;
-        const int64_t shmem_size
-            = rasterize_contributing_common_shmem_size<CTA_SIZE>()
-            + num_pixels_per_cta * num_depth_samples * (sizeof(int32_t) + sizeof(float) + sizeof(uint32_t));
-
-        if(cudaFuncSetAttribute(
-               rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>,
-               cudaFuncAttributeMaxDynamicSharedMemorySize,
-               shmem_size
-           )
-           != cudaSuccess)
+    const bool packed = means2d.dim() == 2;
+    const uint32_t N  = packed ? 0 : means2d.size(-2);
+    launch_contributing_sparse(
+        means2d,
+        conics,
+        opacities,
+        image_width,
+        image_height,
+        tile_size,
+        tile_width,
+        tile_height,
+        active_tiles,
+        tile_offsets,
+        flatten_ids,
+        tile_pixel_mask,
+        tile_pixel_cumsum,
+        pixel_map,
+        [&]<uint32_t PIXELS_PER_THREAD>()
         {
-            AT_ERROR(
-                "Failed to set maximum shared memory size (requested ",
-                shmem_size,
-                " bytes), try lowering tile_size or num_depth_samples."
-            );
+            return TopContributingIdsAccumulator<PIXELS_PER_THREAD>{
+                N,
+                packed,
+                num_depth_samples,
+                top_ids.data_ptr<int32_t>(),
+                top_weights.data_ptr<float>(),
+            };
         }
-
-        Accumulator accum{
-            N,
-            packed,
-            num_depth_samples,
-            top_ids.data_ptr<int32_t>(),
-            top_weights.data_ptr<float>(),
-        };
-
-        rasterize_contributing_common_sparse_kernel<TILE_SIZE, CTA_SIZE, Accumulator>
-            <<<grid, threads, shmem_size, at::cuda::getCurrentCUDAStream()>>>(
-                reinterpret_cast<const vec2 *>(means2d.const_data_ptr<float>()),
-                reinterpret_cast<const vec3 *>(conics.const_data_ptr<float>()),
-                opacities.const_data_ptr<float>(),
-                image_width,
-                image_height,
-                tile_width,
-                tile_height,
-                active_tiles.const_data_ptr<int32_t>(),
-                tile_offsets.const_data_ptr<int32_t>(),
-                flatten_ids.const_data_ptr<int32_t>(),
-                reinterpret_cast<const uint64_t *>(tile_pixel_mask.const_data_ptr<int64_t>()),
-                tile_pixel_cumsum.const_data_ptr<int64_t>(),
-                pixel_map.const_data_ptr<int64_t>(),
-                words,
-                accum
-            );
-    };
-
-    if(tile_size == 16)
-    {
-        launch_variant.template operator()<16, 256>();
-    }
-    else if(tile_size == 4)
-    {
-        launch_variant.template operator()<4, 16>();
-    }
-    else
-    {
-        AT_ERROR("Unsupported tile_size ", tile_size, "; supported values are {4, 16}.");
-    }
+    );
 }
 } // namespace gsplat
 


### PR DESCRIPTION
## Stage 11 - dense forward perf + launcher dedup

- `perf(cuda): one thread per pixel in dense 3DGS forward (tile_size=16)`.
- `refactor(cuda): single-source contributing-gaussian launcher boilerplate` (adds `RasterizeContributingLaunch.cuh`).

**Tests:** full dev:10 suite - 2654 passed, 0 failed.

Stacked on stage 10.