### PR TITLE
 supported gsplat for RTX 5090 (Blackwell/sm_120)

### DIFF
--- a/gsplat/cuda/csrc/Utils.cpp
+++ b/gsplat/cuda/csrc/Utils.cpp
@@ -36,12 +36,12 @@ void merge_streams()
     {
         C10_CUDA_CHECK(cudaSetDevice(device_id));
         auto stream = c10::cuda::getCurrentCUDAStream(device_id);
-        C10_CUDA_CHECK(cudaEventCreate(&events[device_id], cudaEventDisableTiming));
+        C10_CUDA_CHECK(cudaEventCreateWithFlags(&events[device_id], cudaEventDisableTiming));
         C10_CUDA_CHECK(cudaEventRecord(events[device_id], stream));
     }
 
     C10_CUDA_CHECK(cudaSetDevice(merge_device_id));
-    C10_CUDA_CHECK(cudaEventCreate(&merge_event, cudaEventDisableTiming));
+    C10_CUDA_CHECK(cudaEventCreateWithFlags(&merge_event, cudaEventDisableTiming));
     auto merge_stream = c10::cuda::getCurrentCUDAStream(merge_device_id);
     for(const auto device_id: c10::irange(c10::cuda::device_count()))
     {


### PR DESCRIPTION
## Environment

  - GPU: RTX 5090 (Blackwell, sm_120), driver 580.159.03
  - torch 2.7.1+cu128, CUDA 12.8, nerfstudio 1.1.3
  - gsplat: reproduced on 1.0.0, 1.3.0, 1.5.3 (all crash identically)

  ## Problem

  `gsplat.rasterization(...)` (`packed=False`, in `fully_fused_projection_fwd_tensor`) crashes 100% reliably on the first training iteration:

  ```
  RuntimeError: CUDA error: no kernel image is available for execution on the device
  ```

## Summary

  `merge_streams()` in `gsplat/cuda/csrc/Utils.cpp` calls `cudaEventCreate(&event, cudaEventDisableTiming)` — a 2-argument form. The CUDA Runtime API's
  `cudaEventCreate` only takes a single `cudaEvent_t*` argument; creating an event with flags requires `cudaEventCreateWithFlags`. This fails to compile from source
  against a standard CUDA 12.8 toolkit.

  ## Error

  ```
  gsplat/cuda/csrc/Utils.cpp: In function 'void gsplat::merge_streams()':
  gsplat/cuda/csrc/Utils.cpp:39:39: error: too many arguments to function 'cudaError_t cudaEventCreate(CUevent_st**)'
     39 |         C10_CUDA_CHECK(cudaEventCreate(&events[device_id], cudaEventDisableTiming));
        |                        ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  .../cuda_runtime_api.h:3474:39: note: declared here
   3474 | extern __host__ cudaError_t CUDARTAPI cudaEventCreate(cudaEvent_t *event);
        |                                       ^~~~~~~~~~~~~~~
  gsplat/cuda/csrc/Utils.cpp:44:35: error: too many arguments to function 'cudaError_t cudaEventCreate(CUevent_st**)'
     44 |     C10_CUDA_CHECK(cudaEventCreate(&merge_event, cudaEventDisableTiming));
        |                    ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ```

  ## Fix

  Change both call sites in `merge_streams()` to use `cudaEventCreateWithFlags`, which is the actual 2-argument API for creating an event with flags.

  ## Test plan

  - Built from source (`pip install --no-build-isolation -e .`) against CUDA 12.8 (torch 2.7.1+cu128) — compiles cleanly with this fix, previously failed with the
  error above.
  - After the fix, ran `ns-train` (nerfstudio splatfacto) end-to-end for 700 iterations without issue.