### PR TITLE
Detect ROCm toolkit in lazy backend

### DIFF
--- a/gsplat/_lazy_backend.py
+++ b/gsplat/_lazy_backend.py
@@ -57,7 +57,7 @@ _UNSET = object()
 
 
 def cuda_toolkit_available() -> bool:
-    """Return True if a usable CUDA toolkit (nvcc) is discoverable.
+    """Return True if a usable CUDA or ROCm toolkit is discoverable.
 
     Shared by the native-extension loaders so the probe lives in one place.
     ``torch.utils.cpp_extension`` is imported lazily so importing this module
@@ -65,7 +65,23 @@ def cuda_toolkit_available() -> bool:
     """
     from subprocess import DEVNULL, call
 
+    import torch
     import torch.utils.cpp_extension as jit
+
+    if torch.version.hip:
+        # PyTorch's HIP extension machinery keys off ROCM_HOME and invokes
+        # hipcc after hipifying CUDA sources.  CUDA_HOME/nvcc are intentionally
+        # absent in a normal ROCm installation, so a CUDA-only probe leaves the
+        # backend disabled even though jit.load() can build it.
+        rocm_home = getattr(jit, "ROCM_HOME", None)
+        if rocm_home:
+            hipcc_path = os.path.join(rocm_home, "bin", "hipcc")
+            if os.path.isfile(hipcc_path):
+                return True
+        try:
+            return call(["hipcc", "--version"], stdout=DEVNULL, stderr=DEVNULL) == 0
+        except OSError:
+            return False
 
     cuda_home = jit._find_cuda_home()  # tries various heuristics
     if not cuda_home:

--- a/gsplat/cuda/_backend.py
+++ b/gsplat/cuda/_backend.py
@@ -35,7 +35,8 @@ except ImportError:
         _C = build_and_load_gsplat()
     else:
         Console().print(
-            "[yellow]gsplat: No CUDA toolkit found. gsplat will be disabled.[/yellow]"
+            "[yellow]gsplat: No CUDA or ROCm toolkit found. "
+            "gsplat will be disabled.[/yellow]"
         )
 
 __all__ = ["_C"]

--- a/gsplat/experimental/render/kernels/_backend.py
+++ b/gsplat/experimental/render/kernels/_backend.py
@@ -81,7 +81,8 @@ def _get_backend():
                 )
         else:
             _warn(
-                "experimental: No CUDA toolkit found. Inference render will be disabled."
+                "experimental: No CUDA or ROCm toolkit found. "
+                "Inference render will be disabled."
             )
 
     if _C is not None and not _inference_op_registered():

--- a/tests/test_lazy_backend.py
+++ b/tests/test_lazy_backend.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright 2026 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-safe tests for accelerator toolkit discovery."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def lazy_backend_module():
+    path = REPO_ROOT / "gsplat" / "_lazy_backend.py"
+    spec = importlib.util.spec_from_file_location("gsplat_test_lazy_backend", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_fake_torch(monkeypatch, *, hip, rocm_home=None, cuda_home=None):
+    torch = ModuleType("torch")
+    torch.__path__ = []
+    torch.version = SimpleNamespace(hip=hip)
+
+    torch_utils = ModuleType("torch.utils")
+    torch_utils.__path__ = []
+    cpp_extension = ModuleType("torch.utils.cpp_extension")
+    cpp_extension.ROCM_HOME = rocm_home
+    cpp_extension._find_cuda_home = lambda: cuda_home
+
+    torch.utils = torch_utils
+    torch_utils.cpp_extension = cpp_extension
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.utils", torch_utils)
+    monkeypatch.setitem(sys.modules, "torch.utils.cpp_extension", cpp_extension)
+
+
+def test_rocm_toolkit_available_from_rocm_home(lazy_backend_module, monkeypatch):
+    _install_fake_torch(monkeypatch, hip="7.2", rocm_home="/opt/rocm")
+    monkeypatch.setattr(
+        lazy_backend_module.os.path,
+        "isfile",
+        lambda path: path == "/opt/rocm/bin/hipcc",
+    )
+
+    assert lazy_backend_module.cuda_toolkit_available()
+
+
+def test_rocm_toolkit_available_from_path(lazy_backend_module, monkeypatch):
+    _install_fake_torch(monkeypatch, hip="7.2")
+    monkeypatch.setattr(lazy_backend_module.os.path, "isfile", lambda _path: False)
+    monkeypatch.setattr(
+        subprocess,
+        "call",
+        lambda command, **_kwargs: 0 if command == ["hipcc", "--version"] else 1,
+    )
+
+    assert lazy_backend_module.cuda_toolkit_available()
+
+
+def test_rocm_toolkit_unavailable(lazy_backend_module, monkeypatch):
+    _install_fake_torch(monkeypatch, hip="7.2")
+    monkeypatch.setattr(lazy_backend_module.os.path, "isfile", lambda _path: False)
+
+    def missing_hipcc(_command, **_kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "call", missing_hipcc)
+    assert not lazy_backend_module.cuda_toolkit_available()
+
+
+def test_cuda_toolkit_detection_is_unchanged(lazy_backend_module, monkeypatch):
+    _install_fake_torch(monkeypatch, hip=None, cuda_home="/usr/local/cuda")
+    monkeypatch.setattr(
+        lazy_backend_module.os.path,
+        "isfile",
+        lambda path: path == "/usr/local/cuda/bin/nvcc",
+    )
+
+    assert lazy_backend_module.cuda_toolkit_available()


### PR DESCRIPTION
## Summary

- recognize an executable `hipcc` when the installed PyTorch build reports `torch.version.hip`
- prefer PyTorch's resolved `ROCM_HOME`, with a PATH fallback for container/toolchain wrappers
- keep the CUDA `nvcc` probe unchanged
- describe the backend as CUDA/ROCm in user-facing fallback messages

This is deliberately limited to toolkit discovery. It does not duplicate the kernel-porting work in #970; it lets the existing lazy backend reach that ROCm build path instead of disabling gsplat before compilation starts.

## Validation

- `pytest -q --noconftest tests/test_lazy_backend.py` (4 passed)
- CPU-only fakes cover ROCm home, PATH fallback, missing hipcc, and unchanged CUDA behavior
- on a gfx1100 / ROCm 7.2.1 host, the probe reached the HIP JIT compile path (full rasterization validation remains tracked by the ROCm port)

## Scope

Ready for maintainer review alongside #970.

Supersedes #1043 after the source branch was renamed to remove the agent/ prefix.