### PR TITLE
[NV] Expand intersection offsets to 64-bit

### DIFF
--- a/gsplat/cuda/_torch_impl.py
+++ b/gsplat/cuda/_torch_impl.py
@@ -478,7 +478,7 @@ def _isect_offset_encode(
 
     cum_tile_counts = torch.cumsum(tile_counts.flatten(), dim=0).reshape_as(tile_counts)
     offsets = cum_tile_counts - tile_counts
-    return offsets.int()
+    return offsets
 
 
 @torch.no_grad()
@@ -499,7 +499,7 @@ def _isect_tiles_sparse(
     Restricts the tile-intersection enumeration to the tiles flagged active in
     ``tile_mask`` and returns the *compacted* per-active-tile offset table:
 
-      * ``tile_offsets`` — int32 ``[num_active_tiles + 1]``. ``tile_offsets[i]``
+      * ``tile_offsets`` — int64 ``[num_active_tiles + 1]``. ``tile_offsets[i]``
         is the exclusive prefix-sum start of the flatten-id range for
         ``active_tiles[i]`` (active tiles in ascending dense-id order); the
         trailing sentinel ``tile_offsets[-1] == n_isects``.
@@ -580,7 +580,7 @@ def _isect_tiles_sparse(
     n_isects = len(f_ids)
     if n_isects == 0:
         tile_offsets = torch.zeros(
-            active_tiles.numel() + 1, dtype=torch.int32, device=device
+            active_tiles.numel() + 1, dtype=torch.int64, device=device
         )
         flatten_ids = torch.empty(0, dtype=torch.int32, device=device)
         return tile_offsets, flatten_ids
@@ -597,9 +597,9 @@ def _isect_tiles_sparse(
 
     # Compacted offsets: first position of each active tile's range in g_sorted.
     active = active_tiles.to(torch.int64)
-    starts = torch.searchsorted(g_sorted, active, right=False).to(torch.int32)
+    starts = torch.searchsorted(g_sorted, active, right=False)
     tile_offsets = torch.cat(
-        [starts, torch.tensor([n_isects], dtype=torch.int32, device=device)]
+        [starts, torch.tensor([n_isects], dtype=torch.int64, device=device)]
     )
     return tile_offsets, flatten_ids
 

--- a/gsplat/cuda/_torch_impl_eval3d.py
+++ b/gsplat/cuda/_torch_impl_eval3d.py
@@ -272,7 +272,7 @@ def accumulate_eval3d(
     image_ids: Tensor,  # [M]
     image_width: int,
     image_height: int,
-    flatten_idx: Tensor,  # [M] - index in original flatten_ids
+    flatten_idx: Tensor,  # [M] - offset within each sample's tile range
     rays: Tensor,  # [I, P, 6]
     base_transmittance: Optional[
         Tensor
@@ -300,7 +300,7 @@ def accumulate_eval3d(
         image_ids: Image indices for intersections. [M]
         image_width: Image width.
         image_height: Image height.
-        flatten_idx: Index in original flatten_ids [M]
+        flatten_idx: Offset within each sample's tile range in flatten_ids [M]
         rays: Pre-computed rays (origin + direction). [I, P, 6]
         base_transmittance: Optional base transmittance for batched accumulation.
                            Shape: [I, image_height, image_width]. If provided,
@@ -309,7 +309,7 @@ def accumulate_eval3d(
     Returns:
         - **renders**: Accumulated colors. [..., image_height, image_width, channels]
         - **alphas**: Accumulated opacities. [..., image_height, image_width, 1]
-        - **last_ids**: Last flatten_idx per pixel. [..., image_height, image_width]
+        - **last_ids**: Last tile-local flatten_ids offset per pixel. [..., image_height, image_width]
         - **sample_counts**: Number of samples per pixel. [..., image_height, image_width]
         - **normals**: Accumulated normals if return_normals=True, else None. [..., image_height, image_width, 3]
     """
@@ -459,9 +459,10 @@ def accumulate_eval3d(
     else:
         normals = None
 
-    # Compute last flatten_idx per pixel (vectorized using packed_info)
-    # CUDA stores: last_ids[pix_id] = cur_idx (index in flatten_ids)
-    # PyTorch stores: last_ids[ray_id] = flatten_idx (same indexing as CUDA)
+    # Compute the last tile-local flatten_ids offset per pixel (vectorized
+    # using packed_info). CUDA keeps this metadata tile-local so it remains
+    # representable as int32 when the global intersection array exceeds 2^31
+    # entries; mirror that contract here.
 
     # Create packed_info from final filtered indices
     from nerfacc import pack_info
@@ -551,8 +552,8 @@ def _rasterize_to_pixels_eval3d(
         batch_per_iter: Batch size for iterative processing
         viewmats_rs: Optional end pose for rolling shutter [..., C, 4, 4]
         rs_type: Rolling shutter type
-        return_last_ids: If True, return the index of the last Gaussian contributing
-            to each pixel. Default: False.
+        return_last_ids: If True, return the tile-local ``flatten_ids`` offset
+            of the last Gaussian contributing to each pixel. Default: False.
         return_sample_counts: If True, return the number of samples (Gaussians)
             evaluated per pixel. Default: False.
         return_normals: If True, compute and return accumulated normals per pixel.
@@ -756,10 +757,12 @@ def _rasterize_to_pixels_eval3d(
                         )
                     num_pixels = len(pix_ids_in_tile)
 
-                    # Create flatten_ids indices for this batch
+                    # Create tile-local flatten_ids offsets for this batch.
+                    # CUDA last_ids is intentionally tile-local so its int32
+                    # metadata remains valid with int64 global offsets.
                     batch_flatten_indices = torch.arange(
-                        start_idx + local_start,
-                        start_idx + local_end,
+                        local_start,
+                        local_end,
                         device=device,
                         dtype=torch.long,
                     )

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1385,7 +1385,7 @@ def isect_tiles_sparse(
     Returns:
         A tuple:
 
-        - **Tile offsets**. Int32 [num_active_tiles + 1]. ``tile_offsets[i]`` is
+        - **Tile offsets**. Int64 [num_active_tiles + 1]. ``tile_offsets[i]`` is
           the exclusive prefix-sum start of the flatten-id range for
           ``active_tiles[i]``; the trailing sentinel ``tile_offsets[-1] ==
           n_isects``.
@@ -2398,7 +2398,8 @@ def rasterize_to_pixels_eval3d_extra(
     kernel raises ``ValueError``.
 
     Args:
-        return_last_ids: If True, also return last flatten_idx per pixel. Default: True.
+        return_last_ids: If True, also return the last tile-local offset in
+            ``flatten_ids`` per pixel. Default: True.
         return_sample_counts: If True, also return number of accumulated samples per pixel. Default: False.
         return_normals: If True, compute and return accumulated normals per pixel.
             Normals are computed from Gaussian quaternions (canonical normal = (0,0,1)
@@ -2418,7 +2419,8 @@ def rasterize_to_pixels_eval3d_extra(
 
         - **Rendered colors**. [..., C, image_height, image_width, channels]
         - **Rendered alphas**. [..., C, image_height, image_width, 1]
-        - **Last flatten_idx** (optional). [..., C, image_height, image_width]. If return_last_ids=True.
+        - **Last tile-local flatten_ids offset** (optional). [..., C, image_height,
+          image_width]. If return_last_ids=True.
         - **Sample counts** (optional). [..., C, image_height, image_width]. If return_sample_counts=True.
         - **Rendered normals** (optional). [..., C, image_height, image_width, 3]. If return_normals=True.
     """

--- a/gsplat/cuda/csrc/Intersect.cpp
+++ b/gsplat/cuda/csrc/Intersect.cpp
@@ -555,7 +555,7 @@ at::Tensor intersect_offset(
     CHECK_INPUT(isect_ids);
 
     auto opt           = isect_ids.options();
-    at::Tensor offsets = at::empty({I, tile_height, tile_width}, opt.dtype(at::kInt));
+    at::Tensor offsets = at::empty({I, tile_height, tile_width}, opt.dtype(at::kLong));
     launch_intersect_offset_kernel(isect_ids, I, tile_width, tile_height, offsets);
     return offsets;
 }
@@ -682,7 +682,7 @@ std::tuple<at::Tensor, at::Tensor> intersect_tile_sparse(
 
     // Compacted per-active-tile offsets ([num_active_tiles + 1]).
     const int64_t num_active_tiles = active_tiles.size(0);
-    at::Tensor tile_offsets        = at::empty({num_active_tiles + 1}, active_tiles.options().dtype(at::kInt));
+    at::Tensor tile_offsets        = at::empty({num_active_tiles + 1}, active_tiles.options().dtype(at::kLong));
     launch_intersect_offset_sparse_kernel(isect_ids_sorted, active_tiles, tile_width, tile_height, tile_offsets);
 
     return std::make_tuple(tile_offsets, flatten_ids_sorted);
@@ -800,7 +800,7 @@ at::Tensor intersect_offset_privateuseone(
     CHECK_INPUT(isect_ids);
 
     auto opt           = isect_ids.options();
-    at::Tensor offsets = at::empty({I, tile_height, tile_width}, opt.dtype(at::kInt));
+    at::Tensor offsets = at::empty({I, tile_height, tile_width}, opt.dtype(at::kLong));
     launch_intersect_offset_kernels(isect_ids, I, tile_width, tile_height, offsets);
     return offsets;
 }

--- a/gsplat/cuda/csrc/Intersect.h
+++ b/gsplat/cuda/csrc/Intersect.h
@@ -222,7 +222,7 @@ void launch_intersect_offset_sparse_kernel(
     const uint32_t tile_width,
     const uint32_t tile_height,
     // outputs
-    at::Tensor offsets // [num_active_tiles + 1] int32
+    at::Tensor offsets // [num_active_tiles + 1] int64
 );
 
 // One thread per pixel: tightly packs the dense tile id and raster-order in-tile

--- a/gsplat/cuda/csrc/IntersectTile.cu
+++ b/gsplat/cuda/csrc/IntersectTile.cu
@@ -923,46 +923,46 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> intersect_tile_kernels_privateuse
 }
 
 __global__ void intersect_offset_kernel(
-    const uint32_t offset,
-    const uint32_t count,
-    const uint32_t n_isects,
+    const int64_t offset,
+    const int64_t count,
+    const int64_t n_isects,
     const int64_t *__restrict__ isect_ids,
     const uint32_t I,
     const uint32_t n_tiles,
     const uint32_t tile_n_bits,
-    int32_t *__restrict__ offsets // [I, n_tiles]
+    int64_t *__restrict__ offsets // [I, n_tiles]
 )
 {
     // e.g., ids: [1, 1, 1, 3, 3], n_tiles = 6
     // counts: [0, 3, 0, 2, 0, 0]
     // cumsum: [0, 3, 3, 5, 5, 5]
     // offsets: [0, 0, 3, 3, 5, 5]
-    uint32_t idx = cg::this_grid().thread_rank();
-    if(idx >= count)
+    const int64_t local_idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if(local_idx >= count)
     {
         return;
     }
-    idx += offset;
+    const int64_t idx = local_idx + offset;
 
     int64_t isect_id_curr = isect_ids[idx] >> 32;
     int64_t iid_curr      = isect_id_curr >> (tile_n_bits);
-    int64_t tid_curr      = isect_id_curr & ((1 << tile_n_bits) - 1);
+    int64_t tid_curr      = isect_id_curr & ((uint64_t{1} << tile_n_bits) - 1);
     int64_t id_curr       = iid_curr * n_tiles + tid_curr;
 
     if(idx == 0)
     {
         // write out the offsets until the first valid tile (inclusive)
-        for(uint32_t i = 0; i < id_curr + 1; ++i)
+        for(int64_t i = 0; i < id_curr + 1; ++i)
         {
-            offsets[i] = static_cast<int32_t>(idx);
+            offsets[i] = idx;
         }
     }
     if(idx == n_isects - 1)
     {
         // write out the rest of the offsets
-        for(uint32_t i = id_curr + 1; i < I * n_tiles; ++i)
+        for(int64_t i = id_curr + 1; i < static_cast<int64_t>(I) * n_tiles; ++i)
         {
-            offsets[i] = static_cast<int32_t>(n_isects);
+            offsets[i] = n_isects;
         }
     }
 
@@ -978,11 +978,11 @@ __global__ void intersect_offset_kernel(
 
         // write out the offsets between the previous and current tiles
         int64_t iid_prev = isect_id_prev >> (tile_n_bits);
-        int64_t tid_prev = isect_id_prev & ((1 << tile_n_bits) - 1);
+        int64_t tid_prev = isect_id_prev & ((uint64_t{1} << tile_n_bits) - 1);
         int64_t id_prev  = iid_prev * n_tiles + tid_prev;
-        for(uint32_t i = id_prev + 1; i < id_curr + 1; ++i)
+        for(int64_t i = id_prev + 1; i < id_curr + 1; ++i)
         {
-            offsets[i] = static_cast<int32_t>(idx);
+            offsets[i] = idx;
         }
     }
 }
@@ -1020,7 +1020,7 @@ void launch_intersect_offset_kernel(
         I,
         n_tiles,
         tile_n_bits,
-        offsets.data_ptr<int32_t>()
+        offsets.data_ptr<int64_t>()
     );
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -1065,7 +1065,7 @@ void launch_intersect_offset_kernels(
                 I,
                 n_tiles,
                 tile_n_bits,
-                offsets.data_ptr<int32_t>()
+                offsets.data_ptr<int64_t>()
             );
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         }

--- a/gsplat/cuda/csrc/IntersectTileSparse.cu
+++ b/gsplat/cuda/csrc/IntersectTileSparse.cu
@@ -41,7 +41,7 @@ __global__ void intersect_offset_sparse_kernel(
     const uint32_t num_active_tiles,
     const uint32_t n_tiles,
     const uint32_t tile_n_bits,
-    int32_t *__restrict__ offsets // [num_active_tiles + 1]
+    int64_t *__restrict__ offsets // [num_active_tiles + 1]
 )
 {
     uint32_t i = cg::this_grid().thread_rank();
@@ -53,7 +53,7 @@ __global__ void intersect_offset_sparse_kernel(
     // Trailing sentinel.
     if(i == num_active_tiles)
     {
-        offsets[i] = static_cast<int32_t>(n_isects);
+        offsets[i] = n_isects;
         return;
     }
 
@@ -78,7 +78,7 @@ __global__ void intersect_offset_sparse_kernel(
             hi = mid;
         }
     }
-    offsets[i] = static_cast<int32_t>(lo);
+    offsets[i] = lo;
 }
 
 void launch_intersect_offset_sparse_kernel(
@@ -88,7 +88,7 @@ void launch_intersect_offset_sparse_kernel(
     const uint32_t tile_width,
     const uint32_t tile_height,
     // outputs
-    at::Tensor offsets // [num_active_tiles + 1] int32
+    at::Tensor offsets // [num_active_tiles + 1] int64
 )
 {
     const int64_t n_isects          = isect_ids.size(0);
@@ -107,7 +107,7 @@ void launch_intersect_offset_sparse_kernel(
         num_active_tiles,
         n_tiles,
         tile_n_bits,
-        offsets.data_ptr<int32_t>()
+        offsets.data_ptr<int64_t>()
     );
 }
 } // namespace gsplat

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -1022,7 +1022,7 @@ RasterizeToIndices3DGSResult rasterize_to_indices_3dgs(
     at::TensorOptions opt = means2d.options();
     uint32_t I            = (N == 0) ? 0 : means2d.numel() / (2 * N); // number of images
 
-    uint32_t n_isects = flatten_ids.size(0);
+    int64_t n_isects = flatten_ids.size(0);
 
     // First pass: count the number of gaussians that contribute to each pixel
     int64_t n_elems;
@@ -2289,7 +2289,7 @@ RasterizeToIndices2DGSResult rasterize_to_indices_2dgs(
     auto opt   = means2d.options();
     uint32_t I = (N == 0) ? 0 : means2d.numel() / (2 * N); // number of images
 
-    uint32_t n_isects = flatten_ids.size(0);
+    int64_t n_isects = flatten_ids.size(0);
 
     // First pass: count the number of gaussians that contribute to each pixel
     int64_t n_elems;

--- a/gsplat/cuda/csrc/RasterizeCSR.cuh
+++ b/gsplat/cuda/csrc/RasterizeCSR.cuh
@@ -222,12 +222,11 @@ public:
     }
 
     __device__ void set(
-        int32_t last_idx_global, int32_t n_accumulated, int32_t logical_batch_start, bool terminal_batch = false
+        int32_t last_idx_tile, int32_t n_accumulated, int32_t logical_batch_offset, bool terminal_batch = false
     )
     {
-        *value_ = make_ushort2(
-            encodeLast(last_idx_global, logical_batch_start), encodeCount(n_accumulated, terminal_batch)
-        );
+        *value_
+            = make_ushort2(encodeLast(last_idx_tile, logical_batch_offset), encodeCount(n_accumulated, terminal_batch));
     }
 
     __device__ void reset()
@@ -241,14 +240,14 @@ public:
         return (pair.y & BATCH_REPLAY_FLAG) != 0u;
     }
 
-    __device__ int32_t last(int32_t logical_batch_start) const
+    __device__ int32_t last(int32_t logical_batch_offset) const
     {
         const ushort2 pair = *value_;
         if(pair.x == 0u)
         {
             return -1;
         }
-        return logical_batch_start + static_cast<int32_t>(pair.x) - 1;
+        return logical_batch_offset + static_cast<int32_t>(pair.x) - 1;
     }
 
     __device__ bool isTerminalBatch() const
@@ -284,15 +283,15 @@ private:
     //      batch-replay flag; fwd-only mode uses the same high bit per
     //      pixel to mark the terminal pre-threshold batch.
     //
-    // The full global last index is reconstructed from the batch's global
-    // start. This keeps the transient partials tensor compact without changing
-    // the final `last_ids` / `sample_counts` semantics.
-    static __device__ uint16_t encodeLast(int32_t last_idx_global, int32_t logical_batch_start)
+    // The full tile-local last index is reconstructed from the batch's local
+    // start. Keeping final `last_ids` tile-local lets the metadata remain int32
+    // when global intersection offsets require int64.
+    static __device__ uint16_t encodeLast(int32_t last_idx_tile, int32_t logical_batch_offset)
     {
-        if(last_idx_global >= 0)
+        if(last_idx_tile >= 0)
         {
-            assert(last_idx_global >= logical_batch_start);
-            const int32_t last_local = last_idx_global - logical_batch_start;
+            assert(last_idx_tile >= logical_batch_offset);
+            const int32_t last_local = last_idx_tile - logical_batch_offset;
             assert(last_local >= 0);
             assert(last_local < 0xFFFF);
             return static_cast<uint16_t>(last_local + 1);

--- a/gsplat/cuda/csrc/RasterizeContributingCommon.cuh
+++ b/gsplat/cuda/csrc/RasterizeContributingCommon.cuh
@@ -30,13 +30,13 @@ constexpr int64_t rasterize_contributing_common_shmem_size()
 
 template<uint32_t TILE_SIZE, uint32_t CTA_SIZE, typename Accumulator>
 __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_kernel(
-    const uint32_t n_isects,
+    const int64_t n_isects,
     const vec2 *__restrict__ means2d,    // [I, N, 2] or [nnz, 2]
     const vec3 *__restrict__ conics,     // [I, N, 3] or [nnz, 3]
     const float *__restrict__ opacities, // [I, N] or [nnz]
     const uint32_t image_width,
     const uint32_t image_height,
-    const int32_t *__restrict__ tile_offsets, // [I, tile_height, tile_width]
+    const int64_t *__restrict__ tile_offsets, // [I, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     Accumulator accum
 )
@@ -97,12 +97,12 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_kernel
         }
     }
 
-    const int32_t range_start  = tile_offsets[tile_id];
-    const int32_t range_end    = (image_id == static_cast<int32_t>(gridDim.x) - 1)
-                                      && (tile_id == static_cast<int32_t>(grid_width * grid_height) - 1)
-                                   ? n_isects
-                                   : tile_offsets[tile_id + 1];
-    const uint32_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
+    const int64_t range_start = tile_offsets[tile_id];
+    const int64_t range_end   = (image_id == static_cast<int32_t>(gridDim.x) - 1)
+                                     && (tile_id == static_cast<int32_t>(grid_width * grid_height) - 1)
+                                  ? n_isects
+                                  : tile_offsets[tile_id + 1];
+    const int64_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
 
     extern __shared__ int s[];
     int32_t *id_batch      = reinterpret_cast<int32_t *>(s);                          // [BATCH_SIZE]
@@ -117,10 +117,10 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_kernel
     }
 
 #pragma unroll 1
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
-        const uint32_t batch_start = range_start + BATCH_SIZE * b;
-        const uint32_t idx         = batch_start + tid;
+        const int64_t batch_start = range_start + BATCH_SIZE * b;
+        const int64_t idx         = batch_start + tid;
         if(idx < range_end)
         {
             const int32_t g       = flatten_ids[idx]; // flatten index in [I * N] or [nnz]
@@ -139,7 +139,8 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_kernel
             __syncthreads();
         }
 
-        const uint32_t batch_size = min(BATCH_SIZE, static_cast<uint32_t>(range_end - batch_start));
+        const int64_t remaining   = range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < BATCH_SIZE ? remaining : BATCH_SIZE);
         for(uint32_t t = 0; (t < batch_size) && (done_mask != ALL_DONE); ++t)
         {
             const int32_t g        = id_batch[t];

--- a/gsplat/cuda/csrc/RasterizeContributingCommonSparse.cuh
+++ b/gsplat/cuda/csrc/RasterizeContributingCommonSparse.cuh
@@ -47,7 +47,7 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
     const uint32_t tile_height,
     // sparse layout
     const int32_t *__restrict__ active_tiles,      // [AT]
-    const int32_t *__restrict__ tile_offsets,      // [AT + 1]
+    const int64_t *__restrict__ tile_offsets,      // [AT + 1]
     const int32_t *__restrict__ flatten_ids,       // [n_isects]
     const uint64_t *__restrict__ tile_pixel_mask,  // [AT, words]
     const int64_t *__restrict__ tile_pixel_cumsum, // [AT], inclusive
@@ -111,9 +111,9 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
         pix_slot[p] = static_cast<int32_t>(slot);
     }
 
-    const int32_t range_start  = tile_offsets[ord];
-    const int32_t range_end    = tile_offsets[ord + 1];
-    const uint32_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
+    const int64_t range_start = tile_offsets[ord];
+    const int64_t range_end   = tile_offsets[ord + 1];
+    const int64_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
 
     extern __shared__ int s[];
     int32_t *id_batch      = reinterpret_cast<int32_t *>(s);                          // [BATCH_SIZE]
@@ -128,11 +128,11 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
     }
 
 #pragma unroll 1
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
-        const uint32_t batch_start = range_start + BATCH_SIZE * b;
-        const uint32_t idx         = batch_start + tid;
-        if(idx < static_cast<uint32_t>(range_end))
+        const int64_t batch_start = range_start + BATCH_SIZE * b;
+        const int64_t idx         = batch_start + tid;
+        if(idx < range_end)
         {
             const int32_t g       = flatten_ids[idx];
             id_batch[tid]         = g;
@@ -150,7 +150,8 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_contributing_common_sparse
             __syncthreads();
         }
 
-        const uint32_t batch_size = min(BATCH_SIZE, static_cast<uint32_t>(range_end - batch_start));
+        const int64_t remaining   = range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < BATCH_SIZE ? remaining : BATCH_SIZE);
         for(uint32_t t = 0; (t < batch_size) && (done_mask != ALL_DONE); ++t)
         {
             const int32_t g        = id_batch[t];

--- a/gsplat/cuda/csrc/RasterizeContributingLaunch.cuh
+++ b/gsplat/cuda/csrc/RasterizeContributingLaunch.cuh
@@ -55,10 +55,10 @@ void launch_contributing_dense(
     MakeAccum make_accum
 )
 {
-    const uint32_t grid_h   = tile_offsets.size(-2);
-    const uint32_t grid_w   = tile_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
-    const dim3 grid         = {I, grid_h, grid_w};
+    const uint32_t grid_h  = tile_offsets.size(-2);
+    const uint32_t grid_w  = tile_offsets.size(-1);
+    const int64_t n_isects = flatten_ids.size(0);
+    const dim3 grid        = {I, grid_h, grid_w};
 
     auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
     {
@@ -91,7 +91,7 @@ void launch_contributing_dense(
                 opacities.const_data_ptr<float>(),
                 image_width,
                 image_height,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 accum
             );
@@ -171,7 +171,7 @@ void launch_contributing_sparse(
                 tile_width,
                 tile_height,
                 active_tiles.const_data_ptr<int32_t>(),
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 tile_pixel_mask.const_data_ptr<uint64_t>(),
                 tile_pixel_cumsum.const_data_ptr<int64_t>(),

--- a/gsplat/cuda/csrc/RasterizeToIndices2DGSSerialBatch.cu
+++ b/gsplat/cuda/csrc/RasterizeToIndices2DGSSerialBatch.cu
@@ -38,7 +38,7 @@ __global__ void rasterize_to_indices_2dgs_kernel(
     const uint32_t range_end,
     const uint32_t I,
     const uint32_t N,
-    const uint32_t n_isects,
+    const int64_t n_isects,
     const vec2 *__restrict__ means2d,            // [..., N, 2]
     const scalar_t *__restrict__ ray_transforms, // [..., N, 3, 3]
     const scalar_t *__restrict__ opacities,      // [..., N]
@@ -47,7 +47,7 @@ __global__ void rasterize_to_indices_2dgs_kernel(
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
-    const int32_t *__restrict__ tile_offsets,    // [..., tile_height, tile_width]
+    const int64_t *__restrict__ tile_offsets,    // [..., tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,     // [n_isects]
     const scalar_t *__restrict__ transmittances, // [..., image_height, image_width]
     const int32_t *__restrict__ chunk_starts,    // [..., image_height, image_width]
@@ -89,11 +89,11 @@ __global__ void rasterize_to_indices_2dgs_kernel(
     // have all threads in tile process the same gaussians in batches
     // first collect gaussians between range.x and range.y in batches
     // which gaussians to look through in this tile
-    int32_t isect_range_start = tile_offsets[tile_id];
-    int32_t isect_range_end
+    const int64_t isect_range_start = tile_offsets[tile_id];
+    const int64_t isect_range_end
         = (image_id == I - 1) && (tile_id == tile_width * tile_height - 1) ? n_isects : tile_offsets[tile_id + 1];
     const uint32_t block_size = block.size();
-    uint32_t num_batches      = (isect_range_end - isect_range_start + block_size - 1) / block_size;
+    const int64_t num_batches = (isect_range_end - isect_range_start + block_size - 1) / block_size;
 
     if(range_start >= num_batches)
     {
@@ -125,8 +125,9 @@ __global__ void rasterize_to_indices_2dgs_kernel(
     // designated pixel
     uint32_t tr = block.thread_rank();
 
-    int32_t cnt = 0;
-    for(uint32_t b = range_start; b < min(range_end, num_batches); ++b)
+    int32_t cnt               = 0;
+    const int64_t batch_limit = range_end < num_batches ? range_end : num_batches;
+    for(int64_t b = range_start; b < batch_limit; ++b)
     {
         // resync all threads before beginning next batch
         // end early if entire tile is done
@@ -137,8 +138,8 @@ __global__ void rasterize_to_indices_2dgs_kernel(
 
         // each thread fetch 1 gaussian from front to back
         // index of gaussian to load
-        uint32_t batch_start = isect_range_start + block_size * b;
-        uint32_t idx         = batch_start + tr;
+        const int64_t batch_start = isect_range_start + block_size * b;
+        const int64_t idx         = batch_start + tr;
         if(idx < isect_range_end)
         {
             int32_t g            = flatten_ids[idx];
@@ -155,7 +156,8 @@ __global__ void rasterize_to_indices_2dgs_kernel(
         block.sync();
 
         // process gaussians in the current batch for this pixel
-        uint32_t batch_size = min(block_size, isect_range_end - batch_start);
+        const int64_t remaining   = isect_range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < block_size ? remaining : block_size);
         for(uint32_t t = 0; (t < batch_size) && !done; ++t)
         {
             const vec3 u_M     = u_Ms_batch[t];
@@ -251,7 +253,7 @@ void launch_rasterize_to_indices_2dgs_kernel(
     uint32_t I           = means2d.numel() / (2 * N); // number of images
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
 
     // Each block covers a tile on the image. In total there are
     // I * tile_height * tile_width blocks.
@@ -288,7 +290,7 @@ void launch_rasterize_to_indices_2dgs_kernel(
         tile_size,
         tile_width,
         tile_height,
-        tile_offsets.const_data_ptr<int32_t>(),
+        tile_offsets.const_data_ptr<int64_t>(),
         flatten_ids.const_data_ptr<int32_t>(),
         transmittances.const_data_ptr<float>(),
         chunk_starts.has_value() ? chunk_starts.value().const_data_ptr<int32_t>() : nullptr,

--- a/gsplat/cuda/csrc/RasterizeToIndices3DGSSerialBatch.cu
+++ b/gsplat/cuda/csrc/RasterizeToIndices3DGSSerialBatch.cu
@@ -39,7 +39,7 @@ __global__ void rasterize_to_indices_3dgs_kernel(
     const uint32_t range_end,
     const uint32_t I,
     const uint32_t N,
-    const uint32_t n_isects,
+    const int64_t n_isects,
     const vec2 *__restrict__ means2d,       // [..., N, 2]
     const vec3 *__restrict__ conics,        // [..., N, 3]
     const scalar_t *__restrict__ opacities, // [..., N]
@@ -48,7 +48,7 @@ __global__ void rasterize_to_indices_3dgs_kernel(
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
-    const int32_t *__restrict__ tile_offsets,    // [..., tile_height, tile_width]
+    const int64_t *__restrict__ tile_offsets,    // [..., tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,     // [n_isects]
     const scalar_t *__restrict__ transmittances, // [..., image_height, image_width]
     const int32_t *__restrict__ chunk_starts,    // [..., image_height, image_width]
@@ -90,11 +90,11 @@ __global__ void rasterize_to_indices_3dgs_kernel(
     // have all threads in tile process the same gaussians in batches
     // first collect gaussians between range.x and range.y in batches
     // which gaussians to look through in this tile
-    int32_t isect_range_start = tile_offsets[tile_id];
-    int32_t isect_range_end
+    const int64_t isect_range_start = tile_offsets[tile_id];
+    const int64_t isect_range_end
         = (image_id == I - 1) && (tile_id == tile_width * tile_height - 1) ? n_isects : tile_offsets[tile_id + 1];
     const uint32_t block_size = block.size();
-    uint32_t num_batches      = (isect_range_end - isect_range_start + block_size - 1) / block_size;
+    const int64_t num_batches = (isect_range_end - isect_range_start + block_size - 1) / block_size;
 
     if(range_start >= num_batches)
     {
@@ -124,8 +124,9 @@ __global__ void rasterize_to_indices_3dgs_kernel(
     // designated pixel
     uint32_t tr = block.thread_rank();
 
-    int32_t cnt = 0;
-    for(uint32_t b = range_start; b < min(range_end, num_batches); ++b)
+    int32_t cnt               = 0;
+    const int64_t batch_limit = range_end < num_batches ? range_end : num_batches;
+    for(int64_t b = range_start; b < batch_limit; ++b)
     {
         // resync all threads before beginning next batch
         // end early if entire tile is done
@@ -136,8 +137,8 @@ __global__ void rasterize_to_indices_3dgs_kernel(
 
         // each thread fetch 1 gaussian from front to back
         // index of gaussian to load
-        uint32_t batch_start = isect_range_start + block_size * b;
-        uint32_t idx         = batch_start + tr;
+        const int64_t batch_start = isect_range_start + block_size * b;
+        const int64_t idx         = batch_start + tr;
         if(idx < isect_range_end)
         {
             int32_t g            = flatten_ids[idx];
@@ -152,7 +153,8 @@ __global__ void rasterize_to_indices_3dgs_kernel(
         block.sync();
 
         // process gaussians in the current batch for this pixel
-        uint32_t batch_size = min(block_size, isect_range_end - batch_start);
+        const int64_t remaining   = isect_range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < block_size ? remaining : block_size);
         for(uint32_t t = 0; (t < batch_size) && !done; ++t)
         {
             const vec3 conic        = conic_batch[t];
@@ -225,7 +227,7 @@ void launch_rasterize_to_indices_3dgs_kernel(
     uint32_t I           = means2d.numel() / (2 * N); // number of images
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
 
     // Each block covers a tile on the image. In total there are
     // I * tile_height * tile_width blocks.
@@ -261,7 +263,7 @@ void launch_rasterize_to_indices_3dgs_kernel(
         tile_size,
         tile_width,
         tile_height,
-        tile_offsets.const_data_ptr<int32_t>(),
+        tile_offsets.const_data_ptr<int64_t>(),
         flatten_ids.const_data_ptr<int32_t>(),
         transmittances.const_data_ptr<float>(),
         chunk_starts.has_value() ? chunk_starts.value().const_data_ptr<int32_t>() : nullptr,

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchBwd.cu
@@ -39,10 +39,10 @@ namespace cg = cooperative_groups;
 
 template<uint32_t CDIM, typename scalar_t>
 __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
-    const uint32_t I,        // number of images
-    const uint32_t N,        // number of gaussians
-    const uint32_t n_isects, // number of ray-primitive intersections.
-    const bool packed,       // whether the input tensors are packed
+    const uint32_t I,       // number of images
+    const uint32_t N,       // number of gaussians
+    const int64_t n_isects, // number of ray-primitive intersections.
+    const bool packed,      // whether the input tensors are packed
     // fwd inputs
     const vec2 *__restrict__ means2d,            // Projected Gaussian means. [..., N, 2] if
                                                  // packed is False, [nnz, 2] if packed is True.
@@ -70,7 +70,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
-    const int32_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]
+    const int64_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
 
     // fwd outputs
@@ -160,12 +160,13 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
     // have all threads in tile process the same gaussians in batches
     // first collect gaussians between range.x and range.y in batches
     // which gaussians to look through in this tile
-    int32_t range_start = tile_offsets[tile_id];
-    int32_t range_end
+    const int64_t range_start = tile_offsets[tile_id];
+    const int64_t range_end
         = (image_id == I - 1) && (tile_id == tile_width * tile_height - 1) ? n_isects : tile_offsets[tile_id + 1];
-    const uint32_t block_size  = block.size();
+    const uint32_t block_size       = block.size();
+    const int64_t num_intersections = range_end - range_start;
     // number of batches needed to process all gaussians in this tile
-    const uint32_t num_batches = (range_end - range_start + block_size - 1) / block_size;
+    const int64_t num_batches       = (num_intersections + block_size - 1) / block_size;
 
     /**
      * ==============================
@@ -262,7 +263,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
      * =======================================================
      */
     // loop over all batches of primitives
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
         // resync all threads before writing next batch of shared mem
         block.sync();
@@ -270,20 +271,18 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
         // each thread fetch 1 gaussian from back to front
         // 0 index will be furthest back in batch
         // index of gaussian to load
-        // batch end is the index of the last gaussian in the batch
-        // These values can be negative so must be int32 instead of uint32
-
         // loop factors:
         // we start with loop end and interate backwards
-        const int32_t batch_end  = range_end - 1 - block_size * b;
-        const int32_t batch_size = min(block_size, batch_end + 1 - range_start);
+        const int64_t batch_end_offset = num_intersections - 1 - block_size * b;
+        const int64_t remaining        = batch_end_offset + 1;
+        const uint32_t batch_size      = static_cast<uint32_t>(remaining < block_size ? remaining : block_size);
 
         // VERY IMPORTANT HERE!
         // we are looping from back to front
         // so we are processing the gaussians in the order of closest to
         // furthest if you use symbolic solver on splatting rendering equations
         // you will see
-        const int32_t idx = batch_end - tr;
+        const int64_t idx = range_start + batch_end_offset - tr;
 
         /*
          * Fetch Gaussian Primitives and STORE THEM IN REVERSE ORDER
@@ -319,11 +318,13 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
          * BACKWARD LOOPING THROUGH PRIMITIVES
          * ==================================================
          */
-        for(uint32_t t = max(0, batch_end - warp_bin_final); t < batch_size; ++t)
+        const int64_t first_t64 = batch_end_offset > warp_bin_final ? batch_end_offset - warp_bin_final : 0;
+        const uint32_t first_t  = first_t64 < batch_size ? static_cast<uint32_t>(first_t64) : batch_size;
+        for(uint32_t t = first_t; t < batch_size; ++t)
         {
 
             bool valid = inside;
-            if(batch_end - t > bin_final)
+            if(batch_end_offset - t > bin_final)
             {
                 valid = 0;
             }
@@ -449,7 +450,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
             {
 
                 // gradient contribution from median depth
-                if(batch_end - t == median_idx)
+                if(batch_end_offset - t == median_idx)
                 {
                     // v_median is a special gradient input from forward pass
                     // not yet clear what this is for
@@ -745,7 +746,7 @@ void launch_rasterize_to_pixels_2dgs_bwd_kernel(
     uint32_t I           = render_alphas.numel() / (image_height * image_width); // number of images
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
 
     // Each block covers a tile on the image. In total there are
     // I * tile_height * tile_width blocks.
@@ -809,7 +810,7 @@ void launch_rasterize_to_pixels_2dgs_bwd_kernel(
                 tile_size,
                 tile_width,
                 tile_height,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 render_colors.const_data_ptr<float>(),
                 render_alphas.const_data_ptr<float>(),

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchFwd.cu
@@ -43,7 +43,7 @@ template<uint32_t CDIM, typename scalar_t>
 __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     const uint32_t I,                            // number of images
     const uint32_t N,                            // number of gaussians
-    const uint32_t n_isects,                     // number of ray-primitive intersections.
+    const int64_t n_isects,                      // number of ray-primitive intersections.
     const bool packed,                           // whether the input tensors are packed
     const vec2 *__restrict__ means2d,            // Projected Gaussian means. [..., N, 2] if
                                                  // packed is False, [nnz, 2] if packed is True.
@@ -70,7 +70,7 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
-    const int32_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]    //
+    const int64_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]    //
                                               // Intersection offsets outputs from
                                               // `isect_offset_encode()`, this is the
                                               // result of a prefix sum, and gives the
@@ -181,12 +181,12 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     // which gaussians to look through in this tile
 
     // print
-    int32_t range_start = tile_offsets[tile_id];
-    int32_t range_end =
+    const int64_t range_start = tile_offsets[tile_id];
+    const int64_t range_end =
         // see if this is the last tile in the image
         (image_id == I - 1) && (tile_id == tile_width * tile_height - 1) ? n_isects : tile_offsets[tile_id + 1];
     const uint32_t block_size = block.size();
-    uint32_t num_batches      = (range_end - range_start + block_size - 1) / block_size;
+    const int64_t num_batches = (range_end - range_start + block_size - 1) / block_size;
 
     /**
      * ==============================
@@ -217,9 +217,9 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     // numerical precision so we use double for it. However double make bwd 1.5x
     // slower so we stick with float for now.
     // The coefficient for volumetric rendering for our responsible pixel.
-    float T          = 1.0f;
-    // index of most recent gaussian to write to this thread's pixel
-    uint32_t cur_idx = 0;
+    float T                          = 1.0f;
+    // Tile-relative offset of the most recent intersection to contribute.
+    int32_t last_intersection_offset = 0;
 
     // collect and process batches of gaussians
     // each thread loads one gaussian at a time before rasterizing its
@@ -233,8 +233,8 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     float accum_vis_depth = 0.f; // accumulate vis * depth
 
     // keep track of median depth contribution
-    float median_depth  = 0.f;
-    uint32_t median_idx = 0.f;
+    float median_depth                 = 0.f;
+    int32_t median_intersection_offset = 0;
 
     /**
      * ==============================
@@ -249,7 +249,7 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
     //  float pix_out[CDIM + 3] = {0.f}
     float pix_out[CDIM] = {0.f};
     float normal_out[3] = {0.f};
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
         // resync all threads before beginning next batch
         // end early if entire tile is done
@@ -260,8 +260,9 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
 
         // each thread fetch 1 gaussian from front to back
         // index of gaussian to load
-        uint32_t batch_start = range_start + block_size * b;
-        uint32_t idx         = batch_start + tr;
+        const int64_t batch_offset = block_size * b;
+        const int64_t batch_start  = range_start + batch_offset;
+        const int64_t idx          = batch_start + tr;
 
         // only threads within the range of the tile will fetch gaussians
         /**
@@ -335,7 +336,8 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
          * and 2D projected gaussian kernels
          */
         // process gaussians in the current batch for this pixel
-        uint32_t batch_size = min(block_size, range_end - batch_start);
+        const int64_t remaining   = range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < block_size ? remaining : block_size);
         for(uint32_t t = 0; (t < batch_size) && !done; ++t)
         {
 
@@ -423,11 +425,11 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
             // compute median depth
             if(T > 0.5)
             {
-                median_depth = c_ptr[CDIM - 1];
-                median_idx   = batch_start + t;
+                median_depth               = c_ptr[CDIM - 1];
+                median_intersection_offset = static_cast<int32_t>(batch_offset + t);
             }
 
-            cur_idx = batch_start + t;
+            last_intersection_offset = static_cast<int32_t>(batch_offset + t);
 
             T = next_T;
         }
@@ -451,7 +453,7 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
             render_normals[pix_id * 3 + k] = normal_out[k];
         }
         // index in bin of last gaussian in this pixel
-        last_ids[pix_id] = static_cast<int32_t>(cur_idx);
+        last_ids[pix_id] = last_intersection_offset;
 
         if(render_distort != nullptr)
         {
@@ -460,7 +462,7 @@ __global__ void rasterize_to_pixels_2dgs_fwd_kernel(
 
         render_median[pix_id] = median_depth;
         // index in bin of gaussian that contributes to median depth
-        median_ids[pix_id]    = static_cast<int32_t>(median_idx);
+        median_ids[pix_id]    = median_intersection_offset;
     }
 }
 
@@ -496,7 +498,7 @@ void launch_rasterize_to_pixels_2dgs_fwd_kernel(
     uint32_t I           = alphas.numel() / (image_height * image_width); // number of images
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
 
     // Each block covers a tile on the image. In total there are
     // I * tile_height * tile_width blocks.
@@ -547,7 +549,7 @@ void launch_rasterize_to_pixels_2dgs_fwd_kernel(
                 tile_size,
                 tile_width,
                 tile_height,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 renders.data_ptr<float>(),
                 alphas.data_ptr<float>(),

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSDevice.cuh
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSDevice.cuh
@@ -65,10 +65,10 @@ __device__ __forceinline__ bool rasterize_to_pixels_3dgs_blend_fwd(
     const float px,
     const float py,
     const float *__restrict__ color_ptr, // colors + g * CDIM
-    const uint32_t gaussian_idx,         // running index, stored as cur_idx on hit
+    const int32_t intersection_offset,   // tile-relative intersection offset
     float &T,                            // transmittance, updated on accumulate
     float (&pix_out)[CDIM],              // per-channel accumulator, updated
-    uint32_t &cur_idx                    // last contributing gaussian, updated
+    int32_t &last_intersection_offset    // last contributing intersection, updated
 )
 {
     const float opac        = xy_opacity.z;
@@ -91,8 +91,8 @@ __device__ __forceinline__ bool rasterize_to_pixels_3dgs_blend_fwd(
     {
         pix_out[k] += color_ptr[k] * vis;
     }
-    cur_idx = gaussian_idx;
-    T       = next_T;
+    last_intersection_offset = intersection_offset;
+    T                        = next_T;
     return false;
 }
 

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
@@ -42,7 +42,7 @@ template<uint32_t CDIM, typename scalar_t>
 __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     const uint32_t I,
     const uint32_t N,
-    const uint32_t n_isects,
+    const int64_t n_isects,
     const bool packed,
     // fwd inputs
     const vec2 *__restrict__ means2d,         // [..., N, 2] or [nnz, 2]
@@ -57,7 +57,7 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     const uint32_t tile_width,
     const uint32_t tile_height,
     const uint32_t block_offset,
-    const int32_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]
+    const int64_t *__restrict__ tile_offsets, // [..., tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     // fwd outputs
     const scalar_t *__restrict__ render_alphas, // [..., image_height, image_width, 1]
@@ -119,11 +119,12 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     // have all threads in tile process the same gaussians in batches
     // first collect gaussians between range.x and range.y in batches
     // which gaussians to look through in this tile
-    int32_t range_start = tile_offsets[tile_id];
-    int32_t range_end
+    const int64_t range_start = tile_offsets[tile_id];
+    const int64_t range_end
         = (image_id == I - 1) && (tile_id == tile_width * tile_height - 1) ? n_isects : tile_offsets[tile_id + 1];
-    const uint32_t block_size  = block.size();
-    const uint32_t num_batches = (range_end - range_start + block_size - 1) / block_size;
+    const uint32_t block_size       = block.size();
+    const int64_t num_intersections = range_end - range_start;
+    const int64_t num_batches       = (num_intersections + block_size - 1) / block_size;
 
     extern __shared__ int s[];
     int32_t *id_batch      = (int32_t *)s;                                            // [block_size]
@@ -153,7 +154,7 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     const uint32_t tr              = block.thread_rank();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     const int32_t warp_bin_final   = cg::reduce(warp, bin_final, cg::greater<int>());
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
         // resync all threads before writing next batch of shared mem
         block.sync();
@@ -161,11 +162,11 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
         // each thread fetch 1 gaussian from back to front
         // 0 index will be furthest back in batch
         // index of gaussian to load
-        // batch end is the index of the last gaussian in the batch
-        // These values can be negative so must be int32 instead of uint32
-        const int32_t batch_end  = range_end - 1 - block_size * b;
-        const int32_t batch_size = min(block_size, batch_end + 1 - range_start);
-        const int32_t idx        = batch_end - tr;
+        // batch_end_offset is relative to this tile's first intersection.
+        const int64_t batch_end_offset = num_intersections - 1 - block_size * b;
+        const int64_t remaining        = batch_end_offset + 1;
+        const uint32_t batch_size      = static_cast<uint32_t>(remaining < block_size ? remaining : block_size);
+        const int64_t idx              = range_start + batch_end_offset - tr;
         if(idx >= range_start)
         {
             int32_t g            = flatten_ids[idx]; // flatten index in [I * N] or [nnz]
@@ -184,10 +185,12 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
         block.sync();
         // process gaussians in the current batch for this pixel
         // 0 index is the furthest back gaussian in the batch
-        for(uint32_t t = max(0, batch_end - warp_bin_final); t < batch_size; ++t)
+        const int64_t first_t64 = batch_end_offset > warp_bin_final ? batch_end_offset - warp_bin_final : 0;
+        const uint32_t first_t  = first_t64 < batch_size ? static_cast<uint32_t>(first_t64) : batch_size;
+        for(uint32_t t = first_t; t < batch_size; ++t)
         {
             bool valid = inside;
-            if(batch_end - t > bin_final)
+            if(batch_end_offset - t > bin_final)
             {
                 valid = 0;
             }
@@ -354,7 +357,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
     uint32_t I           = render_alphas.numel() / (image_height * image_width); // number of images
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
 
     // Each block covers a tile on the image. In total there are
     // I * tile_height * tile_width blocks.
@@ -412,7 +415,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
                 tile_width,
                 tile_height,
                 0,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 render_alphas.const_data_ptr<float>(),
                 last_ids.const_data_ptr<int32_t>(),
@@ -465,7 +468,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernels(
     uint32_t I           = render_alphas.numel() / (image_height * image_width);
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
     uint32_t n_tiles     = I * tile_height * tile_width;
 
     dim3 threads = {tile_size, tile_size, 1};
@@ -531,7 +534,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernels(
                     tile_width,
                     tile_height,
                     block_offset,
-                    tile_offsets.const_data_ptr<int32_t>(),
+                    tile_offsets.const_data_ptr<int64_t>(),
                     flatten_ids.const_data_ptr<int32_t>(),
                     render_alphas.const_data_ptr<float>(),
                     last_ids.const_data_ptr<int32_t>(),

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
@@ -41,7 +41,7 @@ using SupportedChannels = dispatch::IntParam<GSPLAT_NUM_CHANNELS>;
 template<uint32_t CDIM, uint32_t TILE_SIZE, uint32_t CTA_SIZE>
 __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     const uint32_t N,
-    const uint32_t n_isects,
+    const int64_t n_isects,
     const bool packed,
     const vec2 *__restrict__ means2d,      // [I, N, 2] or [nnz, 2]
     const vec3 *__restrict__ conics,       // [I, N, 3] or [nnz, 3]
@@ -55,7 +55,7 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     const uint32_t tile_width,
     const uint32_t tile_height,
     const uint32_t block_offset,
-    const int32_t *__restrict__ isect_offsets, // [I, tile_height, tile_width]
+    const int64_t *__restrict__ isect_offsets, // [I, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,   // [n_isects]
     float *__restrict__ render_colors,         // [I, image_height, image_width, CDIM]
     float *__restrict__ render_alphas,         // [I, image_height, image_width, 1]
@@ -161,11 +161,11 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     // have all threads in tile process the same gaussians in batches
     // first collect gaussians between range.x and range.y in batches
     // which gaussians to look through in this tile
-    const int32_t range_start  = isect_offsets[tile_id];
-    const int32_t range_end    = (image_id == (int32_t)I - 1) && (tile_id == (int32_t)(grid_width * grid_height) - 1)
-                                   ? n_isects
-                                   : isect_offsets[tile_id + 1];
-    const uint32_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
+    const int64_t range_start = isect_offsets[tile_id];
+    const int64_t range_end   = (image_id == (int32_t)I - 1) && (tile_id == (int32_t)(grid_width * grid_height) - 1)
+                                  ? n_isects
+                                  : isect_offsets[tile_id + 1];
+    const int64_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
 
     extern __shared__ int s[];
     int32_t *id_batch      = (int32_t *)s;                                            // [BATCH_SIZE]
@@ -182,21 +182,22 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
     {
         T[p] = 1.0f;
     }
-    // index of most recent gaussian to write to this thread's pixel
-    uint32_t cur_idx[PIXELS_PER_THREAD]    = {0u};
+    // Tile-relative offset of the most recent intersection to contribute.
+    int32_t last_intersection_offset[PIXELS_PER_THREAD] = {0};
     // result of the rendering for each pixel
-    float pix_out[PIXELS_PER_THREAD][CDIM] = {0.f};
+    float pix_out[PIXELS_PER_THREAD][CDIM]              = {0.f};
 
     // unroll 1: keep the outer batch loop rolled, unrolling it would inflate
     // register pressure (and icache pressure for long loops) without helping
     // throughput here. The inner per-pixel and per-CDIM loops below are also
     // unrolled.
 #    pragma unroll 1
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
         // each thread fetch 1 gaussian from front to back
-        const uint32_t batch_start = range_start + BATCH_SIZE * b;
-        const uint32_t idx         = batch_start + tid; // index of gaussian to load
+        const int64_t batch_offset = BATCH_SIZE * b;
+        const int64_t batch_start  = range_start + batch_offset;
+        const int64_t idx          = batch_start + tid; // index of gaussian to load
         if(idx < range_end)
         {
             const int32_t g       = flatten_ids[idx]; // flatten index in [I * N] or [nnz]
@@ -219,7 +220,8 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
         }
 
         // process gaussians in the current batch
-        const uint32_t batch_size = min(BATCH_SIZE, (uint32_t)range_end - batch_start);
+        const int64_t remaining   = range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < BATCH_SIZE ? remaining : BATCH_SIZE);
         for(uint32_t t = 0; (t < batch_size) && (done_mask != ALL_DONE); ++t)
         {
             const vec3 conic   = conic_batch[t];
@@ -258,8 +260,8 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
                 {
                     pix_out[p][k] += c_ptr[k] * vis;
                 }
-                cur_idx[p] = batch_start + t;
-                T[p]       = next_T;
+                last_intersection_offset[p] = static_cast<int32_t>(batch_offset + t);
+                T[p]                        = next_T;
             }
         }
 
@@ -290,7 +292,7 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_3dgs_fwd_kernel(
                     render_colors[pix_id[p] * CDIM + k]
                         = backgrounds == nullptr ? pix_out[p][k] : (pix_out[p][k] + T[p] * backgrounds[k]);
                 }
-                last_ids[pix_id[p]] = static_cast<int32_t>(cur_idx[p]);
+                last_ids[pix_id[p]] = last_intersection_offset[p];
             }
         }
     }
@@ -319,13 +321,13 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
 {
     const bool packed = means2d.dim() == 2;
 
-    const uint32_t N        = packed ? 0 : means2d.size(-2);                 // number of gaussians
-    const uint32_t I        = alphas.numel() / (image_height * image_width); // number of images
-    const uint32_t grid_h   = isect_offsets.size(-2);
-    const uint32_t grid_w   = isect_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
-    const uint32_t n_tiles  = I * grid_h * grid_w;
-    const dim3 grid         = {n_tiles, 1, 1};
+    const uint32_t N       = packed ? 0 : means2d.size(-2);                 // number of gaussians
+    const uint32_t I       = alphas.numel() / (image_height * image_width); // number of images
+    const uint32_t grid_h  = isect_offsets.size(-2);
+    const uint32_t grid_w  = isect_offsets.size(-1);
+    const int64_t n_isects = flatten_ids.size(0);
+    const uint32_t n_tiles = I * grid_h * grid_w;
+    const dim3 grid        = {n_tiles, 1, 1};
 
     const int32_t channels = colors.size(-1);
     TORCH_CHECK_VALUE(
@@ -379,7 +381,7 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
                     grid_w,
                     grid_h,
                     0,
-                    isect_offsets.const_data_ptr<int32_t>(),
+                    isect_offsets.const_data_ptr<int64_t>(),
                     flatten_ids.const_data_ptr<int32_t>(),
                     renders.data_ptr<float>(),
                     alphas.data_ptr<float>(),
@@ -438,12 +440,12 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernels(
 {
     const bool packed = means2d.dim() == 2;
 
-    const uint32_t N        = packed ? 0 : means2d.size(-2);
-    const uint32_t I        = alphas.numel() / (image_height * image_width);
-    const uint32_t grid_h   = isect_offsets.size(-2);
-    const uint32_t grid_w   = isect_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
-    const uint32_t n_tiles  = I * grid_h * grid_w;
+    const uint32_t N       = packed ? 0 : means2d.size(-2);
+    const uint32_t I       = alphas.numel() / (image_height * image_width);
+    const uint32_t grid_h  = isect_offsets.size(-2);
+    const uint32_t grid_w  = isect_offsets.size(-1);
+    const int64_t n_isects = flatten_ids.size(0);
+    const uint32_t n_tiles = I * grid_h * grid_w;
 
     const int32_t channels = colors.size(-1);
     TORCH_CHECK_VALUE(
@@ -506,7 +508,7 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernels(
                             grid_w,
                             grid_h,
                             block_offset,
-                            isect_offsets.const_data_ptr<int32_t>(),
+                            isect_offsets.const_data_ptr<int64_t>(),
                             flatten_ids.const_data_ptr<int32_t>(),
                             renders.data_ptr<float>(),
                             alphas.data_ptr<float>(),

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.cuh
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGS.cuh
@@ -553,8 +553,8 @@ __device__ __forceinline__ void cooperative_load_fetch_round(
     mat3 *__restrict__ iscl_rot_batch,
     vec3 *__restrict__ scale_batch,
     vec3 *__restrict__ normal_batch,
-    const uint32_t batch_start,
-    const int32_t range_end,
+    const int64_t batch_start,
+    const int64_t range_end,
     const int32_t *__restrict__ flatten_ids,
     const vec3 *__restrict__ means,
     const vec4 *__restrict__ quats,
@@ -587,8 +587,8 @@ __device__ __forceinline__ void cooperative_load_fetch_round(
     };
 
     // Each thread fetches 1 gaussian from front to back
-    const uint32_t idx = batch_start + tid;
-    if(thread_within_fetch_slot() && idx < (uint32_t)range_end)
+    const int64_t idx = batch_start + tid;
+    if(thread_within_fetch_slot() && idx < range_end)
     {
         // TODO: only support 1 camera for now so it is ok to abuse the index.
         int32_t isect_id       = flatten_ids[idx];
@@ -658,7 +658,8 @@ __device__ __forceinline__ void process_fetch_round_blend(
     const mat3 *__restrict__ iscl_rot_batch,
     const vec3 *__restrict__ scale_batch,
     const vec3 *__restrict__ normal_batch,
-    const uint32_t batch_start,
+    const int64_t batch_start,
+    const int32_t batch_offset,
     const uint32_t batch_size,
     const scalar_t *__restrict__ colors,
     const vec3 (&ray_o)[PIXELS_PER_THREAD_T],
@@ -768,7 +769,7 @@ __device__ __forceinline__ void process_fetch_round_blend(
                 normal_out[p]                   += normal * vis;
             }
 
-            cur_idx[p] = batch_start + t;
+            cur_idx[p] = batch_offset + t;
             n_accumulated[p]++;
             T[p] = next_T;
         }
@@ -810,8 +811,9 @@ __device__ __forceinline__ bool process_logical_batch_gaussians(
     mat3 *__restrict__ iscl_rot_batch,
     vec3 *__restrict__ scale_batch,
     vec3 *__restrict__ normal_batch,
-    const uint32_t logical_batch_start,
-    const int32_t range_end,
+    const int64_t logical_batch_start,
+    const int32_t logical_batch_offset,
+    const int64_t range_end,
     const int32_t *__restrict__ flatten_ids,
     const vec3 *__restrict__ means,
     const vec4 *__restrict__ quats,
@@ -848,14 +850,15 @@ __device__ __forceinline__ bool process_logical_batch_gaussians(
 #pragma unroll
     for(uint32_t r = 0; r < FETCHES_PER_BATCH; ++r)
     {
-        const uint32_t batch_start = logical_batch_start + FETCH_SIZE_T * r;
+        const int64_t batch_start  = logical_batch_start + FETCH_SIZE_T * r;
+        const int32_t batch_offset = logical_batch_offset + FETCH_SIZE_T * r;
         // Skip rounds that fall past the tile's gaussian range (last
         // logical batch may be partial). Each thread votes "no fetch"
         // uniformly via the per-thread `idx >= range_end` guard inside
         // cooperative_load_fetch_round; here we only skip the
         // cooperative fetch entirely when the whole round is past
         // range_end.
-        if(batch_start >= (uint32_t)range_end)
+        if(batch_start >= range_end)
         {
             break;
         }
@@ -880,7 +883,8 @@ __device__ __forceinline__ bool process_logical_batch_gaussians(
 
         cta_sync<CTA_SIZE_T>();
 
-        const uint32_t batch_size = min(FETCH_SIZE_T, (uint32_t)range_end - batch_start);
+        const int64_t remaining   = range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < FETCH_SIZE_T ? remaining : FETCH_SIZE_T);
         process_fetch_round_blend<
             CDIM,
             PIXELS_PER_THREAD_T,
@@ -895,6 +899,7 @@ __device__ __forceinline__ bool process_logical_batch_gaussians(
           scale_batch,
           normal_batch,
           batch_start,
+          batch_offset,
           batch_size,
           colors,
           ray_o,

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
@@ -91,9 +91,9 @@ constexpr uint32_t cdim_smem_stride()
 // the `compute_batch_csr` host helper below. Kept `static` because only
 // this TU launches it directly.
 static __global__ void compute_batches_per_tile_kernel(
-    const int32_t *__restrict__ tile_offsets,
+    const int64_t *__restrict__ tile_offsets,
     const uint32_t num_tiles,
-    const uint32_t n_isects,
+    const int64_t n_isects,
     const int32_t pixels_per_tile,
     int32_t *__restrict__ batches_per_tile
 )
@@ -103,17 +103,18 @@ static __global__ void compute_batches_per_tile_kernel(
     {
         return;
     }
-    const int32_t start = tile_offsets[t];
-    const int32_t end   = (t + 1 < num_tiles) ? tile_offsets[t + 1] : static_cast<int32_t>(n_isects);
-    const int32_t range = end - start;
+    const int64_t start = tile_offsets[t];
+    const int64_t end   = (t + 1 < num_tiles) ? tile_offsets[t + 1] : n_isects;
+    const int64_t range = end - start;
     if(range <= 0)
     {
         batches_per_tile[t] = 0;
         return;
     }
     assert(pixels_per_tile > 0);
-    const int32_t num_batches = (range + pixels_per_tile - 1) / pixels_per_tile;
-    batches_per_tile[t]       = num_batches;
+    const int64_t num_batches = (range + pixels_per_tile - 1) / pixels_per_tile;
+    assert(num_batches <= INT32_MAX);
+    batches_per_tile[t] = static_cast<int32_t>(num_batches);
 }
 
 // Host helper: see declaration in `RasterizeCSR.cuh`. Launches the
@@ -135,9 +136,9 @@ std::tuple<at::Tensor, at::Tensor, int64_t> compute_batch_csr(
         const uint32_t threads_per_block = 256;
         const uint32_t blocks            = (num_tiles + threads_per_block - 1) / threads_per_block;
         compute_batches_per_tile_kernel<<<blocks, threads_per_block, 0, at::cuda::getCurrentCUDAStream()>>>(
-            tile_offsets.const_data_ptr<int32_t>(),
+            tile_offsets.const_data_ptr<int64_t>(),
             num_tiles,
-            static_cast<uint32_t>(n_isects),
+            n_isects,
             pixels_per_tile,
             batches_per_tile_t.data_ptr<int32_t>()
         );
@@ -272,7 +273,7 @@ __global__ void rasterize_gradient_bwd_kernel(
     const uint32_t B,
     const uint32_t C,
     const uint32_t N,
-    const uint32_t n_isects,
+    const int64_t n_isects,
     // fwd inputs
     const vec3 *__restrict__ means,           // [B, N, 3]
     const vec4 *__restrict__ quats,           // [B, N, 4]
@@ -300,7 +301,7 @@ __global__ void rasterize_gradient_bwd_kernel(
     const cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_device_coeffs,
     const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
     // intersections
-    const int32_t *__restrict__ tile_offsets, // [B, C, tile_height, tile_width]
+    const int64_t *__restrict__ tile_offsets, // [B, C, tile_height, tile_width]
     const int32_t *__restrict__ flatten_ids,  // [n_isects]
     // fwd outputs
     const scalar_t *__restrict__ render_alphas, // [B, C, image_height, image_width, 1]
@@ -389,8 +390,8 @@ __global__ void rasterize_gradient_bwd_kernel(
         return;
     }
 
-    const int32_t range_start     = tile_offsets[tile_id];
-    const int32_t range_end       = (image_index == static_cast<int32_t>(B * C) - 1) && (tile_id == tiles_per_image - 1)
+    const int64_t range_start     = tile_offsets[tile_id];
+    const int64_t range_end       = (image_index == static_cast<int32_t>(B * C) - 1) && (tile_id == tiles_per_image - 1)
                                       ? n_isects
                                       : tile_offsets[tile_id + 1];
     const int32_t pixels_per_tile = tile_size * tile_size;
@@ -584,10 +585,13 @@ __global__ void rasterize_gradient_bwd_kernel(
 
     // ---- Batch walk: this CTA owns one front-aligned depth batch ----
     {
-        const int32_t batch_start = range_start + static_cast<int32_t>(block_size) * batch_id;
-        const int32_t batch_end   = min(range_end - 1, batch_start + static_cast<int32_t>(block_size) - 1);
-        const int32_t batch_size  = batch_end + 1 - batch_start;
-        const int32_t idx         = batch_end - static_cast<int32_t>(tr);
+        const int32_t batch_start_offset = static_cast<int32_t>(block_size) * batch_id;
+        const int64_t batch_start        = range_start + batch_start_offset;
+        const int64_t candidate_end      = batch_start + static_cast<int32_t>(block_size) - 1;
+        const int64_t batch_end          = candidate_end < range_end ? candidate_end : range_end - 1;
+        const int32_t batch_end_offset   = static_cast<int32_t>(batch_end - range_start);
+        const int32_t actual_batch_size  = batch_end_offset + 1 - batch_start_offset;
+        const int64_t idx                = batch_end - static_cast<int32_t>(tr);
 
         // Threads with tr >= batch_size would otherwise alias into the
         // previous front-side batch for the partial deepest batch.
@@ -617,10 +621,11 @@ __global__ void rasterize_gradient_bwd_kernel(
 
         // process gaussians in the current batch for this pixel
         // 0 index is the furthest back gaussian in the batch
-        for(uint32_t t = max(0, batch_end - warp_bin_final); t < batch_size; ++t)
+        const int32_t first_t = max(0, batch_end_offset - warp_bin_final);
+        for(uint32_t t = first_t; t < actual_batch_size; ++t)
         {
             bool valid = pixel_valid;
-            if(batch_end - t > bin_final)
+            if(batch_end_offset - t > bin_final)
             {
                 valid = 0;
             }
@@ -1021,7 +1026,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_bwd_kernel(
     uint32_t I           = B * C;              // number of images
     uint32_t tile_height = tile_offsets.size(-2);
     uint32_t tile_width  = tile_offsets.size(-1);
-    uint32_t n_isects    = flatten_ids.size(0);
+    int64_t n_isects     = flatten_ids.size(0);
 
     dim3 threads = {tile_size, tile_size, 1};
     if(n_isects == 0)
@@ -1191,7 +1196,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_bwd_kernel(
                 ftheta_device_coeffs,
                 lidar_device_coeffs,
                 external_distortion_device_params,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 render_alphas.const_data_ptr<float>(),
                 last_ids.const_data_ptr<int32_t>(),

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
@@ -176,8 +176,8 @@ template<
 >
 __device__ __forceinline__ void process_batch_gaussians_fwd(
     const uint32_t batch_id,
-    const int32_t range_start,
-    const int32_t range_end,
+    const int64_t range_start,
+    const int64_t range_end,
     const uint32_t tid,
     const uint32_t C,
     const uint32_t N,
@@ -218,8 +218,9 @@ __device__ __forceinline__ void process_batch_gaussians_fwd(
         return;
     }
 
-    const uint32_t logical_batch_start = range_start + batch_id * LOGICAL_BATCH;
-    if(logical_batch_start >= static_cast<uint32_t>(range_end))
+    const int32_t logical_batch_offset = static_cast<int32_t>(batch_id * LOGICAL_BATCH);
+    const int64_t logical_batch_start  = range_start + logical_batch_offset;
+    if(logical_batch_start >= range_end)
     {
         return;
     }
@@ -244,6 +245,7 @@ __device__ __forceinline__ void process_batch_gaussians_fwd(
         scale_batch,
         normal_batch,
         logical_batch_start,
+        logical_batch_offset,
         range_end,
         flatten_ids,
         // Gaussian inputs.
@@ -291,7 +293,7 @@ __global__ void
         const uint32_t B,
         const uint32_t C,
         const uint32_t N,
-        const uint32_t n_isects,
+        const int64_t n_isects,
         const vec3 *__restrict__ means,
         const vec4 *__restrict__ quats,
         const vec3 *__restrict__ scales,
@@ -314,7 +316,7 @@ __global__ void
         const FThetaCameraDistortionDeviceParams ftheta_device_coeffs,
         const DeviceLidarParamsOpt lidar_device_coeffs,
         const DeviceExternalDistortionParamsOpt external_distortion_device_params,
-        const int32_t *__restrict__ tile_offsets,
+        const int64_t *__restrict__ tile_offsets,
         const int32_t *__restrict__ flatten_ids,
         // CSR + outputs. `bid_to_slot[blockIdx.x]` maps the round-major launch
         // id to the tile-major slot used by fwd_batch_state and partials_meta.
@@ -454,9 +456,9 @@ __global__ void
         }
     }
 
-    const int32_t range_start = tile_offsets[tile_id];
-    const int32_t range_end   = (image_index == static_cast<int32_t>(B * C) - 1) && (tile_id == tiles_per_image - 1)
-                                  ? static_cast<int32_t>(n_isects)
+    const int64_t range_start = tile_offsets[tile_id];
+    const int64_t range_end   = (image_index == static_cast<int32_t>(B * C) - 1) && (tile_id == tiles_per_image - 1)
+                                  ? n_isects
                                   : tile_offsets[tile_id + 1];
     // batch_id is the forward depth-walk index from the front. The deepest
     // batch is the only partial batch when the tile's Gaussian count is not a
@@ -612,8 +614,8 @@ __global__ void
     // SOA layout: `fwd_batch_state[slot, k, pix]` and
     // `partials_meta[slot, pix]`. With pix as the fastest-varying axis,
     // each warp writes contiguous addresses for a fixed state element.
-    const int32_t slot                = batch_offsets_csr[tile_linear] + batch_id;
-    const int32_t logical_batch_start = range_start + batch_id * pixels_per_tile;
+    const int32_t slot                 = batch_offsets_csr[tile_linear] + batch_id;
+    const int32_t logical_batch_offset = batch_id * pixels_per_tile;
     if(tid == 0u)
     {
         // `partials_meta` is allocated with at::empty. Pixel 0 carries the
@@ -664,7 +666,7 @@ __global__ void
         if(valid_pixel[p] && (!this_batch_saturated || !ForBackward))
         {
             FwdPartialsMetaView<ushort2> meta_view(partials_meta, slot, pixels_per_tile, pix_rank_in_tile);
-            meta_view.set(cur_idx[p], n_accumulated[p], logical_batch_start, fwd_terminal_batch);
+            meta_view.set(cur_idx[p], n_accumulated[p], logical_batch_offset, fwd_terminal_batch);
         }
 
         if(valid_pixel[p])
@@ -722,7 +724,7 @@ __global__ void
         const uint32_t B,
         const uint32_t C,
         const uint32_t N,
-        const uint32_t n_isects,
+        const int64_t n_isects,
         const vec3 *__restrict__ means,
         const vec4 *__restrict__ quats,
         const vec3 *__restrict__ scales,
@@ -736,7 +738,7 @@ __global__ void
         const uint32_t tile_height,
         const CameraModelType camera_model_type,
         const DeviceLidarParamsOpt lidar_device_coeffs,
-        const int32_t *__restrict__ tile_offsets,
+        const int64_t *__restrict__ tile_offsets,
         const int32_t *__restrict__ flatten_ids,
         // CSR (in/out): partials on entry, cumulative on exit.
         const int32_t *__restrict__ batches_per_tile,
@@ -879,7 +881,6 @@ __global__ void
         = (batches_per_tile != nullptr) ? static_cast<uint32_t>(batches_per_tile[tile_linear]) : 0u;
     const int32_t batch_base          = (batch_offsets != nullptr) ? batch_offsets[tile_linear] : 0;
     constexpr int32_t pixels_per_tile = TILE_SIZE * TILE_SIZE;
-    const int32_t range_start         = tile_offsets[tile_id];
     // Exact-metadata mode reuses the ray-validity sentinel that partials wrote
     // into compose_c_stop. Fwd-only mode does not allocate compose_c_stop,
     // so it reads the equivalent sentinel from priming_state and uses the same
@@ -942,7 +943,7 @@ __global__ void
     for(int32_t c = 0; c < static_cast<int32_t>(num_batches_this_tile); ++c)
     {
         const int32_t slot                            = batch_base + c;
-        const int32_t logical_batch_start             = range_start + c * pixels_per_tile;
+        const int32_t logical_batch_offset            = c * pixels_per_tile;
         const uint32_t batch_replay_mask_before_batch = batch_replay_mask;
 
 // Per-pixel: either fold this batch's partial, or stop just before it
@@ -984,7 +985,7 @@ __global__ void
                 T_cum[p] = T_cum[p] * walk_prod;
                 if constexpr(ForBackward)
                 {
-                    const int32_t last_p_c = meta_view.last(logical_batch_start);
+                    const int32_t last_p_c = meta_view.last(logical_batch_offset);
                     const int32_t n_p_c    = meta_view.count();
                     if(last_p_c >= 0)
                     {
@@ -1153,7 +1154,7 @@ __global__ void
         const uint32_t B,
         const uint32_t C,
         const uint32_t N,
-        const uint32_t n_isects,
+        const int64_t n_isects,
         const vec3 *__restrict__ means,
         const vec4 *__restrict__ quats,
         const vec3 *__restrict__ scales,
@@ -1177,7 +1178,7 @@ __global__ void
         const FThetaCameraDistortionDeviceParams ftheta_device_coeffs,
         const DeviceLidarParamsOpt lidar_device_coeffs,
         const DeviceExternalDistortionParamsOpt external_distortion_device_params,
-        const int32_t *__restrict__ tile_offsets,
+        const int64_t *__restrict__ tile_offsets,
         const int32_t *__restrict__ flatten_ids,
         const int32_t *__restrict__ batches_per_tile,
         const int32_t *__restrict__ batch_offsets,
@@ -1323,9 +1324,9 @@ __global__ void
 
     const int32_t batch_base = (batch_offsets != nullptr) ? batch_offsets[tile_linear] : 0;
 
-    const int32_t range_start = tile_offsets[tile_id];
-    const int32_t range_end   = (image_index == static_cast<int32_t>(B * C) - 1) && (tile_id == tiles_per_image - 1)
-                                  ? static_cast<int32_t>(n_isects)
+    const int64_t range_start = tile_offsets[tile_id];
+    const int64_t range_end   = (image_index == static_cast<int32_t>(B * C) - 1) && (tile_id == tiles_per_image - 1)
+                                  ? n_isects
                                   : tile_offsets[tile_id + 1];
     float T_cum[PIXELS_PER_THREAD];
     float pix_cum[PIXELS_PER_THREAD][CDIM] = {};
@@ -1558,7 +1559,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
     const uint32_t I           = B * C;
     const uint32_t tile_height = static_cast<uint32_t>(tile_offsets.size(-2));
     const uint32_t tile_width  = static_cast<uint32_t>(tile_offsets.size(-1));
-    const uint32_t n_isects    = static_cast<uint32_t>(flatten_ids.size(0));
+    const int64_t n_isects     = flatten_ids.size(0);
     const int32_t pixels_per_tile = tile_size * tile_size;
 
     TORCH_CHECK(ut_params, "ut_params intrusive_ptr is null");
@@ -1796,7 +1797,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
                 ftheta_device_coeffs,
                 lidar_device_coeffs,
                 external_distortion_device_params,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 batch_offsets.const_data_ptr<int32_t>(),
                 data_ptr_or_null<const int32_t>(total_batches > 0, bid_to_slot),
@@ -1842,7 +1843,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
                 tile_height,
                 camera_model,
                 lidar_device_coeffs,
-                tile_offsets.const_data_ptr<int32_t>(),
+                tile_offsets.const_data_ptr<int64_t>(),
                 flatten_ids.const_data_ptr<int32_t>(),
                 batches_per_tile.const_data_ptr<int32_t>(),
                 batch_offsets.const_data_ptr<int32_t>(),
@@ -1910,7 +1911,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
                     ftheta_device_coeffs,
                     lidar_device_coeffs,
                     external_distortion_device_params,
-                    tile_offsets.const_data_ptr<int32_t>(),
+                    tile_offsets.const_data_ptr<int64_t>(),
                     flatten_ids.const_data_ptr<int32_t>(),
                     batches_per_tile.const_data_ptr<int32_t>(),
                     batch_offsets.const_data_ptr<int32_t>(),

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSSerialBatchFwd.cu
@@ -67,7 +67,7 @@ __global__ void
     __launch_bounds__(CTA_SIZE, min_blocks_for_cdim<CDIM, CTA_SIZE>()) rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_kernel(
         const uint32_t C,
         const uint32_t N,
-        const uint32_t n_isects,
+        const int64_t n_isects,
         const bool packed,
         const vec3 *__restrict__ means,        // [B, N, 3]
         const vec4 *__restrict__ quats,        // [B, N, 4]
@@ -94,7 +94,7 @@ __global__ void
         const cuda::std::optional<RowOffsetStructuredSpinningLidarModelParametersExtDevice> lidar_device_coeffs,
         const cuda::std::optional<extdist::BivariateWindshieldModelDeviceParams> external_distortion_device_params,
         // intersections
-        const int32_t *__restrict__ isect_offsets, // [B, C, tile_height, tile_width]
+        const int64_t *__restrict__ isect_offsets, // [B, C, tile_height, tile_width]
         const int32_t *__restrict__ flatten_ids,   // [n_isects]
         float *__restrict__ render_colors,         // [B, C, image_height, image_width, CDIM]
         float *__restrict__ render_alphas,         // [B, C, image_height, image_width, 1]
@@ -309,8 +309,8 @@ __global__ void
     }
 
     // Gaussian range for this tile
-    const int32_t range_start = isect_offsets[tile_id];
-    const int32_t range_end   = (iid == (int32_t)gridDim.x - 1) && (tile_id == (int32_t)(grid_width * grid_height) - 1)
+    const int64_t range_start = isect_offsets[tile_id];
+    const int64_t range_end   = (iid == (int32_t)gridDim.x - 1) && (tile_id == (int32_t)(grid_width * grid_height) - 1)
                                   ? n_isects
                                   : isect_offsets[tile_id + 1];
     // Logical-batch count matches the bwd's view (= ceil(range / pixels_per_tile)),
@@ -411,7 +411,8 @@ __global__ void
         // the CSR slot positions. Internally it issues FETCHES_PER_BATCH
         // cooperative fetch rounds of FETCH_SIZE (= CTA_SIZE) gaussians each
         // — this is what keeps the CTA at one warp.
-        const uint32_t logical_batch_start = range_start + LOGICAL_BATCH * lb;
+        const int32_t logical_batch_offset = static_cast<int32_t>(LOGICAL_BATCH * lb);
+        const int64_t logical_batch_start  = range_start + logical_batch_offset;
         const bool all_done                = process_logical_batch_gaussians<
             CDIM,
             LOGICAL_BATCH,
@@ -432,6 +433,7 @@ __global__ void
             scale_batch,
             normal_batch,
             logical_batch_start,
+            logical_batch_offset,
             range_end,
             // Gaussian inputs.
             flatten_ids,
@@ -584,18 +586,18 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_impl(
     bool packed = opacities.dim() == 1;
     TORCH_CHECK(!packed, "packed mode not supported for 3DGUT forward rasterization");
 
-    const uint32_t N        = packed ? 0 : means.size(-2); // number of gaussians
+    const uint32_t N       = packed ? 0 : means.size(-2); // number of gaussians
     // Number of batches: product of the leading dims. Computed this way rather
     // than means.numel()/(N*3) because:
     // - the division is undefined for an empty gaussian set (N == 0)
     // - the leading-dim product matches how the calling op sizes its outputs,
     //   so an empty input renders a clean background image instead of crashing
-    const uint32_t B        = static_cast<uint32_t>(c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)));
-    const uint32_t C        = viewmats0.size(-3); // number of cameras
-    const uint32_t I        = B * C;              // number of images
-    const uint32_t grid_h   = isect_offsets.size(-2);
-    const uint32_t grid_w   = isect_offsets.size(-1);
-    const uint32_t n_isects = flatten_ids.size(0);
+    const uint32_t B       = static_cast<uint32_t>(c10::multiply_integers(means.sizes().slice(0, means.dim() - 2)));
+    const uint32_t C       = viewmats0.size(-3); // number of cameras
+    const uint32_t I       = B * C;              // number of images
+    const uint32_t grid_h  = isect_offsets.size(-2);
+    const uint32_t grid_w  = isect_offsets.size(-1);
+    const int64_t n_isects = flatten_ids.size(0);
 
     TORCH_CHECK(ut_params, "ut_params intrusive_ptr is null");
     FThetaCameraDistortionDeviceParams ftheta_device_coeffs(gsplat::checked_deref(ftheta_coeffs, "ftheta_coeffs"));
@@ -724,7 +726,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_serial_batch_fwd_impl(
             lidar_device_coeffs,
             external_distortion_device_params,
             // intersections
-            isect_offsets.const_data_ptr<int32_t>(),
+            isect_offsets.const_data_ptr<int64_t>(),
             flatten_ids.const_data_ptr<int32_t>(),
             renders.data_ptr<float>(),
             alphas.data_ptr<float>(),

--- a/gsplat/cuda/csrc/RasterizeToPixelsSparseBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsSparseBwd.cu
@@ -66,7 +66,7 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
     const uint32_t tile_height,
     // sparse layout
     const int32_t *__restrict__ active_tiles,      // [AT]
-    const int32_t *__restrict__ tile_offsets,      // [AT + 1]
+    const int64_t *__restrict__ tile_offsets,      // [AT + 1]
     const int32_t *__restrict__ flatten_ids,       // [n_isects]
     const uint64_t *__restrict__ tile_pixel_mask,  // [AT, words]
     const int64_t *__restrict__ tile_pixel_cumsum, // [AT], inclusive
@@ -116,10 +116,11 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
     const int64_t out_idx           = sparse_pixel_slot(tile_mask_words, in_tile, pix_start, pixel_map);
     const bool inside               = out_idx >= 0;
 
-    const int32_t range_start  = tile_offsets[ord];
-    const int32_t range_end    = tile_offsets[ord + 1];
-    const uint32_t block_size  = block.size();
-    const uint32_t num_batches = (range_end - range_start + block_size - 1) / block_size;
+    const int64_t range_start       = tile_offsets[ord];
+    const int64_t range_end         = tile_offsets[ord + 1];
+    const uint32_t block_size       = block.size();
+    const int64_t num_intersections = range_end - range_start;
+    const int64_t num_batches       = (num_intersections + block_size - 1) / block_size;
 
     extern __shared__ int s[];
     int32_t *id_batch      = (int32_t *)s;
@@ -147,15 +148,16 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
     const uint32_t tr              = block.thread_rank();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     const int32_t warp_bin_final   = cg::reduce(warp, bin_final, cg::greater<int>());
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
         // resync all threads before writing next batch of shared mem
         block.sync();
 
         // each thread fetch 1 gaussian from back to front
-        const int32_t batch_end  = range_end - 1 - block_size * b;
-        const int32_t batch_size = min((int32_t)block_size, batch_end + 1 - range_start);
-        const int32_t idx        = batch_end - tr;
+        const int64_t batch_end_offset = num_intersections - 1 - block_size * b;
+        const int64_t remaining        = batch_end_offset + 1;
+        const uint32_t batch_size      = static_cast<uint32_t>(remaining < block_size ? remaining : block_size);
+        const int64_t idx              = range_start + batch_end_offset - tr;
         if(idx >= range_start)
         {
             int32_t g            = flatten_ids[idx];
@@ -174,10 +176,12 @@ __global__ void rasterize_to_pixels_sparse_bwd_kernel(
         block.sync();
 
         // process gaussians in the current batch for this pixel, back to front
-        for(uint32_t t = max(0, batch_end - warp_bin_final); t < batch_size; ++t)
+        const int64_t first_t64 = batch_end_offset > warp_bin_final ? batch_end_offset - warp_bin_final : 0;
+        const uint32_t first_t  = first_t64 < batch_size ? static_cast<uint32_t>(first_t64) : batch_size;
+        for(uint32_t t = first_t; t < batch_size; ++t)
         {
             bool valid = inside;
-            if(batch_end - t > bin_final)
+            if(batch_end_offset - t > bin_final)
             {
                 valid = 0;
             }
@@ -311,8 +315,8 @@ void launch_rasterize_to_pixels_sparse_bwd_kernel(
     at::Tensor v_opacities                  // [..., N] or [nnz]
 )
 {
-    const uint32_t AT       = active_tiles.size(0);
-    const uint32_t n_isects = flatten_ids.size(0);
+    const uint32_t AT      = active_tiles.size(0);
+    const int64_t n_isects = flatten_ids.size(0);
     if(AT == 0 || n_isects == 0)
     {
         return; // nothing to scatter into the (already zeroed) grad buffers
@@ -361,7 +365,7 @@ void launch_rasterize_to_pixels_sparse_bwd_kernel(
             tile_width,
             tile_height,
             active_tiles.const_data_ptr<int32_t>(),
-            tile_offsets.const_data_ptr<int32_t>(),
+            tile_offsets.const_data_ptr<int64_t>(),
             flatten_ids.const_data_ptr<int32_t>(),
             tile_pixel_mask.const_data_ptr<uint64_t>(),
             tile_pixel_cumsum.const_data_ptr<int64_t>(),

--- a/gsplat/cuda/csrc/RasterizeToPixelsSparseFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsSparseFwd.cu
@@ -57,7 +57,7 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
     const uint32_t tile_height,
     // sparse layout
     const int32_t *__restrict__ active_tiles,      // [AT]
-    const int32_t *__restrict__ tile_offsets,      // [AT + 1]
+    const int64_t *__restrict__ tile_offsets,      // [AT + 1]
     const int32_t *__restrict__ flatten_ids,       // [n_isects]
     const uint64_t *__restrict__ tile_pixel_mask,  // [AT, words]
     const int64_t *__restrict__ tile_pixel_cumsum, // [AT], inclusive
@@ -153,9 +153,9 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
     }
 
     // Gaussians intersecting this active tile, from the compacted offsets.
-    const int32_t range_start  = tile_offsets[ord];
-    const int32_t range_end    = tile_offsets[ord + 1];
-    const uint32_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
+    const int64_t range_start = tile_offsets[ord];
+    const int64_t range_end   = tile_offsets[ord + 1];
+    const int64_t num_batches = (range_end - range_start + BATCH_SIZE - 1) / BATCH_SIZE;
 
     extern __shared__ int s[];
     int32_t *id_batch      = (int32_t *)s;                                            // [BATCH_SIZE]
@@ -168,16 +168,17 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
     {
         T[p] = 1.0f;
     }
-    uint32_t cur_idx[PIXELS_PER_THREAD]    = {0u};
-    float pix_out[PIXELS_PER_THREAD][CDIM] = {0.f};
+    int32_t last_intersection_offset[PIXELS_PER_THREAD] = {0};
+    float pix_out[PIXELS_PER_THREAD][CDIM]              = {0.f};
 
 #    pragma unroll 1
-    for(uint32_t b = 0; b < num_batches; ++b)
+    for(int64_t b = 0; b < num_batches; ++b)
     {
         // each thread fetch 1 gaussian from front to back
-        const uint32_t batch_start = range_start + BATCH_SIZE * b;
-        const uint32_t idx         = batch_start + tid;
-        if(idx < (uint32_t)range_end)
+        const int64_t batch_offset = BATCH_SIZE * b;
+        const int64_t batch_start  = range_start + batch_offset;
+        const int64_t idx          = batch_start + tid;
+        if(idx < range_end)
         {
             const int32_t g       = flatten_ids[idx];
             id_batch[tid]         = g;
@@ -196,7 +197,8 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
             __syncthreads();
         }
 
-        const uint32_t batch_size = min(BATCH_SIZE, (uint32_t)range_end - batch_start);
+        const int64_t remaining   = range_end - batch_start;
+        const uint32_t batch_size = static_cast<uint32_t>(remaining < BATCH_SIZE ? remaining : BATCH_SIZE);
         for(uint32_t t = 0; (t < batch_size) && (done_mask != ALL_DONE); ++t)
         {
             const vec3 conic   = conic_batch[t];
@@ -211,7 +213,15 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
                     continue;
                 }
                 if(rasterize_to_pixels_3dgs_blend_fwd<CDIM>(
-                       conic, xy_opac, px, py[p], c_ptr, batch_start + t, T[p], pix_out[p], cur_idx[p]
+                       conic,
+                       xy_opac,
+                       px,
+                       py[p],
+                       c_ptr,
+                       static_cast<int32_t>(batch_offset + t),
+                       T[p],
+                       pix_out[p],
+                       last_intersection_offset[p]
                    ))
                 {
                     done_mask |= (1u << p);
@@ -241,7 +251,10 @@ __global__ void __launch_bounds__(CTA_SIZE) rasterize_to_pixels_sparse_fwd_kerne
             render_colors[o * CDIM + k]
                 = backgrounds == nullptr ? pix_out[p][k] : (pix_out[p][k] + T[p] * backgrounds[k]);
         }
-        last_ids[o] = static_cast<int32_t>(cur_idx[p]);
+        if(last_ids != nullptr)
+        {
+            last_ids[o] = last_intersection_offset[p];
+        }
     }
 }
 
@@ -329,7 +342,7 @@ void launch_rasterize_to_pixels_sparse_fwd_kernel(
                     tile_width,
                     tile_height,
                     active_tiles.const_data_ptr<int32_t>(),
-                    tile_offsets.const_data_ptr<int32_t>(),
+                    tile_offsets.const_data_ptr<int64_t>(),
                     flatten_ids.const_data_ptr<int32_t>(),
                     tile_pixel_mask.const_data_ptr<uint64_t>(),
                     tile_pixel_cumsum.const_data_ptr<int64_t>(),

--- a/tests/cpp/test_raster_eval3d.cpp
+++ b/tests/cpp/test_raster_eval3d.cpp
@@ -658,6 +658,7 @@ private:
 
         const torch::TensorOptions f32_cuda = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
         const torch::TensorOptions i32_cuda = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt32);
+        const torch::TensorOptions i64_cuda = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt64);
 
         at::Tensor means = torch::zeros({num_gaussians, 3}, f32_cuda);
         means.index_put_({Slice(), 2}, 1.0f + torch::arange(num_gaussians, f32_cuda) * 1.0e-3f);
@@ -681,7 +682,7 @@ private:
         },
             f32_cuda
         );
-        at::Tensor isect_offsets = torch::zeros({1, 1, 1}, i32_cuda);
+        at::Tensor isect_offsets = torch::zeros({1, 1, 1}, i64_cuda);
         at::Tensor flatten_ids   = torch::arange(num_gaussians, i32_cuda);
         at::Tensor background    = torch::tensor(
             {

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -596,7 +596,7 @@ def test_rasterize_to_pixels_2dgs_masked_tile_outputs_initialized():
     densify = torch.zeros((1, N, 2), device=device)
     backgrounds = torch.tensor([[0.2, 0.4, 0.6]], device=device)
     masks = torch.zeros((1, 1, 1), dtype=torch.bool, device=device)  # tile masked off
-    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int32, device=device)
+    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int64, device=device)
     flatten_ids = torch.empty((0,), dtype=torch.int32, device=device)
 
     (

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1303,6 +1303,7 @@ def test_isect(test_data, dtype: torch.dtype, batch_dims: Tuple[int, ...]):
         means2d, radii, depths, tile_size, tile_width, tile_height
     )
     isect_offsets = isect_offset_encode(isect_ids, I, tile_width, tile_height)
+    assert isect_offsets.dtype == torch.int64
 
     _tiles_per_gauss, _isect_ids, _gauss_ids = _isect_tiles(
         means2d, radii, depths, tile_size, tile_width, tile_height
@@ -3892,10 +3893,10 @@ def test_rasterize_to_pixels_eval3d(
     assert not (count_match & vis_mismatch).any()
     assert not (count_mismatch & count_match).any()
 
-    # On count-matched pixels, the last contributing gaussian's flatten_idx
-    # must match exactly. An off-by-one, such as over-counting the saturating
-    # gaussian past TRANSMITTANCE_THRESHOLD, can shift last_ids by 1 while
-    # sample_counts still coincidentally match.
+    # On count-matched pixels, the last contributing gaussian's tile-local
+    # flatten_ids offset must match exactly. An off-by-one, such as
+    # over-counting the saturating gaussian past TRANSMITTANCE_THRESHOLD, can
+    # shift last_ids by 1 while sample_counts still coincidentally match.
     last_ids_match = render_last_ids[count_match] == _render_last_ids[count_match]
     assert last_ids_match.all(), (
         f"last_ids diverge on {(~last_ids_match).sum().item()} of "
@@ -4381,7 +4382,7 @@ def test_eval3d_masked_tile_writes_safe_defaults(tile_size, renderer_config):
         ],
         device=device,
     )
-    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int32, device=device)
+    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int64, device=device)
     flatten_ids = torch.empty((0,), dtype=torch.int32, device=device)
 
     public_render_colors, public_render_alphas = gsplat.rasterize_to_pixels_eval3d(
@@ -7807,7 +7808,7 @@ def test_rasterize_to_pixels_3dgs_masked_tile_outputs_initialized(packed: bool, 
         else backgrounds_batched.clone()
     ).requires_grad_()
     masks = torch.zeros((I, 1, 1), dtype=torch.bool, device=device)  # tiles masked off
-    isect_offsets = torch.zeros((I, 1, 1), dtype=torch.int32, device=device)
+    isect_offsets = torch.zeros((I, 1, 1), dtype=torch.int64, device=device)
     flatten_ids = torch.empty((0,), dtype=torch.int32, device=device)
 
     (
@@ -8161,7 +8162,7 @@ def test_rasterize_to_indices_in_range_empty():
     conics = torch.zeros(C, 0, 3, device=device)
     opacities = torch.zeros(C, 0, device=device)
     transmittances = torch.ones(C, H, W, device=device)
-    isect_offsets = torch.zeros(C, 1, 1, dtype=torch.int32, device=device)
+    isect_offsets = torch.zeros(C, 1, 1, dtype=torch.int64, device=device)
     flatten_ids = torch.empty(0, dtype=torch.int32, device=device)
 
     gauss_ids, pixel_ids, image_ids = rasterize_to_indices_in_range(
@@ -8205,7 +8206,7 @@ def test_rasterize_to_pixels_eval3d_empty():
         [[[float(W), 0.0, W / 2.0], [0.0, float(H), H / 2.0], [0.0, 0.0, 1.0]]],
         device=device,
     )
-    isect_offsets = torch.zeros(C, 1, 1, dtype=torch.int32, device=device)
+    isect_offsets = torch.zeros(C, 1, 1, dtype=torch.int64, device=device)
     flatten_ids = torch.empty(0, dtype=torch.int32, device=device)
 
     # Must not crash (pre-fix: host-side division by zero on the empty input),

--- a/tests/test_sparse_intersect.py
+++ b/tests/test_sparse_intersect.py
@@ -75,7 +75,7 @@ def _check(means2d, radii, depths, mask, active, C, ts, tw, th, image_ids=None):
     r_off, r_ids = _isect_tiles_sparse(
         means2d, radii, depths, mask, active, C, ts, tw, th, image_ids=image_ids
     )
-    assert g_off.dtype == torch.int32 and g_ids.dtype == torch.int32
+    assert g_off.dtype == torch.int64 and g_ids.dtype == torch.int32
     assert g_off.shape == (active.numel() + 1,)
     torch.testing.assert_close(g_off, r_off, rtol=0, atol=0)
     torch.testing.assert_close(g_ids, r_ids, rtol=0, atol=0)


### PR DESCRIPTION
This PR cherry-picks for upstreaming the expansion of intersection offsets to 64-bit. This is necessary to handle larger numbers of Gaussians in reconstructions where the number of Gaussian-tile intersections exceeds the 32-bit limit.