### PR TITLE
Add FULL_OPENCV & radial-fisheye COLMAP models; fix fisheye principal point

### DIFF
--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -111,14 +111,19 @@ def _camera_distortion(camera: Any) -> tuple[np.ndarray, str]:
         return np.array([params[3], params[4], 0.0, 0.0], dtype=np.float32), "fisheye"
     if model_name == "FULL_OPENCV":
         # params: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
-        # The perspective undistortion path (OpenCV) supports the coefficients up to
-        # k3; the rational-model terms k4, k5, k6 are not handled here, so require
-        # them to be zero rather than silently dropping non-zero distortion.
+        # This loader undistorts with the [k1, k2, p1, p2, k3] coefficients
+        # only. OpenCV can represent the full rational model (an 8-element
+        # [k1, k2, p1, p2, k3, k4, k5, k6] vector), but that is not wired
+        # through here, so refuse cameras whose rational terms k4, k5, k6 are
+        # non-zero rather than silently dropping their distortion. Raise (not
+        # assert) so the check is not stripped under `python -O`.
         k4, k5, k6 = float(params[9]), float(params[10]), float(params[11])
-        assert np.allclose((k4, k5, k6), 0.0), (
-            "FULL_OPENCV camera has non-zero rational distortion terms "
-            f"(k4={k4}, k5={k5}, k6={k6}); only coefficients up to k3 are supported."
-        )
+        if not np.allclose((k4, k5, k6), 0.0):
+            raise ValueError(
+                "FULL_OPENCV camera has non-zero rational distortion terms "
+                f"(k4={k4}, k5={k5}, k6={k6}); only coefficients up to k3 are "
+                "supported by this loader."
+            )
         # keep k1, k2, p1, p2, k3 (OpenCV accepts a 5-element distortion vector)
         return np.array(params[4:9], dtype=np.float32), "perspective"
 

--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -101,6 +101,18 @@ def _camera_distortion(camera: Any) -> tuple[np.ndarray, str]:
         return np.array(params[4:8], dtype=np.float32), "perspective"
     if model_name == "OPENCV_FISHEYE":
         return np.array(params[4:8], dtype=np.float32), "fisheye"
+    if model_name == "FULL_OPENCV":
+        # params: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
+        # The perspective undistortion path (OpenCV) supports the coefficients up to
+        # k3; the rational-model terms k4, k5, k6 are not handled here, so require
+        # them to be zero rather than silently dropping non-zero distortion.
+        k4, k5, k6 = float(params[9]), float(params[10]), float(params[11])
+        assert np.allclose((k4, k5, k6), 0.0), (
+            "FULL_OPENCV camera has non-zero rational distortion terms "
+            f"(k4={k4}, k5={k5}, k6={k6}); only coefficients up to k3 are supported."
+        )
+        # keep k1, k2, p1, p2, k3 (OpenCV accepts a 5-element distortion vector)
+        return np.array(params[4:9], dtype=np.float32), "perspective"
 
     raise ValueError(
         f"Only perspective and fisheye cameras are supported, got {model_name}"

--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -419,8 +419,12 @@ class Parser:
                     + params[2] * theta**6
                     + params[3] * theta**8
                 )
-                mapx = (fx * x1 * r + width // 2).astype(np.float32)
-                mapy = (fy * y1 * r + height // 2).astype(np.float32)
+                # Re-center on the principal point (cx, cy), not the image
+                # center: with zero distortion (r == 1) this is the identity
+                # map, and it keeps the undistorted image consistent with the
+                # K_undist used at render time when cx/cy are off-center.
+                mapx = (fx * x1 * r + cx).astype(np.float32)
+                mapy = (fy * y1 * r + cy).astype(np.float32)
 
                 # Use mask to define ROI
                 mask = np.logical_and(

--- a/examples/datasets/colmap.py
+++ b/examples/datasets/colmap.py
@@ -101,6 +101,14 @@ def _camera_distortion(camera: Any) -> tuple[np.ndarray, str]:
         return np.array(params[4:8], dtype=np.float32), "perspective"
     if model_name == "OPENCV_FISHEYE":
         return np.array(params[4:8], dtype=np.float32), "fisheye"
+    if model_name == "SIMPLE_RADIAL_FISHEYE":
+        # params: f, cx, cy, k. Equidistant fisheye with a single radial term;
+        # identical to OPENCV_FISHEYE with k2 = k3 = k4 = 0.
+        return np.array([params[3], 0.0, 0.0, 0.0], dtype=np.float32), "fisheye"
+    if model_name == "RADIAL_FISHEYE":
+        # params: f, cx, cy, k1, k2. Equidistant fisheye with two radial terms;
+        # identical to OPENCV_FISHEYE with k3 = k4 = 0.
+        return np.array([params[3], params[4], 0.0, 0.0], dtype=np.float32), "fisheye"
     if model_name == "FULL_OPENCV":
         # params: fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6
         # The perspective undistortion path (OpenCV) supports the coefficients up to


### PR DESCRIPTION
Extends the example COLMAP loader (`examples/datasets/colmap.py`) to load
three more COLMAP camera models and fixes a principal-point bug in the
fisheye undistortion. All changes are localized to `_camera_distortion`
and the fisheye undistortion map.

**Changes**
- **FULL_OPENCV** (`fx,fy,cx,cy,k1,k2,p1,p2,k3,k4,k5,k6`) → perspective
  path, undistorting with `[k1,k2,p1,p2,k3]`. Cameras with non-zero
  rational terms `k4,k5,k6` are refused with a clear error (via `raise`,
  so it holds under `python -O`) rather than silently dropping distortion.
- **SIMPLE_RADIAL_FISHEYE** (`f,cx,cy,k`) → fisheye `[k,0,0,0]` and
  **RADIAL_FISHEYE** (`f,cx,cy,k1,k2`) → fisheye `[k1,k2,0,0]`. Verified
  against COLMAP `models.h`: these are OPENCV_FISHEYE with higher
  `θ`-polynomial coefficients zeroed, so the mapping is exact.
- **Fisheye principal-point fix**: the manual undistortion map recentered
  on `width//2, height//2` instead of `cx, cy`. With zero distortion that
  was a shift of `(width/2 − cx)`, inconsistent with the `K_undist` used
  at render time. Using `cx, cy` makes zero distortion the identity map.
  Kept equidistant (does *not* switch to `cv2.fisheye`, which rectifies to
  pinhole and breaks >180° FOV); gsplat's fisheye projection already uses
  `cx, cy`.

**Loader coverage now**: SIMPLE_PINHOLE, PINHOLE, SIMPLE_RADIAL, RADIAL,
OPENCV, FULL_OPENCV, OPENCV_FISHEYE, SIMPLE_RADIAL_FISHEYE, RADIAL_FISHEYE.
Not supported (need model-specific undistortion): FOV, THIN_PRISM_FISHEYE,
division / EUCM / equirectangular.

**Testing**: `py_compile` and Black 22.3.0 pass. End-to-end runs need
captures using these models (not in the repo's standard datasets).
