### PR TITLE
Fix batched Gaussian state accumulation

### DIFF
--- a/gsplat/strategy/default.py
+++ b/gsplat/strategy/default.py
@@ -265,9 +265,9 @@ class DefaultStrategy(Strategy):
             gs_ids = info["gaussian_ids"]  # [nnz]
             radii = info["radii"].max(dim=-1).values  # [nnz]
         else:
-            # grads is [C, N, 2]
-            sel = (info["radii"] > 0.0).all(dim=-1)  # [C, N]
-            gs_ids = torch.where(sel)[1]  # [nnz]
+            # grads is [..., C, N, 2]
+            sel = (info["radii"] > 0.0).all(dim=-1)  # [..., C, N]
+            gs_ids = torch.where(sel)[-1]  # [nnz]
             grads = grads[sel]  # [nnz, 2]
             radii = info["radii"][sel].max(dim=-1).values  # [nnz]
         state["grad2d"].index_add_(0, gs_ids, grads.norm(dim=-1))

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -46,6 +46,45 @@ def test_mcmc_strategy_positional_constructor():
     assert strategy.noise_opacity_k == 30.0
 
 
+def test_default_strategy_accumulates_batched_observations_by_gaussian():
+    from gsplat.strategy import DefaultStrategy
+
+    n_gaussians = 3
+    means2d = torch.zeros(2, 2, n_gaussians, 2, requires_grad=True)
+    gradients = torch.zeros_like(means2d)
+    radii = torch.zeros(2, 2, n_gaussians, 2)
+
+    visible_observations = [
+        (0, 0, 0, 1.0),
+        (0, 1, 1, 2.0),
+        (1, 0, 2, 3.0),
+        (1, 1, 0, 4.0),
+    ]
+    for batch, camera, gaussian, gradient in visible_observations:
+        gradients[batch, camera, gaussian, 0] = gradient
+        radii[batch, camera, gaussian] = 1.0
+    means2d.grad = gradients
+
+    strategy = DefaultStrategy()
+    state = strategy.initialize_state()
+    strategy._update_state(
+        params={"means": torch.empty(n_gaussians, 3)},
+        state=state,
+        info={
+            "width": 2,
+            "height": 2,
+            "n_cameras": 2,
+            "radii": radii,
+            "gaussian_ids": None,
+            "means2d": means2d,
+        },
+        packed=False,
+    )
+
+    torch.testing.assert_close(state["count"], torch.tensor([2.0, 1.0, 1.0]))
+    torch.testing.assert_close(state["grad2d"], torch.tensor([10.0, 4.0, 6.0]))
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.skipif(not gsplat.has_3dgs(), reason="3DGS support isn't built in")
 def test_strategy():


### PR DESCRIPTION
## Summary

Fix `DefaultStrategy` state accumulation when non-packed rasterization outputs include leading batch dimensions.

For the original `[C, N]` visibility mask, `torch.where(sel)[1]` identifies the Gaussian dimension. With batched inputs, however, the mask is shaped `[..., C, N]`, so coordinate 1 can be a batch or camera coordinate instead. Gradients and visibility counts are consequently accumulated into the wrong Gaussians without raising an error.

## Approach

Use the last coordinate returned by `torch.where(sel)` as the Gaussian ID. The final mask dimension is always `N`, independent of the number of leading batch and camera dimensions.

The existing masked gradient and radius selection remains unchanged, so every visible batch-camera observation continues to contribute independently to the accumulated gradient and visibility count. The observations are not collapsed across batches because doing so would change the averaging semantics used by the densification strategy.

## Regression coverage

Add a CPU regression with:

- 2 batches
- 2 cameras
- 3 Gaussians
- different visible Gaussians and gradient magnitudes in each batch-camera pair

Before the fix, the strategy assigns observations according to camera coordinates, producing counts `[2, 2, 0]` and accumulated gradients `[8, 12, 0]`. With the fix, observations are assigned by Gaussian index, producing the expected counts `[2, 1, 1]` and gradients `[10, 4, 6]`.

## Test results

- `pytest -q tests/test_strategy.py`: 2 passed, 2 skipped
- `pytest -q tests`: 539 passed, 342 skipped
- `black --check --diff --required-version 22.3.0 gsplat/strategy/default.py tests/test_strategy.py`
- `git diff --check`

The skipped tests require CUDA or native CUDA kernels and are unrelated to this CPU state-accumulation path.

Fixes #854
