### PR TITLE
[NV] Support FTheta FOV beyond 180 degrees

### DIFF
--- a/gsplat/cuda/_torch_cameras.py
+++ b/gsplat/cuda/_torch_cameras.py
@@ -1966,15 +1966,15 @@ class _FThetaCameraModel(_BaseCameraModel):
             margin_factor: Margin for image bounds checking
 
         Returns:
-            image_point: [M, 2] projected image coordinates
+            image_point: [M, 2] projected image coordinates. Only meaningful
+                where `valid` is True. Rays outside the `max_angle` cone are
+                still projected after being clamped to the cone, so invalid
+                entries contain plausible-looking coordinates, not sentinels.
             valid: [M] validity mask
         """
         # Preconditions
         M = cam_ray.shape[:-1]
         assert_shape("cam_ray", cam_ray, M + (3,))
-
-        # Points behind camera are invalid
-        not_behind_camera = cam_ray[..., 2] > 0.0  # [M]
 
         # Compute norm of xy components using numerically stable method
         cam_ray_xy_norm = _numerically_stable_norm2(
@@ -2047,12 +2047,7 @@ class _FThetaCameraModel(_BaseCameraModel):
         # Mark FOV-clamped points as invalid. Compare against the pre-clamp
         # `theta_full`; comparing `theta` here would be a tautology because
         # `theta = min(theta_full, max_angle)` above.
-        valid = (
-            not_behind_camera & (theta_full < self.max_angle[..., None]) & valid_bounds
-        )
-
-        # Zero out image_points for rays behind the camera.
-        image_point = image_point * not_behind_camera[..., None]
+        valid = (theta_full < self.max_angle[..., None]) & valid_bounds
 
         # Postconditions
         assert_shape("image_point", image_point, M + (2,))

--- a/gsplat/cuda/_torch_impl_ut.py
+++ b/gsplat/cuda/_torch_impl_ut.py
@@ -426,7 +426,7 @@ def _fully_fused_projection_with_ut(
             height=height,
             camera_model=camera_model,
             principal_points=principal_points,
-            focal_lengths=focal_lengths,
+            focal_lengths=None if camera_model == "ftheta" else focal_lengths,
             radial_coeffs=radial_coeffs,
             tangential_coeffs=tangential_coeffs,
             thin_prism_coeffs=thin_prism_coeffs,
@@ -462,10 +462,20 @@ def _fully_fused_projection_with_ut(
         + t_cam[..., None, :]
     )  # [B, C, N, 3]
 
-    # Check if Gaussian center is within frustum.
-    # Use transformed center point (means_cam) for depth check
+    # Near/far cull depth is signed camera-space z unless Euclidean depth
+    # sorting is requested. In that mode LiDAR and FTheta use radial depth
+    # because their model classes accept rays with z <= 0; every other model
+    # retains signed z because its projection rejects those rays. This is a
+    # per-model rule: an FTheta calibration with max_angle <= pi/2 still takes
+    # the radial branch even though it images nothing behind the plane.
+    # Keeping forward-only models on signed z also prevents a behind-camera
+    # center from surviving through a few valid UT sigma points.
     center_z = means_cam[..., 2]  # [B, C, N]
-    in_frustum = (center_z >= near_plane) & (center_z <= far_plane)
+    use_radial_culling = not global_z_order and (
+        camera_model == "lidar" or camera_model == "ftheta"
+    )
+    cull_depth = means_cam.norm(dim=-1) if use_radial_culling else center_z
+    in_frustum = (cull_depth >= near_plane) & (cull_depth <= far_plane)
 
     # Cull degenerate Gaussians: zero-length quaternion (no defined orientation)
     # or near-zero scale on any axis (divergent precision matrix in rasterization).

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -2583,7 +2583,13 @@ def fully_fused_projection_with_ut(
             Gaussians are sorted by their z-coordinate in camera space. If False, they are sorted
             by their Euclidean distance from the camera origin. The z-coordinate sorting is typically
             faster and sufficient for most cases, while Euclidean distance can be useful for scenes
-            with wide field-of-view or non-standard camera models. Default: True.
+            with wide field-of-view or non-standard camera models. When False, the UT projection
+            kernel uses Euclidean near/far culling only for LiDAR and FTheta; forward-only camera
+            models continue to use camera-space z culling. A wide-FOV FTheta calibration therefore
+            requires ``global_z_order=False`` to render its beyond-180-degree band. The same setting
+            also makes the D/ED depth channel use Euclidean distance. An FTheta ``max_angle`` must
+            come from calibration and must not be raised merely to widen rendered FOV: its forward
+            polynomial is trusted only over ``[0, max_angle]``. Default: True.
     """
     if lidar_coeffs is not None:
         assert isinstance(

--- a/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
+++ b/gsplat/cuda/csrc/ProjectionUT3DGSFused.cu
@@ -63,6 +63,7 @@ __global__ void
         const float far_plane,
         const float radius_clip,
         const bool global_z_order,
+        const bool use_radial_culling,
         // uncented transform
         const UnscentedTransformParameters ut_params,
         // sensor model parameters
@@ -127,7 +128,7 @@ __global__ void
     const auto shutter_pose = interpolate_shutter_pose(0.5f, rs_params);
     const vec3 mean_c       = glm::rotate(shutter_pose.q, mean) + shutter_pose.t;
 
-    const float cull_depth = global_z_order ? mean_c.z : glm::length(mean_c);
+    const float cull_depth = use_radial_culling ? glm::length(mean_c) : mean_c.z;
     if(cull_depth < near_plane || cull_depth > far_plane)
     {
         radii[idx * 2]     = 0;
@@ -399,6 +400,16 @@ void launch_projection_ut_3dgs_fused_kernel(
     // Default unscented-transform parameters when the caller leaves them unset.
     const auto ut = ut_params.has_value() ? ut_params.value() : c10::make_intrusive<UnscentedTransformParameters>();
 
+    // Near/far cull depth. Signed camera-space z unless Euclidean depth sorting
+    // is requested, in which case:
+    //  - LiDAR and FTheta: radial. Their projection accepts rays with z <= 0, so
+    //    a signed-z cull would drop centres they can still image.
+    //  - every other model: still signed z. Its projection rejects z <= 0 rays.
+    // This is per model, not per calibration: a max_angle <= pi/2 FTheta fit
+    // images nothing behind the plane but still takes the radial branch.
+    const bool use_radial_culling
+        = !global_z_order && (camera_model == CameraModelType::LIDAR || camera_model == CameraModelType::FTHETA);
+
     auto launch_kernel = [&]<typename SensorModel>()
     {
         projection_ut_3dgs_fused_kernel<SensorModel, float>
@@ -419,6 +430,7 @@ void launch_projection_ut_3dgs_fused_kernel(
                 far_plane,
                 radius_clip,
                 global_z_order,
+                use_radial_culling,
                 // uncented transform
                 *ut,
                 std::get<typename SensorModel::KernelParameters>(sensor_model_params),

--- a/gsplat/cuda/include/Cameras.cuh
+++ b/gsplat/cuda/include/Cameras.cuh
@@ -1607,13 +1607,12 @@ public:
     inline __device__ auto camera_ray_to_image_point_impl(const glm::fvec3 &cam_ray, float margin_factor) const ->
         typename Base::ImagePointReturn
     {
-        if(cam_ray.z <= 0.f)
-        {
-            return {
-                {0.f, 0.f},
-                false
-            };
-        }
+        // No z <= 0 guard here, unlike the other models in this header:
+        //  - FTheta calibrations with max_angle > pi/2 model beyond-180-degree FOV.
+        //  - A ray with z <= 0 has theta_full >= pi/2 and stays valid while
+        //    theta_full < max_angle and its projection lands in bounds.
+        //  - Rays outside the cone are clamped to max_angle below and marked
+        //    invalid there.
 
         // Make sure norm is non-vanishing (norm vanishes for points along the principal-axis)
         auto cam_ray_xy_norm = numerically_stable_norm2(cam_ray.x, cam_ray.y);

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -459,8 +459,14 @@ def rasterization(
             with_eval3d=True. Default is False.
         global_z_order: Whether to use z-depth (True) or Euclidean distance (False) for
             sorting Gaussians during rasterization. When True, Gaussians are sorted by their
-            z-coordinate in camera space. When False, they are sorted by their Euclidean
-            distance from the camera origin. Default is True.
+            z-coordinate in camera space. When False, they are sorted by their Euclidean distance
+            from the camera origin. The UT projection kernel then uses Euclidean near/far culling
+            only for LiDAR and FTheta; forward-only camera models continue to use camera-space z
+            culling. A wide-FOV FTheta calibration therefore requires ``global_z_order=False`` to
+            render its beyond-180-degree band. The same setting also makes the D/ED depth channel
+            use Euclidean distance. An FTheta ``max_angle`` must come from calibration and must not
+            be raised merely to widen rendered FOV: its forward polynomial is trusted only over
+            ``[0, max_angle]``. Default is True.
         radial_coeffs: Opencv pinhole/fisheye radial distortion coefficients. Default is None.
             For pinhole camera, the shape should be [..., C, 6]. For fisheye camera, the shape
             should be [..., C, 4].

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -52,6 +52,8 @@ from gsplat._helper import (
 
 from gsplat.cuda._wrapper import (
     CameraModel,
+    FThetaCameraDistortionParameters,
+    FThetaPolynomialType,
     RollingShutterType,
     UnscentedTransformParameters,
     _make_lazy_cuda_cls,
@@ -706,7 +708,7 @@ def test_fully_fused_projection_packed(
     not torch.cuda.is_available(), reason="CUDA required for UT projection"
 )
 @pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
-@pytest.mark.parametrize("camera_model", ["pinhole", "ortho"])
+@pytest.mark.parametrize("camera_model", ["pinhole", "ortho", "ftheta"])
 @pytest.mark.parametrize("batch_dims", [(), (2,), (1, 2)])
 @pytest.mark.parametrize(
     "require_all_valid", [True, False], ids=["allvalid", "somevalid"]
@@ -751,6 +753,31 @@ def test_fully_fused_projection_ut(
     ut_params = UnscentedTransformParameters(
         require_all_sigma_points_valid=require_all_valid
     )
+    ftheta_coeffs = (
+        FThetaCameraDistortionParameters(
+            reference_poly=FThetaPolynomialType.ANGLE_TO_PIXELDIST,
+            pixeldist_to_angle_poly=(
+                0.0,
+                8.4335003e-03,
+                2.3174282e-06,
+                -5.0478608e-08,
+                6.1392608e-10,
+                -1.7447865e-12,
+            ),
+            angle_to_pixeldist_poly=(
+                0.0,
+                118.43232,
+                -2.562147,
+                6.317949,
+                -10.41861,
+                3.6694396,
+            ),
+            max_angle=math.radians(120.0),
+            linear_cde=(9.9968284e-01, 1.8735906e-05, 1.7659619e-05),
+        )
+        if camera_model == "ftheta"
+        else None
+    )
 
     # Setup rolling shutter (end viewmats) if not GLOBAL
     if rolling_shutter != RollingShutterType.GLOBAL:
@@ -779,6 +806,7 @@ def test_fully_fused_projection_ut(
         "width": width,
         "height": height,
         "camera_model": camera_model,
+        "ftheta_coeffs": ftheta_coeffs,
         "eps2d": 0.3,
         "near_plane": 0.01,
         "far_plane": 1e10,
@@ -884,9 +912,21 @@ def test_fully_fused_projection_ut(
         _bound = 5e-2 + 2e-3 * means2d_torch[sel].abs()
         _fail = _diff > _bound
         _fr = _fail.float().mean().item()
-        # fail_cap = 1.05 x worst observed (0.013145%) -> 0.014%.
-        assert _fr <= 1.4e-4, (
-            f"UT means2d (rolling): fail-rate {_fr:.4%} > cap 0.014% "
+        # ROLLING means2d has a boundary tail; cap the fail-rate per camera
+        # model. The fail-rate is a fraction over the selected elements, so
+        # subsampling the scene raises its variance and the cap must admit that.
+        # Keep the calibrated caps explicit per model so a new model cannot
+        # silently inherit another model's numerical-error budget.
+        # Preserve main's 0.014% budget for its existing models. RTX A6000
+        # FTheta worst observed fail-rate is 0.000928%; retain a 0.015% cap for
+        # cross-GPU/codegen margin.
+        _fail_cap = {
+            "pinhole": 1.4e-4,
+            "ortho": 1.4e-4,
+            "ftheta": 1.5e-4,
+        }[camera_model]
+        assert _fr <= _fail_cap, (
+            f"UT means2d (rolling): fail-rate {_fr:.4%} > cap {_fail_cap:.3%} "
             f"(atol=5e-2, rtol=2e-3, {int(_fail.sum().item())}/{_fail.numel()})"
         )
         # Outlier guard: even admitted outliers must satisfy a per-element
@@ -920,11 +960,14 @@ def test_fully_fused_projection_ut(
     # high rel-diff -- previously rtol=10.0 admitted any error.  Use a
     # bounded per-element check with a fail-rate cap.
     if rolling_shutter == RollingShutterType.GLOBAL:
+        _conics_rtol, _conics_atol = (
+            (2e-2, 3.2e-2) if camera_model == "ftheta" else (2e-3, 2e-3)
+        )
         torch.testing.assert_close(
             conics_cuda[sel],
             conics_torch[sel],
-            rtol=2e-3,
-            atol=2e-3,
+            rtol=_conics_rtol,
+            atol=_conics_atol,
         )
     else:
         _diff_c = (conics_cuda[sel] - conics_torch[sel]).abs()
@@ -934,8 +977,11 @@ def test_fully_fused_projection_ut(
         # fail_cap = 1.05 x envelope:
         #   RTX PRO 2000  worst fail-rate 0.0161%
         #   RTX PRO 6000  worst fail-rate 0.0191%
-        assert _fr_c <= 2.1e-4, (
-            f"UT conics (rolling): fail-rate {_fr_c:.4%} > cap 0.021% "
+        #   RTX A6000 FTheta  worst fail-rate 0.0598%
+        _conics_fail_cap = 6.3e-4 if camera_model == "ftheta" else 2.1e-4
+        assert _fr_c <= _conics_fail_cap, (
+            f"UT conics (rolling): fail-rate {_fr_c:.4%} > cap "
+            f"{_conics_fail_cap:.3%} "
             f"(atol=1e-2, rtol=1e-2, {int(_fail_c.sum().item())}/{_fail_c.numel()})"
         )
         # Outlier guard tightened to 1.05 x worst observed (1.855) -> 2.0.
@@ -962,8 +1008,11 @@ def test_fully_fused_projection_ut(
     #   boundary band: Gaussians whose footprint crosses an integer y ->
     #                 budgeted, symmetric flip-rate check.
     if rolling_shutter == RollingShutterType.GLOBAL:
+        # FTheta worst observed max_abs is 2.8178e-2 in CI; use a 1.05x
+        # cross-GPU envelope while retaining the tighter budget for other models.
+        _comps_atol = 3e-2 if camera_model == "ftheta" else 1e-2
         torch.testing.assert_close(
-            comps_cuda[sel], comps_torch[sel], rtol=0.01, atol=0.01
+            comps_cuda[sel], comps_torch[sel], rtol=0.01, atol=_comps_atol
         )
     else:
         # Boundary mask = "any of the 7 UT sigma points might project within
@@ -1002,13 +1051,17 @@ def test_fully_fused_projection_ut(
         # CUDA does not expose per-sigma-point projections, so a true cross
         # predicate cannot be written here; the boundary mask is a geometric
         # proxy.
+        # FTheta calibration on this fixture: interior max_abs=1.42e-2 and
+        # boundary flip ratio=0.1368%; use 1.05x envelopes.
+        _comps_interior_atol = 1.5e-2 if camera_model == "ftheta" else 7e-3
+        _comps_boundary_flip_cap = 1.5e-3 if camera_model == "ftheta" else 4.5e-4
         assert_close_with_boundary_band(
             comps_cuda[sel],
             comps_torch[sel],
             boundary_mask=boundary_mask,
-            interior_atol=7e-3,
+            interior_atol=_comps_interior_atol,
             interior_rtol=0.01,
-            boundary_max_flip_ratio=4.5e-4,  # 1.05 x observed worst (4.23e-4)
+            boundary_max_flip_ratio=_comps_boundary_flip_cap,
             boundary_symmetry_tol=1.0,  # disabled: too few flips meaningful
             flip_predicate=lambda a, e: (a - e).abs() > 7e-3,
             boundary_cross_predicate=None,
@@ -1025,6 +1078,142 @@ def test_fully_fused_projection_ut(
             f"exceed outlier bound atol=0.46; worst diff "
             f"{_diff_a.max().item():.4e}"
         )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for UT projection"
+)
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
+def test_fully_fused_projection_ut_ftheta_straddles_camera_plane():
+    """Invalid FTheta sigma points still contribute their clamped projections."""
+    from gsplat.cuda._torch_impl_ut import _fully_fused_projection_with_ut
+    from gsplat.cuda._wrapper import fully_fused_projection_with_ut
+
+    focal = 80.0
+    width, height = 640, 480
+    means = torch.tensor([[0.2, 0.1, 0.04]], device=device)
+    scales = torch.tensor([[0.05, 0.08, 0.4]], device=device)
+    ftheta_coeffs = FThetaCameraDistortionParameters(
+        reference_poly=FThetaPolynomialType.ANGLE_TO_PIXELDIST,
+        pixeldist_to_angle_poly=(0.0, 1.0 / focal, 0.0, 0.0, 0.0, 0.0),
+        angle_to_pixeldist_poly=(0.0, focal, 0.0, 0.0, 0.0, 0.0),
+        max_angle=math.radians(85.0),
+        linear_cde=(1.0, 0.0, 0.0),
+    )
+    ut_params = UnscentedTransformParameters(
+        alpha=0.1,
+        beta=2.0,
+        kappa=0.0,
+        require_all_sigma_points_valid=False,
+    )
+
+    near_plane = 0.01
+    # The center passes the near-plane test, while the negative-z sigma point
+    # lies outside this <= pi/2 FTheta cone and is projected at max_angle.
+    # Sigma-point offset along z is sqrt(n + lambda) * scale, with n = 3 the UT
+    # state dimension and lambda = alpha**2 * (n + kappa) - n, which collapses
+    # to alpha * sqrt(n) at kappa = 0.
+    sigma_spread_z = ut_params.alpha * math.sqrt(3) * scales[0, 2]
+    assert means[0, 2] > near_plane
+    assert means[0, 2] - sigma_spread_z < 0.0
+
+    parameters = {
+        "means": means,
+        "quats": torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device),
+        "scales": scales,
+        "opacities": None,
+        "viewmats": torch.eye(4, device=device).reshape(1, 4, 4),
+        "Ks": torch.tensor(
+            [
+                [
+                    [1.0, 0.0, width / 2],
+                    [0.0, 1.0, height / 2],
+                    [0.0, 0.0, 1.0],
+                ]
+            ],
+            device=device,
+        ),
+        "width": width,
+        "height": height,
+        "camera_model": "ftheta",
+        "ftheta_coeffs": ftheta_coeffs,
+        "eps2d": 0.3,
+        "near_plane": near_plane,
+        "far_plane": 1e10,
+        "ut_params": ut_params,
+    }
+
+    radii_cuda, means2d_cuda, _, conics_cuda, _ = fully_fused_projection_with_ut(
+        **parameters
+    )
+    radii_torch, means2d_torch, _, conics_torch, _ = _fully_fused_projection_with_ut(
+        **parameters
+    )
+
+    assert (radii_cuda > 0).all()
+    assert (radii_torch > 0).all()
+
+    # Pin the footprint so changing both implementations in lockstep cannot
+    # restore the old (0, 0)-sentinel contribution unnoticed.
+    expected_means2d = torch.tensor([[[191.88852, 172.81131]]], device=device)
+    torch.testing.assert_close(means2d_cuda, expected_means2d, rtol=0, atol=5e-2)
+    torch.testing.assert_close(means2d_torch, expected_means2d, rtol=0, atol=5e-2)
+    torch.testing.assert_close(means2d_cuda, means2d_torch, rtol=2e-3, atol=5e-2)
+    torch.testing.assert_close(conics_cuda, conics_torch, rtol=2e-3, atol=2e-3)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for UT projection"
+)
+@pytest.mark.skipif(not gsplat.has_3dgut(), reason="3DGUT support isn't built in")
+def test_fully_fused_projection_ut_ftheta_culling_branch():
+    """FTheta switches from signed-z to radial culling with distance sorting."""
+    from gsplat.cuda._torch_impl_ut import _fully_fused_projection_with_ut
+    from gsplat.cuda._wrapper import fully_fused_projection_with_ut
+
+    focal = 80.0
+    width, height = 640, 480
+    parameters = {
+        "means": torch.tensor([[0.2, 0.1, -0.04]], device=device),
+        "quats": torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device),
+        "scales": torch.full((1, 3), 0.01, device=device),
+        "opacities": None,
+        "viewmats": torch.eye(4, device=device).reshape(1, 4, 4),
+        "Ks": torch.tensor(
+            [
+                [
+                    [1.0, 0.0, width / 2],
+                    [0.0, 1.0, height / 2],
+                    [0.0, 0.0, 1.0],
+                ]
+            ],
+            device=device,
+        ),
+        "width": width,
+        "height": height,
+        "camera_model": "ftheta",
+        "ftheta_coeffs": FThetaCameraDistortionParameters(
+            reference_poly=FThetaPolynomialType.ANGLE_TO_PIXELDIST,
+            pixeldist_to_angle_poly=(0.0, 1.0 / focal, 0.0, 0.0, 0.0, 0.0),
+            angle_to_pixeldist_poly=(0.0, focal, 0.0, 0.0, 0.0, 0.0),
+            max_angle=math.radians(120.0),
+            linear_cde=(1.0, 0.0, 0.0),
+        ),
+        "eps2d": 0.3,
+        "near_plane": 0.01,
+        "far_plane": 1e10,
+        "ut_params": UnscentedTransformParameters(),
+    }
+
+    for projection in (
+        fully_fused_projection_with_ut,
+        _fully_fused_projection_with_ut,
+    ):
+        radii_global_z = projection(**parameters, global_z_order=True)[0]
+        radii_radial = projection(**parameters, global_z_order=False)[0]
+
+        assert (radii_global_z == 0).all()
+        assert (radii_radial > 0).all()
 
 
 @pytest.mark.skipif(

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -788,16 +788,22 @@ class TestCameraModels:
 
         # Validity mismatch handling.
         #
-        # The validity flag is `not_behind_camera & converged & (theta <=
-        # max_angle) & valid_bounds`. Empirically, the FP-amplifier on this
-        # path is the Newton iteration that inverts the ftheta polynomial
-        # (`_eval_poly_inverse_horner_newton`); each iteration's residual is
-        # within ULP of the convergence threshold (|dx|<1e-6) for rays at
-        # high incidence (z near 0, theta near pi/2). ULP noise can
-        # flip the convergence flag, which then zeros image_point and flips
-        # validity. The flip is in INTERNAL Newton state -- not directly
-        # observable from outside the kernel -- so we cannot write a strict
-        # cross predicate ("a was just-converged, b was just-not-converged").
+        # The FTheta validity flag is `(theta_full < max_angle) &
+        # valid_bounds`, compared against the *pre-clamp* angle. Negative-z
+        # rays have `theta_full > pi/2`, so they survive only when max_angle
+        # exceeds their own theta_full and the projection lands in bounds.
+        # Empirically, the FP-amplifier on this path is the Newton iteration
+        # that inverts the ftheta polynomial
+        # (`_eval_poly_inverse_horner_newton`). Neither implementation gates
+        # validity on Newton's `converged` flag; both discard it. What flips
+        # is the value:
+        #   - ULP drift in `delta` moves `image_point` by a fraction of a
+        #     pixel and can flip `valid_bounds` for a ray on the image border;
+        #   - ULP drift in `theta_full` can flip `theta_full < max_angle` for
+        #     a ray on the cone edge.
+        # The drift is internal to the polynomial evaluation -- not observable
+        # from outside the kernel -- so we cannot write a strict cross
+        # predicate.
         # We rely on:
         #   interior assert (exact agreement off-band) -- regression catcher
         #   band flip-rate cap                        -- absorb FP noise
@@ -830,6 +836,8 @@ class TestCameraModels:
         boundary_mask = (theta_full > 1.0) | ((max_angle - theta_full).abs() < 5e-2)
 
         # Calibration trace (RTX PRO 2000):
+        # Measured before the behind-camera guard was dropped from the FTheta
+        # validity flag; negative-z rays inside max_angle were all invalid then.
         #   - boundary band: rays at theta > 1.3 rad or within 0.05 of max_angle
         #   - in-band flips:
         #       * 493/N_band  (1.52% of total)  ftheta[pinhole+p2a] arms
@@ -1000,6 +1008,65 @@ def test_projection_rejects_rays_beyond_max_angle(test_camera, ref_camera):
         f"validity divergence: cuda={test_valid.flatten().tolist()} "
         f"ref={ref_valid.flatten().tolist()}"
     )
+
+
+@pytest.mark.parametrize(
+    "reference_poly",
+    [
+        FThetaPolynomialType.ANGLE_TO_PIXELDIST,
+        FThetaPolynomialType.PIXELDIST_TO_ANGLE,
+    ],
+)
+def test_ftheta_camera_supports_negative_z_with_wide_fov(reference_poly):
+    """FTheta keeps rays behind z=0 when they remain inside max_angle."""
+    device = torch.device("cuda")
+    focal = 15.0
+    cx, cy = 160.0, 120.0
+    max_angle = math.radians(120.0)
+    ftheta_coeffs = FThetaCameraDistortionParameters(
+        reference_poly=reference_poly,
+        pixeldist_to_angle_poly=(0.0, 1.0 / focal, 0.0, 0.0, 0.0, 0.0),
+        angle_to_pixeldist_poly=(0.0, focal, 0.0, 0.0, 0.0, 0.0),
+        max_angle=max_angle,
+        linear_cde=(1.0, 0.0, 0.0),
+    )
+    camera_params = {
+        "camera_model": "ftheta",
+        "width": 320,
+        "height": 240,
+        "principal_points": torch.tensor([[cx, cy]], device=device),
+        "ftheta_coeffs": ftheta_coeffs,
+    }
+    cameras = (
+        create_camera_model(**camera_params),
+        _BaseCameraModel.create(**camera_params),
+    )
+    valid_theta = math.radians(100.0)
+    invalid_theta = max_angle + math.radians(1.0)
+    rays = torch.tensor(
+        [
+            [math.sin(valid_theta), 0.0, math.cos(valid_theta)],
+            [math.sin(invalid_theta), 0.0, math.cos(invalid_theta)],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    # FTheta offsets the principal point by half a pixel because the image
+    # origin is the centre of the first pixel.
+    expected = torch.tensor([cx + 0.5 + focal * valid_theta, cy + 0.5], device=device)
+    for camera in cameras:
+        image_points, valid = camera.camera_ray_to_image_point(rays, 0.0)
+
+        assert valid.flatten().tolist() == [True, False]
+        # Reuse the file-wide FTheta budget above, calibrated to 1.05x the
+        # observed maximum CUDA/reference residual.
+        torch.testing.assert_close(
+            image_points.reshape(-1, 2)[0],
+            expected,
+            atol=1.6e-5,
+            rtol=1.8e-7,
+        )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")


### PR DESCRIPTION
This PR cherry-picks support for FTheta camera FOVs > 180 degrees for upstreaming.