### PR TITLE
Fix CUDA 13 toolkit and MSVC build failures

### DIFF
--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchBwd.cu
@@ -769,7 +769,7 @@ void launch_rasterize_to_pixels_2dgs_bwd_kernel(
 
     auto launch_kernel = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         int64_t shmem_size = tile_size
                            * tile_size

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSSerialBatchFwd.cu
@@ -517,7 +517,7 @@ void launch_rasterize_to_pixels_2dgs_fwd_kernel(
 
     auto launch_kernel = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         if(cudaFuncSetAttribute(
                rasterize_to_pixels_2dgs_fwd_kernel<CDIM, float>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_size

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchBwd.cu
@@ -379,7 +379,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
 
     auto launch_kernel = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         int64_t shmem_size
             = tile_size * tile_size * (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3) + sizeof(float) * CDIM);
@@ -486,7 +486,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernels(
 
     auto launch_kernels = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         int64_t shmem_size
             = tile_size * tile_size * (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3) + sizeof(float) * CDIM);

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSSerialBatchFwd.cu
@@ -338,7 +338,7 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernel(
 
     auto launch_kernel = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
         {
@@ -456,7 +456,7 @@ void launch_rasterize_to_pixels_3dgs_fwd_kernels(
 
     auto launch_kernels = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
         {

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
@@ -18,6 +18,10 @@
 
 #include "Config.h"
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 #if GSPLAT_BUILD_3DGUT
 
 #    include <ATen/Dispatch.h>
@@ -186,7 +190,13 @@ namespace
         {
             return 0;
         }
+#if defined(_MSC_VER)
+        unsigned long leading_zero = 0;
+        _BitScanReverse64(&leading_zero, x - 1);
+        return 64u - static_cast<uint32_t>(leading_zero);
+#else
         return 64u - static_cast<uint32_t>(__builtin_clzll(x - 1));
+#endif
     }
 } // namespace
 
@@ -1220,3 +1230,16 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_bwd_kernel(
 } // namespace gsplat
 
 #endif
+
+// MSVC: the implicit instantiation of this torch cub detail template is not
+// emitted when this translation unit is compiled with nvcc on Windows; force
+// it here (after the header that defines the template body).
+template void at::cuda::cub::detail::radix_sort_pairs_impl<int64_t, 4>(
+    const int64_t* keys_in,
+    int64_t* keys_out,
+    const at::cuda::cub::detail::OpaqueType<4>* values_in,
+    at::cuda::cub::detail::OpaqueType<4>* values_out,
+    int64_t n,
+    bool descending,
+    int64_t begin_bit,
+    int64_t end_bit);

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu
@@ -18,6 +18,8 @@
 
 #include "Config.h"
 
+#include <cub/device/device_radix_sort.cuh>
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
@@ -240,16 +242,33 @@ at::Tensor compute_bid_to_slot(
     // Sort by `(batch_round, tile)` while carrying the original tile-major
     // slot as the value. The sorted values are the launch-index to slot
     // permutation; no extra scatter is needed.
-    at::cuda::cub::radix_sort_pairs<int64_t, int32_t>(
-        sort_keys.const_data_ptr<int64_t>(),
-        sorted_keys.data_ptr<int64_t>(),
-        sort_values.const_data_ptr<int32_t>(),
-        bid_to_slot.data_ptr<int32_t>(),
-        total_batches,
-        /*descending=*/false,
-        /*begin_bit=*/0,
-        /*end_bit=*/static_cast<int64_t>(total_bits == 0 ? 1u : total_bits)
-    );
+    // Sort by `(batch_round, tile)` while carrying the original tile-major
+    // slot as the value. The sorted values are the launch-index to slot
+    // permutation; no extra scatter is needed. CUB is called directly:
+    // at::cuda::cub::detail::radix_sort_pairs_impl is not exported from
+    // torch_cuda.dll on Windows, which breaks linking of this extension.
+    TORCH_CHECK(total_batches <= std::numeric_limits<int>::max(),
+                "too many batches for cub radix sort: ", total_batches);
+    const int num_items = static_cast<int>(total_batches);
+    const int begin_bit = 0;
+    const int end_bit   = static_cast<int>(total_bits == 0 ? 1u : total_bits);
+
+    size_t temp_storage_bytes = 0;
+    cudaError_t cub_err = cub::DeviceRadixSort::SortPairs(
+        nullptr, temp_storage_bytes,
+        sort_keys.const_data_ptr<int64_t>(), sorted_keys.data_ptr<int64_t>(),
+        sort_values.const_data_ptr<int32_t>(), bid_to_slot.data_ptr<int32_t>(),
+        num_items, begin_bit, end_bit, stream);
+    TORCH_CHECK(cub_err == cudaSuccess, "cub radix sort (query) failed: ", cudaGetErrorString(cub_err));
+
+    at::Tensor temp_storage = at::empty({static_cast<int64_t>(temp_storage_bytes)},
+                                        dummy_options.dtype(at::kByte));
+    cub_err = cub::DeviceRadixSort::SortPairs(
+        temp_storage.data_ptr(), temp_storage_bytes,
+        sort_keys.const_data_ptr<int64_t>(), sorted_keys.data_ptr<int64_t>(),
+        sort_values.const_data_ptr<int32_t>(), bid_to_slot.data_ptr<int32_t>(),
+        num_items, begin_bit, end_bit, stream);
+    TORCH_CHECK(cub_err == cudaSuccess, "cub radix sort failed: ", cudaGetErrorString(cub_err));
 
     return bid_to_slot;
 }
@@ -1230,16 +1249,3 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_bwd_kernel(
 } // namespace gsplat
 
 #endif
-
-// MSVC: the implicit instantiation of this torch cub detail template is not
-// emitted when this translation unit is compiled with nvcc on Windows; force
-// it here (after the header that defines the template body).
-template void at::cuda::cub::detail::radix_sort_pairs_impl<int64_t, 4>(
-    const int64_t* keys_in,
-    int64_t* keys_out,
-    const at::cuda::cub::detail::OpaqueType<4>* values_in,
-    at::cuda::cub::detail::OpaqueType<4>* values_out,
-    int64_t n,
-    bool descending,
-    int64_t begin_bit,
-    int64_t end_bit);

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSParallelBatchFwd.cu
@@ -1527,7 +1527,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
     const at::Tensor batch_offsets,    // [num_tiles + 1] int32
     const at::Tensor bid_to_slot,      // [total_batches] int32
     const int64_t total_batches,       // scalar; equals batch_offsets[num_tiles]
-    const bool fwd_only,
+    bool fwd_only,
     // outputs
     at::Tensor renders,                     // [..., C, image_height, image_width, channels]
     at::Tensor alphas,                      // [..., C, image_height, image_width]
@@ -1610,8 +1610,8 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
                              typename UseHitDistanceT,
                              typename FwdOnlyT>()
     {
-        constexpr uint32_t CDIM       = ChannelsT::value;
-        constexpr bool ReturnNormals  = static_cast<bool>(ReturnNormalsT::value);
+        static constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr bool ReturnNormals  = static_cast<bool>(ReturnNormalsT::value);
         constexpr bool UseHitDistance = static_cast<bool>(UseHitDistanceT::value);
         constexpr int64_t StateDim
             = FWD_BATCH_STATE_PIX_OFFSET + CDIM + (ReturnNormals ? FWD_BATCH_STATE_NORMAL_EXTRA : 0);
@@ -1701,9 +1701,9 @@ void launch_rasterize_to_pixels_from_world_3dgs_parallel_batch_fwd_kernel(
         //             co-resident CTAs; wins on training)
         //  tile 16 -> CTA 256, 1 px/thread (one thread per pixel; wins on
         //             high-res fwd-only)
-        constexpr uint32_t TILE_SIZE = TileSizeT::value;
-        constexpr uint32_t CTA_SIZE  = CtaSizeForTile<TILE_SIZE>::value;
-        constexpr bool ForBackward   = FwdOnlyT::value == 0;
+        static constexpr uint32_t TILE_SIZE = TileSizeT::value;
+        static constexpr uint32_t CTA_SIZE  = CtaSizeForTile<TILE_SIZE>::value;
+        static constexpr bool ForBackward   = FwdOnlyT::value == 0;
         const dim3 threads           = {CTA_SIZE, 1, 1};
         // Shared memory: id_batch + xyz_opacity_batch + iscl_rot_batch +
         // scale_batch + normal_batch — CTA_SIZE entries each.

--- a/gsplat/cuda/csrc/RasterizeToPixelsSparseBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsSparseBwd.cu
@@ -333,7 +333,7 @@ void launch_rasterize_to_pixels_sparse_bwd_kernel(
 
     auto launch_kernel = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         int64_t shmem_size
             = tile_size * tile_size * (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3) + sizeof(float) * CDIM);

--- a/gsplat/cuda/csrc/RasterizeToPixelsSparseFwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsSparseFwd.cu
@@ -292,7 +292,7 @@ void launch_rasterize_to_pixels_sparse_fwd_kernel(
 
     auto launch_kernel = [&]<typename ChannelsT>()
     {
-        constexpr uint32_t CDIM = ChannelsT::value;
+        static constexpr uint32_t CDIM = ChannelsT::value;
 
         auto launch_variant = [&]<uint32_t TILE_SIZE, uint32_t CTA_SIZE>()
         {

--- a/gsplat/cuda/csrc/SphericalHarmonicsL1PlusCUDA.cu
+++ b/gsplat/cuda/csrc/SphericalHarmonicsL1PlusCUDA.cu
@@ -24,6 +24,7 @@
 #include <ATen/ops/zeros.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAStream.h>
+#include <cuda/std/array>
 #include <array>
 #include <cooperative_groups.h>
 #include <vector>
@@ -704,7 +705,7 @@ __global__ void spherical_harmonics_l1_plus_bwd_kernel(
         return;
     }
 
-    std::array<opmath_t, MAX_K> acc{};
+    cuda::std::array<opmath_t, MAX_K> acc{};
 
     const scalar_t *coeffs_ptr = coeffs + coeff_id * K * D;
     const uint32_t image_count = packed ? 1 : B * C;

--- a/gsplat/cuda/include/Cameras.cuh
+++ b/gsplat/cuda/include/Cameras.cuh
@@ -43,6 +43,18 @@
 #include "ExternalDistortion.cuh"
 #include "Utils.cuh"
 
+// CUDA 13 (CCCL 3.0) removed the device-side overloads that used to make
+// std::isfinite callable from device code; __finitef is the stable device
+// intrinsic across CUDA 11.8-13.x.
+inline __device__ bool gsplat_isfinite(float v)
+{
+#if defined(__CUDA_ARCH__)
+    return __finitef(v) != 0;
+#else
+    return std::isfinite(v) != 0;
+#endif
+}
+
 template<typename T, std::size_t N>
 __device__ std::array<T, N> make_array(const T *ptr)
 {
@@ -779,7 +791,7 @@ struct OrthographicCameraModel
         }
 
         const auto point = glm::fvec2{ray.x, ray.y} / ray.z;
-        if(!std::isfinite(point.x) || !std::isfinite(point.y))
+        if(!gsplat_isfinite(point.x) || !gsplat_isfinite(point.y))
         {
             return {
                 glm::fvec2{0.f, 0.f},

--- a/gsplat/experimental/render/kernels/cuda/csrc/gaussian_inference/Utils.h
+++ b/gsplat/experimental/render/kernels/cuda/csrc/gaussian_inference/Utils.h
@@ -28,21 +28,21 @@ __device__ __forceinline__ void AssignAs(U &u, const V &v)
 }
 
 // Round-to-nearest (ties away from zero) __half2 pair to the M bits of mantissa
-template<uint M, bool MASK_OUT_OUTPUT = true>
+template<unsigned int M, bool MASK_OUT_OUTPUT = true>
 __device__ __forceinline__ __half2 RoundToNearest(const __half2 &v)
 {
-    constexpr uint MANTISSA_MASK = 0x03FF03FF;
-    constexpr uint TRUNC_MASK    = ~(((1u << (10 - M)) - 1) * 0x10001u);
+    constexpr unsigned int MANTISSA_MASK = 0x03FF03FF;
+    constexpr unsigned int TRUNC_MASK    = ~(((1u << (10 - M)) - 1) * 0x10001u);
     // get rounding offset scale s*2^e (input float with mantissa zeroed out)
-    const uint vn                = reinterpret_cast<const uint &>(v) & ~MANTISSA_MASK;
+    const unsigned int vn                = reinterpret_cast<const unsigned int &>(v) & ~MANTISSA_MASK;
     const __half2 vb             = reinterpret_cast<const __half2 &>(vn);
     // get rounding offset
     const __half2 vs             = __float2half2_rn((1 << (10 - M)) / 2048.0f);
     // add to float a scaled rounding offset
     const __half2 v_r            = __hfma2(vb, vs, v);
     // return masked __half2
-    const uint vi_r
-        = MASK_OUT_OUTPUT ? (reinterpret_cast<const uint &>(v_r) & TRUNC_MASK) : reinterpret_cast<const uint &>(v_r);
+    const unsigned int vi_r
+        = MASK_OUT_OUTPUT ? (reinterpret_cast<const unsigned int &>(v_r) & TRUNC_MASK) : reinterpret_cast<const unsigned int &>(v_r);
     return reinterpret_cast<const __half2 &>(vi_r);
 }
 
@@ -137,9 +137,9 @@ __forceinline__ __device__ __half2 __uint8x2_to_half2(uint32_t src)
     return dp.f;
 }
 
-__forceinline__ __device__ uint __cvt_pack_sat_u8_f32(float a0, float a1, float a2, float a3)
+__forceinline__ __device__ unsigned int __cvt_pack_sat_u8_f32(float a0, float a1, float a2, float a3)
 {
-    uint rval;
+    unsigned int rval;
     asm volatile(
         "{.reg .u32 tmp, i0, i1;\n"
         "cvt.rni.s32.f32 i0, %1;\n"
@@ -154,7 +154,7 @@ __forceinline__ __device__ uint __cvt_pack_sat_u8_f32(float a0, float a1, float 
     return rval;
 }
 
-__forceinline__ __device__ uint __cvt_pack_sat_u8_f32(const float4 &a)
+__forceinline__ __device__ unsigned int __cvt_pack_sat_u8_f32(const float4 &a)
 {
     return __cvt_pack_sat_u8_f32(a.x, a.y, a.z, a.w);
 }


### PR DESCRIPTION
## Summary

The CUDA extension cannot be built with the **CUDA 13.0 toolkit + MSVC** (tested: MSVC 19.44 / VS 17.14, torch 2.9.1+cu130, RTX 4060 Laptop): six independent source issues fail the compile, and one torch-internal symbol breaks the link. This PR fixes all of them. No behavior changes on Linux / CUDA 12.x.

## Fixes

1. **CCCL 3.0 removed device-side `std::isfinite`** — `Cameras.cuh` calls it in a `__device__` method. Added a `gsplat_isfinite()` helper using `__finitef` (stable across CUDA 11.8–13.x; host code keeps `std::isfinite`).
2. **`__builtin_clzll` is a GCC builtin** — `RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu` uses it in host code; MSVC fails with C3861. Use `_BitScanReverse64` under `_MSC_VER`.
3. **MSVC C3495** — `constexpr` locals captured by `[&]` lambdas and used as template arguments (e.g. `constexpr uint32_t CDIM = ChannelsT::value;` inside dispatch functions) are rejected by MSVC. Made them `static constexpr` in six rasterization `.cu` files (behavior-identical for nvcc/gcc).
4. **MSVC mangles top-level `const` on by-value parameters, GCC does not** — `RasterizeToPixelsFromWorld3DGS.h` declares `bool fwd_only` while `ParallelBatchFwd.cu` defines `const bool fwd_only`, producing two different symbols → LNK2001. Aligned the definition with the header.
5. **CCCL 3.0 removed device-side `std::array::operator[]` for the zero-size specialization** — `SphericalHarmonicsL1PlusCUDA.cu` instantiates `std::array<opmath_t, MAX_K>` with `MAX_K == 0`. Use `cuda::std::array` (available in both CCCL 2.x and 3.x).
6. **CUDA 13 removed the non-standard `uint` typedef** — `experimental/render/kernels/cuda/csrc/gaussian_inference/Utils.h` uses it 11 times. Replaced with `unsigned int`.

## Link fix (the interesting one)

`RasterizeToPixelsFromWorld3DGSParallelBatchBwd.cu` calls `at::cuda::cub::detail::radix_sort_pairs_impl<int64_t, 4>` (a torch-internal function template). With MSVC this fails to link:

- `torch_cuda.dll` does not export the `<int64_t, 4>` instantiation (dumpbin-verified: explicit instantiations are not compiled with `dllexport`, so they never reach the import library — on Linux the same code links because the linker resolves any defined symbol in the shared object);
- and nvcc does not emit the host-side symbol for an explicit instantiation definition placed in a `.cu` file (dumpbin-verified: the obj still lists it as UNDEF).

Fix: call `cub::DeviceRadixSort::SortPairs` **directly** (CUDA 13 ships CUB 3.0) with the two-pass query/allocate pattern over the caching allocator. Semantics are identical to the torch wrapper for this call site (ascending sort over `[begin_bit, end_bit)` with provided in/out buffers, `n <= INT_MAX` guarded).

## Verification

Windows 11, RTX 4060 Laptop (8 GB), CUDA 13.0 (V13.0.88), MSVC 19.44, torch 2.9.1+cu130:

- `setup.py build_ext --inplace` completes; both `gsplat.csrc` and the experimental render kernels `.pyd` build and import.
- Functional smoke (full rasterization pipeline on GPU): rendering 8 random gaussians at 100×100 returns `(1, 100, 100, 3)` with `alpha_max = 0.958` and 743 non-empty pixels — the CUDA kernels execute correctly, not just link.
- `RasterizeContributingCommon*.cuh`'s `__builtin_ctz` sites compile under nvcc's constexpr evaluation (only the host-side `__builtin_clzll` needed the MSVC branch).

Environment notes for reproducing: CUDA 13 moved the CCCL headers to `include/cccl/`; TUs that include `cuda/std/...` through the host compiler need that root on `INCLUDE`.
