### PR TITLE
Fix cudaEventCreate build error in Utils.cpp merge_streams

### DIFF
--- a/gsplat/cuda/csrc/Utils.cpp
+++ b/gsplat/cuda/csrc/Utils.cpp
@@ -36,12 +36,12 @@ void merge_streams()
     {
         C10_CUDA_CHECK(cudaSetDevice(device_id));
         auto stream = c10::cuda::getCurrentCUDAStream(device_id);
-        C10_CUDA_CHECK(cudaEventCreate(&events[device_id], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[device_id], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[device_id], stream));
     }
 
     C10_CUDA_CHECK(cudaSetDevice(merge_device_id));
-    C10_CUDA_CHECK(cudaEventCreate(&merge_event, cudaEventDisableTiming));
+    C10_CUDA_CHECK(cudaEventCreateWithFlags(&merge_event, cudaEventDisableTiming));
     auto merge_stream = c10::cuda::getCurrentCUDAStream(merge_device_id);
     for(const auto device_id: c10::irange(c10::cuda::device_count()))
     {


### PR DESCRIPTION
## Problem

`merge_streams()` in `gsplat/cuda/csrc/Utils.cpp` (added in #1019  / commit 4561ac47) calls `cudaEventCreate` with two arguments:

```cpp
C10_CUDA_CHECK(cudaEventCreate(&events[device_id], cudaEventDisableTiming));
```

The C runtime function `cudaEventCreate` takes a single argument. The two-argument form is a C++ convenience overload declared in `cuda_runtime.h`, which is not in scope here: `Utils.cpp` is compiled by the host C++ compiler and only pulls in `cuda_runtime_api.h` (directly and via the c10 CUDA headers). In environments where `cuda_runtime.h` isn't otherwise dragged in, the build fails:

```
gsplat/cuda/csrc/Utils.cpp:39:39: error: too many arguments to function 'cudaError_t cudaEventCreate(CUevent_st**)'
```

(Observed building with pip from source on CUDA 12.9 / torch 2.x / gcc, Ubuntu 22.04. The same pattern works in `.cu` files because nvcc auto-includes `cuda_runtime.h`.)

## Fix

Use `cudaEventCreateWithFlags`, the C API function intended for passing `cudaEventDisableTiming`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)