### PR TITLE
Add weighted-median LiDAR return rendering

### DIFF
--- a/gsplat/__init__.py
+++ b/gsplat/__init__.py
@@ -62,6 +62,7 @@ from .cuda._wrapper import (
 from .exporter import export_splats
 from .optimizers import SelectiveAdam
 from .rendering import (
+    LidarReturnMode,
     RasterizeMode,
     RendererConfig,
     RendererConfig_MixedBatch,
@@ -111,6 +112,7 @@ __all__ = [
     "CameraModel",
     "ExternalDistortionModelMeta",
     "ExternalDistortionModelParameters",
+    "LidarReturnMode",
     "RasterizeMode",
     "RendererConfig",
     "RendererConfig_MixedBatch",

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -2131,6 +2131,7 @@ def rasterize_to_pixels_eval3d(
     use_hit_distance: bool = False,
     return_normals: bool = False,
     renderer_config: Any = None,
+    use_median_hit_distance: bool = False,
 ) -> Tuple[Tensor, Tensor]:
     """Rasterizes Gaussians to pixels.
 
@@ -2186,6 +2187,7 @@ def rasterize_to_pixels_eval3d(
         return_last_ids=False,
         return_sample_counts=False,
         use_hit_distance=use_hit_distance,
+        use_median_hit_distance=use_median_hit_distance,
         return_normals=return_normals,
         renderer_config=renderer_config,
     )
@@ -2227,6 +2229,7 @@ def rasterize_to_pixels_eval3d_extra(
     renderer_config: Any = None,
     return_last_ids: bool = True,
     unsafe_masked_tile_outputs: bool = False,
+    use_median_hit_distance: bool = False,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor]]:
     """Rasterizes Gaussians to pixels, returning extra information for debugging.
 
@@ -2317,6 +2320,7 @@ def rasterize_to_pixels_eval3d_extra(
         renderer_config,
         return_last_ids,
         unsafe_masked_tile_outputs,
+        use_median_hit_distance,
     )
 
     return render_colors, render_alphas, last_ids, sample_counts, render_normals

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -2402,6 +2402,7 @@ RasterizeToPixelsFromWorld3DGSFwdResult rasterize_to_pixels_from_world_3dgs_fwd(
     const at::Tensor tile_offsets, // [..., C, tile_height, tile_width]
     const at::Tensor flatten_ids,  // [n_isects]
     const bool use_hit_distance,
+    const bool use_median_hit_distance,
     const RendererConfig renderer_config,
     const bool fwd_only,
     const bool return_last_ids,
@@ -2449,6 +2450,18 @@ RasterizeToPixelsFromWorld3DGSFwdResult rasterize_to_pixels_from_world_3dgs_fwd(
         !fwd_only || !sample_counts.has_value(),
         "fwd-only eval3d rasterization cannot return sample_counts; "
         "request exact metadata instead"
+    );
+    TORCH_CHECK(
+        !use_median_hit_distance || use_hit_distance,
+        "use_median_hit_distance requires use_hit_distance=True"
+    );
+    TORCH_CHECK(
+        !use_median_hit_distance || camera_model == CameraModelType::LIDAR,
+        "use_median_hit_distance requires camera_model=LIDAR"
+    );
+    TORCH_CHECK(
+        !use_median_hit_distance || renderer_config == RendererConfig::MIXED_BATCH,
+        "use_median_hit_distance only supports RendererConfig::MIXED_BATCH"
     );
 
     // Validate inputs.
@@ -2733,6 +2746,7 @@ RasterizeToPixelsFromWorld3DGSFwdResult rasterize_to_pixels_from_world_3dgs_fwd(
             tile_offsets,
             flatten_ids,
             use_hit_distance,
+            use_median_hit_distance,
             unsafe_masked_tile_outputs,
             batches_per_tile,
             batch_offsets,
@@ -3251,6 +3265,7 @@ namespace
                 tile_offsets,
                 flatten_ids,
                 use_hit_distance,
+                false, // use_median_hit_distance (autograd path unsupported)
                 parsed_renderer_config,
                 /*fwd_only=*/false,
                 /*return_last_ids=*/true,
@@ -3475,7 +3490,8 @@ RasterizeToPixelsFromWorld3DGSResult rasterize_to_pixels_from_world_3dgs(
     bool return_normals,
     int64_t renderer_config,
     bool return_last_ids,
-    bool unsafe_masked_tile_outputs
+    bool unsafe_masked_tile_outputs,
+    bool use_median_hit_distance
 )
 {
 #if !GSPLAT_BUILD_3DGUT
@@ -3538,6 +3554,7 @@ RasterizeToPixelsFromWorld3DGSResult rasterize_to_pixels_from_world_3dgs(
             tile_offsets,
             flatten_ids,
             use_hit_distance,
+            use_median_hit_distance,
             parsed_renderer_config,
             /*fwd_only=*/fwd_only,
             return_last_ids,
@@ -3554,6 +3571,10 @@ RasterizeToPixelsFromWorld3DGSResult rasterize_to_pixels_from_world_3dgs(
         };
     }
 
+    TORCH_CHECK(
+        !use_median_hit_distance,
+        "use_median_hit_distance is inference-only and does not support autograd"
+    );
     return RasterizeToPixelsFromWorld3DGSAutograd::call(
         means,
         quats,

--- a/gsplat/cuda/csrc/Rasterization.h
+++ b/gsplat/cuda/csrc/Rasterization.h
@@ -548,6 +548,7 @@ RasterizeToPixelsFromWorld3DGSFwdResult rasterize_to_pixels_from_world_3dgs_fwd(
     const at::Tensor tile_offsets, // [..., C, tile_height, tile_width]
     const at::Tensor flatten_ids,  // [n_isects]
     bool use_hit_distance,
+    bool use_median_hit_distance,
     RendererConfig renderer_config,
     bool fwd_only,
     bool return_last_ids,
@@ -625,6 +626,7 @@ RasterizeToPixelsFromWorld3DGSResult rasterize_to_pixels_from_world_3dgs(
     bool return_normals,
     int64_t renderer_config,
     bool return_last_ids,
-    bool unsafe_masked_tile_outputs
+    bool unsafe_masked_tile_outputs,
+    bool use_median_hit_distance
 );
 } // namespace gsplat

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.cuh
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.cuh
@@ -661,6 +661,7 @@ __device__ __forceinline__ void process_fetch_round_blend(
     const uint32_t batch_start,
     const uint32_t batch_size,
     const scalar_t *__restrict__ colors,
+    const bool use_median_hit_distance,
     const vec3 (&ray_o)[PIXELS_PER_THREAD_T],
     const vec3 (&ray_d)[PIXELS_PER_THREAD_T],
     const uint32_t ALL_DONE,
@@ -746,8 +747,24 @@ __device__ __forceinline__ void process_fetch_round_blend(
 #pragma unroll
                 for(uint32_t k = 0; k < CDIM; ++k)
                 {
-                    const float value  = (k == CDIM - 1) ? hit_distance : c_ptr[k];
-                    pix_out[p][k]     += value * vis;
+                    if(k == CDIM - 1)
+                    {
+                        if(use_median_hit_distance)
+                        {
+                            if(T[p] > 0.5f && next_T <= 0.5f)
+                            {
+                                pix_out[p][k] = hit_distance;
+                            }
+                        }
+                        else
+                        {
+                            pix_out[p][k] += hit_distance * vis;
+                        }
+                    }
+                    else
+                    {
+                        pix_out[p][k] += c_ptr[k] * vis;
+                    }
                 }
             }
             else
@@ -818,6 +835,7 @@ __device__ __forceinline__ bool process_logical_batch_gaussians(
     const vec3 *__restrict__ scales,
     const scalar_t *__restrict__ opacities,
     const scalar_t *__restrict__ colors,
+    const bool use_median_hit_distance,
     const uint32_t C,
     const uint32_t N,
     const vec3 (&ray_o)[PIXELS_PER_THREAD_T],
@@ -897,6 +915,7 @@ __device__ __forceinline__ bool process_logical_batch_gaussians(
           batch_start,
           batch_size,
           colors,
+          use_median_hit_distance,
           ray_o,
           ray_d,
           ALL_DONE,

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.h
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.h
@@ -64,6 +64,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_kernel(
     const at::Tensor tile_offsets, // [..., C, tile_height, tile_width]
     const at::Tensor flatten_ids,  // [n_isects]
     const bool use_hit_distance,
+    const bool use_median_hit_distance,
     const bool unsafe_masked_tile_outputs,
     // CSR batch structure (precomputed by caller, shared with bwd)
     const at::Tensor batches_per_tile, // [num_tiles] int32

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
@@ -252,6 +252,7 @@ __device__ __forceinline__ void process_batch_gaussians_fwd(
         scales,
         opacities,
         colors,
+        false, // weighted-median hit distance is MixedBatch-only
         C,
         N,
         // Per-pixel rays and accumulation state.

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
@@ -96,6 +96,7 @@ __global__ void
         // intersections
         const int32_t *__restrict__ isect_offsets, // [B, C, tile_height, tile_width]
         const int32_t *__restrict__ flatten_ids,   // [n_isects]
+        const bool use_median_hit_distance,
         float *__restrict__ render_colors,         // [B, C, image_height, image_width, CDIM]
         float *__restrict__ render_alphas,         // [B, C, image_height, image_width, 1]
         float *__restrict__ render_normals,        // [B, C, image_height, image_width, 3] optional
@@ -440,6 +441,7 @@ __global__ void
             scales,
             opacities,
             colors,
+            use_median_hit_distance,
             C,
             N,
             // Per-pixel rays and accumulation state.
@@ -564,6 +566,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_impl(
     const at::Tensor isect_offsets, // [..., C, grid_h, grid_w]
     const at::Tensor flatten_ids,   // [n_isects]
     const bool use_hit_distance,
+    const bool use_median_hit_distance,
     const bool unsafe_masked_tile_outputs,
     // CSR batch structure (precomputed by caller, shared with bwd)
     const at::Tensor batches_per_tile, // [num_tiles] int32
@@ -726,6 +729,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_impl(
             // intersections
             isect_offsets.const_data_ptr<int32_t>(),
             flatten_ids.const_data_ptr<int32_t>(),
+            use_median_hit_distance,
             renders.data_ptr<float>(),
             alphas.data_ptr<float>(),
             data_ptr_or_null<float>(normals),
@@ -780,6 +784,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_kernel(
     const at::Tensor isect_offsets, // [..., C, grid_h, grid_w]
     const at::Tensor flatten_ids,   // [n_isects]
     const bool use_hit_distance,
+    const bool use_median_hit_distance,
     const bool unsafe_masked_tile_outputs,
     // CSR batch structure (precomputed by caller, shared with bwd)
     const at::Tensor batches_per_tile, // [num_tiles] int32
@@ -821,6 +826,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_kernel(
         isect_offsets,
         flatten_ids,
         use_hit_distance,
+        use_median_hit_distance,
         unsafe_masked_tile_outputs,
         batches_per_tile,
         batch_offsets,

--- a/gsplat/cuda/csrc/Rendering.cpp
+++ b/gsplat/cuda/csrc/Rendering.cpp
@@ -131,6 +131,7 @@ namespace
         ShutterType rolling_shutter,
         bool global_z_order,
         bool use_hit_distance,
+        bool use_median_hit_distance,
         bool return_normals,
         bool distributed
     )
@@ -273,6 +274,10 @@ namespace
             );
         }
         TORCH_CHECK(!use_hit_distance || with_eval3d, "hit-distance render modes require with_eval3d=True");
+        TORCH_CHECK(
+            !use_median_hit_distance || (is_lidar_camera && with_eval3d && use_hit_distance),
+            "median hit distance requires LiDAR Eval3D hit-distance rendering"
+        );
         TORCH_CHECK(!return_normals || with_eval3d, "return_normals=True requires with_eval3d=True");
         TORCH_CHECK(!sparse_grad || packed, "sparse_grad is only supported when packed is True");
         TORCH_CHECK(!sparse_grad || means.dim() == 2, "sparse_grad does not support batch dimensions");
@@ -856,7 +861,8 @@ Rasterization3DGSResult rasterization_3dgs(
     bool return_normals,
     int64_t renderer_config,
     const at::optional<std::string> &process_group_name,
-    int64_t world_size
+    int64_t world_size,
+    bool use_median_hit_distance
 )
 {
     DEVICE_GUARD(means);
@@ -903,6 +909,7 @@ Rasterization3DGSResult rasterization_3dgs(
         rolling_shutter,
         global_z_order,
         use_hit_distance,
+        use_median_hit_distance,
         return_normals,
         distributed
     );
@@ -1423,6 +1430,9 @@ Rasterization3DGSResult rasterization_3dgs(
     {
         const int64_t end         = std::min(start + channel_chunk, channels);
         at::Tensor features_chunk = channel_chunk_or_contiguous(projected_features, start, end);
+        const bool chunk_uses_hit_distance
+            = use_hit_distance && (!use_median_hit_distance || end == channels);
+        const bool chunk_uses_median_hit_distance = use_median_hit_distance && end == channels;
         at::optional<at::Tensor> backgrounds_chunk;
         if(render_backgrounds.has_value())
         {
@@ -1459,11 +1469,12 @@ Rasterization3DGSResult rasterization_3dgs(
                 raster_isect_offsets,
                 raster_flatten_ids,
                 false, // return_sample_counts
-                use_hit_distance,
+                chunk_uses_hit_distance,
                 return_normals && start == 0,
                 renderer_config,
                 false, // return_last_ids
-                false  // unsafe_masked_tile_outputs (safe default: masked tiles write defined outputs)
+                false, // unsafe_masked_tile_outputs (safe default: masked tiles write defined outputs)
+                chunk_uses_median_hit_distance
             );
             render_color_chunks.push_back(raster.renders);
             if(!render_alphas.defined())
@@ -1528,7 +1539,7 @@ Rasterization3DGSResult rasterization_3dgs(
         render_alphas,
         extra_signals.has_value(),
         append_depth,
-        expected_depth,
+        expected_depth && !use_median_hit_distance,
         primary_channels,
         extra_signal_channels
     );

--- a/gsplat/cuda/ext.cpp
+++ b/gsplat/cuda/ext.cpp
@@ -1137,7 +1137,7 @@ TORCH_LIBRARY(gsplat, m)
         "__torch__.torch.classes.gsplat.RowOffsetStructuredSpinningLidarModelParametersExt? lidar_coeffs, "
         "__torch__.torch.classes.gsplat.BivariateWindshieldModelParameters? external_distortion_params, bool "
         "global_z_order, bool use_hit_distance, bool return_normals, int renderer_config, str? process_group_name, int "
-        "world_size) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, "
+        "world_size, bool use_median_hit_distance=False) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, "
         "Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, int, int)"
     );
 #endif
@@ -1230,7 +1230,8 @@ TORCH_LIBRARY(gsplat, m)
         "__torch__.torch.classes.gsplat.RowOffsetStructuredSpinningLidarModelParametersExt? lidar_coeffs, "
         "__torch__.torch.classes.gsplat.BivariateWindshieldModelParameters? external_distortion_params, Tensor "
         "tile_offsets, Tensor flatten_ids, bool return_sample_counts, bool use_hit_distance, bool return_normals, int "
-        "renderer_config, bool return_last_ids, bool unsafe_masked_tile_outputs=False) -> (Tensor, Tensor, Tensor?, "
+        "renderer_config, bool return_last_ids, bool unsafe_masked_tile_outputs=False, bool "
+        "use_median_hit_distance=False) -> (Tensor, Tensor, Tensor?, "
         "Tensor?, Tensor?)"
     );
 

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -63,6 +63,7 @@ _POST_CODE = {"none": 0, "shift": 1, "shift_relu": 2}
 # Hit distance modes (d/Ed): compute along-ray distance in rasterization
 RenderMode = Literal["RGB", "d", "Ed", "D", "ED", "RGB-d", "RGB-Ed", "RGB+D", "RGB+ED"]
 RasterizeMode = Literal["classic", "antialiased"]
+LidarReturnMode = Literal["expected", "median"]
 
 
 class RendererConfig:
@@ -287,6 +288,7 @@ def rasterization(
         int
     ] = None,  # Currently only None or 3 is accepted.
     renderer_config: Optional[RendererConfig] = None,
+    lidar_return_mode: LidarReturnMode = "expected",
 ) -> Tuple[Tensor, Tensor, Dict]:
     """Rasterize a set of 3D Gaussians (N) to a batch of image planes (C).
 
@@ -470,6 +472,10 @@ def rasterization(
             The shape should be [..., C, 4] if provided.
         ftheta_coeffs: F-Theta camera distortion coefficients shared for all cameras.
             Default is None. See `FThetaCameraDistortionParameters` for details.
+        lidar_return_mode: LiDAR hit-distance reduction. ``"expected"`` keeps the
+            opacity-weighted mean; ``"median"`` selects the front-to-back hit whose
+            contribution crosses cumulative opacity 0.5. Median mode is inference-only
+            and requires LiDAR Eval3D hit-distance rendering with MixedBatch.
         rolling_shutter: The rolling shutter type. Default `RollingShutterType.GLOBAL` means
             global shutter.
         viewmats_rs: The second viewmat when rolling shutter is used. Default is None.
@@ -547,6 +553,32 @@ def rasterization(
             f"{type(renderer_config).__name__} requires with_eval3d=True; "
             "the non-eval3d path only supports RendererConfig_MixedBatch."
         )
+    if lidar_return_mode not in {"expected", "median"}:
+        raise ValueError(
+            "lidar_return_mode must be either 'expected' or 'median', "
+            f"got {lidar_return_mode!r}"
+        )
+    use_median_hit_distance = lidar_return_mode == "median"
+    if use_median_hit_distance:
+        if camera_model != "lidar":
+            raise ValueError(
+                "lidar_return_mode='median' requires camera_model='lidar'"
+            )
+        if not with_eval3d:
+            raise ValueError("lidar_return_mode='median' requires with_eval3d=True")
+        if not render_mode_has_hit_distance(render_mode):
+            raise ValueError(
+                "lidar_return_mode='median' requires a hit-distance render_mode"
+            )
+        if not isinstance(renderer_config, RendererConfig_MixedBatch):
+            raise ValueError(
+                "lidar_return_mode='median' only supports RendererConfig_MixedBatch"
+            )
+        if torch.is_grad_enabled():
+            raise ValueError(
+                "lidar_return_mode='median' is inference-only; use "
+                "torch.inference_mode() or torch.no_grad()"
+            )
     renderer_config_impl = _renderer_config_type(renderer_config)
 
     # Both paths run the single C++ orchestrator. `distributed` is honored as
@@ -641,6 +673,7 @@ def rasterization(
         renderer_config_impl,
         process_group_name,
         world_size,
+        use_median_hit_distance,
     )
 
     if absgrad and not with_eval3d:

--- a/tests/cpp/test_raster_eval3d.cpp
+++ b/tests/cpp/test_raster_eval3d.cpp
@@ -215,6 +215,7 @@ protected:
             scene.isect_offsets,
             scene.flatten_ids,
             false, // use_hit_distance
+            false, // use_median_hit_distance
             gsplat::RendererConfig::MIXED_BATCH,
             fwd_only,
             return_last_ids,
@@ -427,6 +428,7 @@ TEST_P(FwdBatchStateTest, LastSlotMatchesTerminalAfterEarlyExit)
         scene.isect_offsets,
         scene.flatten_ids,
         false, // use_hit_distance
+        false, // use_median_hit_distance
         gsplat::RendererConfig::MIXED_BATCH,
         false,        // fwd_only
         true,         // return_last_ids
@@ -501,6 +503,7 @@ TEST_P(FwdBatchStateTest, ParallelBatchSaturatedSlotMatchesTerminal)
         scene.isect_offsets,
         scene.flatten_ids,
         false, // use_hit_distance
+        false, // use_median_hit_distance
         gsplat::RendererConfig::PARALLEL_BATCH,
         false,        // fwd_only
         true,         // return_last_ids
@@ -570,6 +573,7 @@ TEST_P(FwdBatchStateTest, ParallelBatchFwdOnlyMatchesExactWithoutMetadata)
             scene.isect_offsets,
             scene.flatten_ids,
             false, // use_hit_distance
+            false, // use_median_hit_distance
             gsplat::RendererConfig::PARALLEL_BATCH,
             fwd_only,
             return_last_ids,
@@ -752,6 +756,7 @@ TEST_P(InvalidRayStateTest, SkipsBatchStateForInvalidRays)
         scene.isect_offsets,
         scene.flatten_ids,
         false, // use_hit_distance
+        false, // use_median_hit_distance
         gsplat::RendererConfig::PARALLEL_BATCH,
         false, // fwd_only
         true,  // return_last_ids
@@ -825,6 +830,7 @@ TEST_P(FwdBatchStateTest, NonContiguousExternalDistortionPolyThrows)
             scene.isect_offsets,
             scene.flatten_ids,
             false, // use_hit_distance
+            false, // use_median_hit_distance
             gsplat::RendererConfig::MIXED_BATCH,
             false,        // fwd_only
             false,        // return_last_ids

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5958,6 +5958,129 @@ def test_rasterization_cpp_ut_lidar_absgrad_forward_neutral(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
 @pytest.mark.parametrize(
+    ("lidar_return_mode", "expected_message"),
+    [
+        ("invalid", "lidar_return_mode"),
+        ("median", "camera_model='lidar'"),
+    ],
+)
+def test_rasterization_validates_lidar_return_mode(
+    lidar_return_mode: str, expected_message: str
+):
+    scene = _make_cpp_classic_rasterization_scene(n_channels=3, n_cameras=1)
+
+    with pytest.raises(ValueError, match=expected_message):
+        gsplat.rasterization(
+            **scene,
+            width=48,
+            height=40,
+            tile_size=8,
+            render_mode="RGB-Ed",
+            packed=False,
+            with_ut=True,
+            with_eval3d=True,
+            lidar_return_mode=lidar_return_mode,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
+def test_rasterization_lidar_median_selects_threshold_crossing_hit():
+    from gsplat.cuda._lidar import (
+        RowOffsetStructuredSpinningLidarModelParameters,
+        SpinningDirection,
+        compute_angles_to_columns_map,
+        compute_tiling,
+    )
+
+    n_rows, n_columns = 8, 64
+    lidar_params = RowOffsetStructuredSpinningLidarModelParameters(
+        row_elevations_rad=torch.linspace(0.2, -0.2, n_rows, device=device),
+        column_azimuths_rad=torch.linspace(
+            math.pi, -math.pi, n_columns, device=device
+        ),
+        row_azimuth_offsets_rad=torch.zeros(n_rows, device=device),
+        spinning_frequency_hz=10.0,
+        spinning_direction=SpinningDirection.CLOCKWISE,
+    )
+    angles_to_columns_map = compute_angles_to_columns_map(lidar_params).to(device)
+    tiling = compute_tiling(
+        lidar_params,
+        n_bins_elevation=4,
+        max_pts_per_tile=8 * 8,
+        resolution_elevation=1600,
+        densification_factor_azimuth=8,
+    )
+    lidar_coeffs = gsplat.RowOffsetStructuredSpinningLidarModelParametersExt(
+        lidar_params, angles_to_columns_map, tiling
+    )
+    row = lidar_coeffs.n_rows // 2
+    col = lidar_coeffs.n_columns // 2
+    elevation = lidar_coeffs.row_elevations_rad[row]
+    azimuth = (
+        lidar_coeffs.column_azimuths_rad[col]
+        + lidar_coeffs.row_azimuth_offsets_rad[row]
+    )
+    ray = torch.stack(
+        [
+            torch.cos(azimuth) * torch.cos(elevation),
+            torch.sin(azimuth) * torch.cos(elevation),
+            torch.sin(elevation),
+        ]
+    )
+
+    distances = torch.tensor([2.0, 8.0], device=device)
+    means = distances[:, None] * ray[None, :]
+    quats = torch.zeros(2, 4, device=device)
+    quats[:, 0] = 1.0
+    scales = torch.full((2, 3), 0.05, device=device)
+    opacities = torch.full((2,), 0.6, device=device)
+    viewmats = torch.eye(4, device=device).unsqueeze(0)
+    Ks = torch.eye(3, device=device).unsqueeze(0)
+    kwargs = dict(
+        means=means,
+        quats=quats,
+        scales=scales,
+        opacities=opacities,
+        colors=None,
+        viewmats=viewmats,
+        Ks=Ks,
+        width=lidar_coeffs.n_columns,
+        height=lidar_coeffs.n_rows,
+        render_mode="Ed",
+        packed=False,
+        with_ut=True,
+        with_eval3d=True,
+        global_z_order=False,
+        camera_model="lidar",
+        lidar_coeffs=lidar_coeffs,
+    )
+
+    with torch.inference_mode():
+        expected, expected_alpha, _ = gsplat.rasterization(
+            **kwargs, lidar_return_mode="expected"
+        )
+        median, median_alpha, _ = gsplat.rasterization(
+            **kwargs, lidar_return_mode="median"
+        )
+        low_opacity_median, low_opacity_alpha, _ = gsplat.rasterization(
+            **{**kwargs, "opacities": torch.full((2,), 0.2, device=device)},
+            lidar_return_mode="median",
+        )
+
+    expected_distance = expected[0, row, col, 0]
+    median_distance = median[0, row, col, 0]
+    torch.testing.assert_close(expected_alpha, median_alpha)
+    assert 2.0 < expected_distance.item() < 8.0
+    torch.testing.assert_close(median_distance, distances[0], rtol=1e-4, atol=1e-4)
+    assert median_alpha[0, row, col, 0].item() >= 0.5
+    assert low_opacity_alpha[0, row, col, 0].item() < 0.5
+    assert low_opacity_median[0, row, col, 0].item() == 0.0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
+@pytest.mark.parametrize(
     "width,height,expected_tile_size",
     [
         (540, 540, 8),  # well below 1080p


### PR DESCRIPTION
## Summary
- add an opt-in `lidar_return_mode="median"` for LiDAR Eval3D hit-distance rendering
- select the hit distance whose cumulative opacity crosses 0.5, avoiding expected-distance interpolation across depth discontinuities
- constrain median returns to inference-only MixedBatch rendering and preserve existing expected-return behavior by default
- add Python validation/regression coverage and update native Eval3D call sites

## Testing
- `conda run -n gsplat2 env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/test_basic.py::test_rasterization_validates_lidar_return_mode tests/test_basic.py::test_rasterization_lidar_median_selects_threshold_crossing_hit -q` (3 passed)
- `conda run -n gsplat2 env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/test_cpp.py -q` (124 passed)