### PR TITLE
Guard MCMC refinement against empty live sets

### DIFF
--- a/gsplat/strategy/ops.py
+++ b/gsplat/strategy/ops.py
@@ -92,6 +92,18 @@ def _multinomial_sample(weights: Tensor, n: int, replacement: bool = True) -> Te
         return sampled_idxs.to(weights.device)
 
 
+def _ensure_live_gaussians(
+    opacities: Tensor, min_opacity: float, operation: str
+) -> None:
+    if not torch.any(opacities > min_opacity).item():
+        raise RuntimeError(
+            f"MCMC {operation} cannot continue because there are no live Gaussians "
+            f"with opacity above min_opacity={min_opacity}. Restore a checkpoint "
+            "with live Gaussians, or lower min_opacity or the opacity "
+            "regularization strength."
+        )
+
+
 @torch.no_grad()
 def _update_param_with_optimizer(
     param_fn: Callable[[str, Tensor], Tensor],
@@ -323,6 +335,8 @@ def relocate(
     n = len(dead_indices)
 
     # Sample for new GSs
+    if n > 0:
+        _ensure_live_gaussians(opacities[alive_indices], min_opacity, "relocation")
     probs = opacities[alive_indices].flatten()  # ensure its shape is [N,]
     sampled_idxs = _multinomial_sample(probs, n, replacement=True)
     sampled_idxs = alive_indices[sampled_idxs]
@@ -368,6 +382,8 @@ def sample_add(
 ):
     opacities = torch.sigmoid(params["opacities"])
 
+    if n > 0:
+        _ensure_live_gaussians(opacities, min_opacity, "growth")
     probs = opacities.flatten()
     sampled_idxs = _multinomial_sample(probs, n, replacement=True)
     new_opacities, new_scales = compute_relocation(

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -46,6 +46,31 @@ def test_mcmc_strategy_positional_constructor():
     assert strategy.noise_opacity_k == 30.0
 
 
+@pytest.mark.parametrize("operation", ["relocate", "add"])
+def test_mcmc_strategy_rejects_empty_live_set(operation):
+    from gsplat.strategy import MCMCStrategy
+
+    n_gaussians = 20
+    params = torch.nn.ParameterDict(
+        {
+            "means": torch.zeros(n_gaussians, 3),
+            "scales": torch.zeros(n_gaussians, 3),
+            "quats": torch.zeros(n_gaussians, 4),
+            "opacities": torch.logit(torch.full((n_gaussians,), 0.001)),
+        }
+    )
+    strategy = MCMCStrategy(cap_max=n_gaussians + 1, min_opacity=0.005)
+    binoms = strategy.initialize_state()["binoms"]
+
+    with pytest.raises(RuntimeError, match=r"no live Gaussians.*min_opacity=0\.005"):
+        if operation == "relocate":
+            strategy._relocate_gs(params, {}, binoms)
+        else:
+            strategy._add_new_gs(params, {}, binoms)
+
+    assert len(params["means"]) == n_gaussians
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
 def test_strategy():


### PR DESCRIPTION
## Summary

- fail fast when MCMC refinement has no Gaussians above `min_opacity`
- guard both dead-Gaussian relocation and capacity growth before multinomial/CUDA work
- return an actionable recovery message without mutating model parameters
- add CPU-only regression coverage for both refinement paths

Fixes #1027

## Testing

- `CUDA_HOME=/nonexistent PATH=/root/miniconda3/bin:/usr/bin:/bin python -m pytest tests/test_strategy.py -q` (3 passed, 2 skipped)
- `lint/format-code.sh --check --changed origin/main`
- `python -m compileall -q gsplat/strategy/ops.py tests/test_strategy.py`
- `git diff --check`

The regression test intentionally disables the local CUDA toolkit so it verifies the error is raised before any native CUDA operator is needed.