### PR TITLE
Make JIT compiler flags ROCm-aware

### DIFF
--- a/gsplat/cuda/build.py
+++ b/gsplat/cuda/build.py
@@ -63,7 +63,7 @@ except ImportError:
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 DEBUG = os.getenv("DEBUG", "0") == "1"
-FAST_MATH = os.getenv("FAST_MATH", "1") == "1"
+FAST_MATH = os.getenv("FAST_MATH", "0" if torch.version.hip else "1") == "1"
 WITH_SYMBOLS = os.getenv("WITH_SYMBOLS", "1" if DEBUG else "0") == "1"
 NVCC_FLAGS = os.getenv("NVCC_FLAGS", "")
 MAX_JOBS = os.getenv("MAX_JOBS")
@@ -98,12 +98,17 @@ def format_jit_cuda_cflags(cuda_cflags):
 def get_build_parameters():
     name = "gsplat_cuda"
     current_dir = os.path.dirname(os.path.abspath(__file__))
+    is_rocm = torch.version.hip is not None
 
     # Include paths -----------------------------------
     extra_include_paths = [
         os.path.join(PATH, "include/"),
         os.path.join(current_dir, "csrc", "third_party", "glm"),
     ]
+    if is_rocm:
+        # PyTorch hipifies CUDA translation units into ``gsplat/hip/csrc`` but
+        # quoted project headers continue to live in ``gsplat/cuda/csrc``.
+        extra_include_paths.append(os.path.join(current_dir, "csrc"))
     # Fix for CUDA 12+ in conda environment
     if CUDA_HOME and os.path.isdir(os.path.join(CUDA_HOME, "targets")):
         for arch in os.listdir(os.path.join(CUDA_HOME, "targets")):
@@ -145,7 +150,8 @@ def get_build_parameters():
         extra_cflags += ["-arch", "arm64"]
         extra_ldflags += ["-arch", "arm64"]
 
-    extra_cuda_cflags += ["--forward-unknown-opts"]
+    if not is_rocm:
+        extra_cuda_cflags += ["--forward-unknown-opts"]
 
     # Debug/Release mode
     # MSVC (cl) does not support -O3/-O0; use -O2/-Od (torch converts - to /)
@@ -155,13 +161,15 @@ def get_build_parameters():
         # so no need to add it here; WITH_SYMBOLS is the single source of truth.
         if sys.platform != "win32":  # MSVC equivalent (/W4 /WX) is untested
             extra_cflags += ["-Wall"]
-            extra_cuda_cflags += [
-                # nvcc intercepts bare -Werror as its own --Werror flag, so
-                # pass it via -Xcompiler instead of --forward-unknown-opts.
-                "-Xcompiler=-Werror",
-                "--Werror",
-                "all-warnings",
-            ]
+            if not is_rocm:
+                extra_cuda_cflags += [
+                    # nvcc intercepts bare -Werror as its own --Werror flag, so
+                    # pass it via -Xcompiler instead of
+                    # --forward-unknown-opts.
+                    "-Xcompiler=-Werror",
+                    "--Werror",
+                    "all-warnings",
+                ]
         else:
             extra_cflags += ["/Zi", "/Od"]
             extra_cuda_cflags += ["-Od"]
@@ -172,14 +180,16 @@ def get_build_parameters():
             extra_cflags += ["/O2", "-DNDEBUG"]
             extra_cuda_cflags += ["-O2", "-DNDEBUG"]
 
-    extra_cuda_cflags += ["-use_fast_math"] if FAST_MATH else []
+    if FAST_MATH:
+        extra_cuda_cflags += ["-ffast-math" if is_rocm else "-use_fast_math"]
 
     # Silencing of warnings
     # GLM/Torch has spammy and very annoyingly verbose warnings that this suppresses.
     # 3189: C++20 makes `module` a contextual keyword. PyTorch's
     #       torch::python::module member is valid code, but nvcc emits
     #       a noisy compatibility diagnostic when parsing it as an identifier.
-    extra_cuda_cflags += ["-diag-suppress", "3189,20012,186"]
+    if not is_rocm:
+        extra_cuda_cflags += ["-diag-suppress", "3189,20012,186"]
     if not os.name == "nt":
         extra_cflags += ["-Wno-attributes"]
         # PyTorch headers trip this under GCC when gsplat's debug build enables -Werror.
@@ -222,12 +232,15 @@ def get_build_parameters():
     extra_ldflags += [] if WITH_SYMBOLS or sys.platform == "win32" else ["-s"]
 
     if WITH_SYMBOLS:
-        extra_cuda_cflags += ["-lineinfo"]
+        extra_cuda_cflags += ["-gline-tables-only" if is_rocm else "-lineinfo"]
 
-    if torch.version.hip:
+    if is_rocm:
         # USE_ROCM was added to later versions of PyTorch.
         # Define here to support older PyTorch versions as well:
         extra_cflags += ["-DUSE_ROCM", "-U__HIP_NO_HALF_CONVERSIONS__"]
+        # Current HIP headers gate CUDA-compatible complex min/max builtins
+        # behind this Clang opt-in.
+        extra_cuda_cflags += ["-D__CLANG_CUDA_COMPLEX_BUILTINS=1"]
     else:
         extra_cuda_cflags += ["--expt-relaxed-constexpr"]
 

--- a/tests/test_rocm_build_parameters.py
+++ b/tests/test_rocm_build_parameters.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright 2026 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-safe coverage for CUDA versus ROCm JIT build parameters."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_build_module(monkeypatch, *, hip, fast_math=None, debug=False):
+    torch = ModuleType("torch")
+    torch.__path__ = []
+    torch.version = SimpleNamespace(hip=hip)
+    torch.__config__ = SimpleNamespace(
+        parallel_info=lambda: "ATen parallel backend: OpenMP"
+    )
+
+    torch_utils = ModuleType("torch.utils")
+    torch_utils.__path__ = []
+    cpp_extension = ModuleType("torch.utils.cpp_extension")
+    cpp_extension.CUDA_HOME = None
+    cpp_extension._get_build_directory = lambda *_args, **_kwargs: "/tmp/gsplat"
+
+    torch.utils = torch_utils
+    torch_utils.cpp_extension = cpp_extension
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.utils", torch_utils)
+    monkeypatch.setitem(sys.modules, "torch.utils.cpp_extension", cpp_extension)
+
+    for name in ("WITH_SYMBOLS", "NVCC_FLAGS", "NUM_CHANNELS"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DEBUG", "1" if debug else "0")
+    if fast_math is None:
+        monkeypatch.delenv("FAST_MATH", raising=False)
+    else:
+        monkeypatch.setenv("FAST_MATH", "1" if fast_math else "0")
+
+    path = REPO_ROOT / "gsplat" / "cuda" / "build.py"
+    module_name = f"gsplat_test_build_{'hip' if hip else 'cuda'}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rocm_release_uses_hipcc_flags(monkeypatch):
+    parameters = _load_build_module(monkeypatch, hip="7.2").get_build_parameters()
+
+    assert str(REPO_ROOT / "gsplat" / "cuda" / "csrc") in {
+        str(Path(path).resolve()) for path in parameters.extra_include_paths
+    }
+    assert "--forward-unknown-opts" not in parameters.extra_cuda_cflags
+    assert "-diag-suppress" not in parameters.extra_cuda_cflags
+    assert "-use_fast_math" not in parameters.extra_cuda_cflags
+    assert "-ffast-math" not in parameters.extra_cuda_cflags
+    assert "-D__CLANG_CUDA_COMPLEX_BUILTINS=1" in parameters.extra_cuda_cflags
+    assert "-DUSE_ROCM" in parameters.extra_cflags
+
+
+def test_rocm_fast_math_is_explicit_opt_in(monkeypatch):
+    parameters = _load_build_module(
+        monkeypatch, hip="7.2", fast_math=True
+    ).get_build_parameters()
+
+    assert "-ffast-math" in parameters.extra_cuda_cflags
+    assert "-use_fast_math" not in parameters.extra_cuda_cflags
+
+
+def test_rocm_debug_uses_clang_diagnostics(monkeypatch):
+    parameters = _load_build_module(
+        monkeypatch, hip="7.2", debug=True
+    ).get_build_parameters()
+
+    assert "-gline-tables-only" in parameters.extra_cuda_cflags
+    assert "-lineinfo" not in parameters.extra_cuda_cflags
+    assert "-Xcompiler=-Werror" not in parameters.extra_cuda_cflags
+    assert "--Werror" not in parameters.extra_cuda_cflags
+
+
+def test_cuda_build_parameters_are_unchanged(monkeypatch):
+    parameters = _load_build_module(monkeypatch, hip=None).get_build_parameters()
+
+    assert "--forward-unknown-opts" in parameters.extra_cuda_cflags
+    assert "-diag-suppress" in parameters.extra_cuda_cflags
+    assert "-use_fast_math" in parameters.extra_cuda_cflags
+    assert "-ffast-math" not in parameters.extra_cuda_cflags
+    assert "-D__CLANG_CUDA_COMPLEX_BUILTINS=1" not in parameters.extra_cuda_cflags
+
+
+def test_cuda_debug_keeps_nvcc_diagnostics(monkeypatch):
+    parameters = _load_build_module(
+        monkeypatch, hip=None, debug=True
+    ).get_build_parameters()
+
+    assert "-lineinfo" in parameters.extra_cuda_cflags
+    assert "-gline-tables-only" not in parameters.extra_cuda_cflags
+    assert "-Xcompiler=-Werror" in parameters.extra_cuda_cflags
+    assert "--Werror" in parameters.extra_cuda_cflags


### PR DESCRIPTION
## Summary

- select hipcc/Clang-compatible JIT flags when the installed PyTorch build reports `torch.version.hip`
- keep ROCm fast math opt-in because `-ffast-math` can move ill-conditioned projection gradients beyond the existing tolerances
- preserve the existing CUDA defaults and NVCC diagnostics
- add CPU-safe tests for ROCm/CUDA release, debug, symbols, include paths, and fast-math behavior

## Why

`gsplat/cuda/build.py` already has a ROCm branch, but several flags are emitted unconditionally for the device compiler: `--forward-unknown-opts`, `-diag-suppress`, NVCC's `--Werror` form, `-lineinfo`, and `-use_fast_math`. hipcc rejects or misinterprets these before the ROCm kernel compatibility work can be exercised.

This is intentionally a build-configuration prerequisite. It does not duplicate the kernel ports in #798, #957, #970, or #1038. It is also independent of the lazy toolkit probe in #1043.

The flag set is based on the Linux gfx1100 / ROCm 7.2.1 JIT path used for BiGym three-camera Gaussian rendering. Full rasterization still depends on the ROCm kernel port.

## Validation

- `python -m pytest -q -c /dev/null -p no:cacheprovider --noconftest tests/test_rocm_build_parameters.py` (`5 passed`)
- `python -m py_compile gsplat/cuda/build.py tests/test_rocm_build_parameters.py`
- `python -m black --check gsplat/cuda/build.py tests/test_rocm_build_parameters.py`
- `git diff --check`

Supersedes #1044 after the source branch was renamed to remove the agent/ prefix.